### PR TITLE
LPS-123064 Adds the implementation of the Timeline components and the skeleton of the RuleEditor page

### DIFF
--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/components/rule-builder/RuleEditor.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/components/rule-builder/RuleEditor.es.js
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import ClayButton from '@clayui/button';
+import React from 'react';
+
+import Timeline from './Timeline.es';
+
+export default function RuleEditor({onCancel, onSubmit}) {
+	return (
+		<Timeline>
+			<div className="liferay-ddm-form-rule-builder-header">
+				<h2 className="form-builder-section-title text-default">
+					{Liferay.Language.get('rule')}
+				</h2>
+
+				<h4 className="text-default">
+					{Liferay.Language.get(
+						'define-condition-and-action-to-change-fields-and-elements-on-the-form'
+					)}
+				</h4>
+			</div>
+			<Timeline.List>
+				<Timeline.Header title={Liferay.Language.get('condition')} />
+				<Timeline.Item>
+					<Timeline.Condition expression={Liferay.Language.get('if')}>
+						<input />
+					</Timeline.Condition>
+					<Timeline.ActionTrash />
+				</Timeline.Item>
+				<Timeline.Item>
+					<Timeline.IncrementButton />
+				</Timeline.Item>
+			</Timeline.List>
+			<Timeline.List>
+				<Timeline.Header title={Liferay.Language.get('actions')} />
+				<Timeline.Item>
+					<Timeline.Condition expression={Liferay.Language.get('do')}>
+						<input />
+					</Timeline.Condition>
+					<Timeline.ActionTrash />
+				</Timeline.Item>
+				<Timeline.Item>
+					<Timeline.IncrementButton />
+				</Timeline.Item>
+			</Timeline.List>
+			<div className="liferay-ddm-form-rule-builder-footer">
+				<ClayButton.Group spaced>
+					<ClayButton displayType="primary" onClick={onSubmit}>
+						{Liferay.Language.get('save')}
+					</ClayButton>
+					<ClayButton displayType="secondary" onClick={onCancel}>
+						{Liferay.Language.get('cancel')}
+					</ClayButton>
+				</ClayButton.Group>
+			</div>
+		</Timeline>
+	);
+}

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/components/rule-builder/Timeline.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/components/rule-builder/Timeline.es.js
@@ -1,0 +1,156 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
+import {ClayDropDownWithItems} from '@clayui/drop-down';
+import ClayIcon from '@clayui/icon';
+import ClayPanel from '@clayui/panel';
+import classnames from 'classnames';
+import React from 'react';
+
+import './Timeline.scss';
+
+const TimelineIncrement = ({children, className, ...otherProps}) => (
+	<div
+		{...otherProps}
+		className={classnames(className, 'timeline-increment')}
+	>
+		{children}
+	</div>
+);
+
+const TimelineIncrementIcon = (props) => (
+	<TimelineIncrement {...props}>
+		<span className="timeline-icon"></span>
+	</TimelineIncrement>
+);
+
+const TimelineIncrementButton = (props) => (
+	<TimelineIncrement className="timeline-increment-action-button">
+		<ClayButtonWithIcon
+			className="rounded-circle"
+			small
+			symbol="plus"
+			{...props}
+		/>
+	</TimelineIncrement>
+);
+
+const Condition = ({children, expression}) => (
+	<ClayPanel displayTitle={<></>} displayType="secondary">
+		<ClayPanel.Body>
+			<div className="form-group-autofit">
+				<div className="form-group-item form-group-item-label form-group-item-shrink">
+					<h4>
+						<span className="text-truncate-inline">
+							<span className="text-truncate">{expression}</span>
+						</span>
+					</h4>
+				</div>
+				{React.Children.map(children, (Child) => (
+					<div className="form-group-item">
+						<Child />
+					</div>
+				))}
+			</div>
+			<TimelineIncrementIcon />
+		</ClayPanel.Body>
+	</ClayPanel>
+);
+
+const ActionTrash = (props) => (
+	<div className="container-trash">
+		<ClayButtonWithIcon
+			displayType="secondary"
+			small
+			symbol="trash"
+			{...props}
+		/>
+	</div>
+);
+
+const Operator = ({operator}) => (
+	<ClayPanel className="inline-item" displayType="secondary">
+		<ClayPanel.Body>
+			<span className="text-uppercase">{operator}</span>
+		</ClayPanel.Body>
+	</ClayPanel>
+);
+
+const List = ({children, className, ...otherProps}) => (
+	<ul
+		{...otherProps}
+		className={classnames(
+			'liferay-ddm-form-builder-rule-condition-list liferay-ddm-form-rule-builder-timeline timeline can-remove-item',
+			className
+		)}
+	>
+		{children}
+	</ul>
+);
+
+const ListItem = ({children, className, ...otherProps}) => (
+	<li {...otherProps} className={classnames(className, 'timeline-item')}>
+		{children}
+	</li>
+);
+
+const ListHeader = ({items, operator, title, ...otherProps}) => (
+	<ListItem {...otherProps}>
+		<ClayPanel displayTitle={title} displayType="secondary">
+			{operator && (
+				<ClayDropDownWithItems
+					items={items}
+					trigger={
+						<ClayButton
+							className="dropdown-toggle-operator mr-3"
+							displayType="secondary"
+						>
+							<span className="dropdown-toggle-selected-value text-uppercase">
+								{operator}
+							</span>
+							<span className="inline-item inline-item-after">
+								<ClayIcon symbol="caret-bottom" />
+							</span>
+						</ClayButton>
+					}
+				/>
+			)}
+			<TimelineIncrementIcon />
+		</ClayPanel>
+	</ListItem>
+);
+
+const Timeline = ({children, className, ...otherProps}) => (
+	<div
+		{...otherProps}
+		className={classnames(
+			'form-builder-rule-builder liferay-ddm-form-builder-rule-builder-content',
+			className
+		)}
+	>
+		{children}
+	</div>
+);
+
+Timeline.ActionTrash = ActionTrash;
+Timeline.Condition = Condition;
+Timeline.Header = ListHeader;
+Timeline.IncrementButton = TimelineIncrementButton;
+Timeline.IncrementIcon = TimelineIncrementIcon;
+Timeline.Item = ListItem;
+Timeline.List = List;
+Timeline.Operator = Operator;
+
+export default Timeline;

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/components/rule-builder/Timeline.scss
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/components/rule-builder/Timeline.scss
@@ -1,0 +1,11 @@
+.timeline-increment-action-button {
+	&:after {
+		content: '';
+		display: block;
+		height: 32px;
+	}
+
+	.timeline-increment {
+		left: 0;
+	}
+}


### PR DESCRIPTION
Related Issue: https://issues.liferay.com/browse/LPS-123064

This is an initial implementation of the RuleEditor, the great part is just a composition of the components for creating the RuleEditor screen, this will make it easier to implement the business rule for the RuleEditor, I added the components in Timeline and cleaned up the classes and markups a little using some things from Clay, this will break the poshi tests but we will only see it breaking when RuleEditor is implemented on ticket [LPS-123065](https://issues.liferay.com/browse/LPS-123065).

- We still need to do some class cleanup so that we no longer depend on something specific from DDM, for example `liferay-ddm-form-rule-builder`. I will clean this up in the next task.
- The poshi tests that can break can be more related to selectors, so I will fix this when these components are used, they are not yet, so there is no problem sending it to the master and we will see the tests pass here.
- I'm still unsure if the `<RuleEditor />` component needs to live in the `components` folder because it is a page component composed of other components, so maybe we need to organize it a bit and have a folder just for pages.