### PR TITLE
[TECHNICAL SUPPORT] LPS-122906 Forms do not need to store the version of workflow definitions

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-instance/src/main/java/com/liferay/dynamic/data/mapping/data/provider/instance/WorkflowDefinitionsDataProvider.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-instance/src/main/java/com/liferay/dynamic/data/mapping/data/provider/instance/WorkflowDefinitionsDataProvider.java
@@ -18,7 +18,6 @@ import com.liferay.dynamic.data.mapping.data.provider.DDMDataProvider;
 import com.liferay.dynamic.data.mapping.data.provider.DDMDataProviderException;
 import com.liferay.dynamic.data.mapping.data.provider.DDMDataProviderRequest;
 import com.liferay.dynamic.data.mapping.data.provider.DDMDataProviderResponse;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.KeyValuePair;
@@ -78,9 +77,7 @@ public class WorkflowDefinitionsDataProvider implements DDMDataProvider {
 			String languageId = LocaleUtil.toLanguageId(locale);
 
 			for (WorkflowDefinition workflowDefinition : workflowDefinitions) {
-				String value =
-					workflowDefinition.getName() + StringPool.AT +
-						workflowDefinition.getVersion();
+				String value = workflowDefinition.getName();
 
 				keyValuePairs.add(
 					new KeyValuePair(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/build.gradle
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/build.gradle
@@ -36,6 +36,7 @@ dependencies {
 	compileOnly project(":apps:portal-search:portal-search-api")
 	compileOnly project(":apps:portal-search:portal-search-spi")
 	compileOnly project(":apps:portal-template:portal-template-soy-api")
+	compileOnly project(":apps:portal-workflow:portal-workflow-kaleo-api")
 	compileOnly project(":apps:portal:portal-aop-api")
 	compileOnly project(":apps:portal:portal-dao-orm-custom-sql-api")
 	compileOnly project(":apps:portal:portal-instance-lifecycle-api")

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMFormInstanceLocalServiceImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMFormInstanceLocalServiceImpl.java
@@ -30,10 +30,12 @@ import com.liferay.dynamic.data.mapping.model.DDMFormInstanceVersion;
 import com.liferay.dynamic.data.mapping.model.DDMFormLayout;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.model.DDMStructureVersion;
+import com.liferay.dynamic.data.mapping.model.UnlocalizedValue;
 import com.liferay.dynamic.data.mapping.service.DDMFormInstanceRecordLocalService;
 import com.liferay.dynamic.data.mapping.service.DDMFormInstanceVersionLocalService;
 import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
 import com.liferay.dynamic.data.mapping.service.base.DDMFormInstanceLocalServiceBaseImpl;
+import com.liferay.dynamic.data.mapping.storage.DDMFormFieldValue;
 import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
 import com.liferay.dynamic.data.mapping.storage.StorageType;
 import com.liferay.dynamic.data.mapping.util.DDMFormFactory;
@@ -55,6 +57,8 @@ import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.workflow.kaleo.model.KaleoDefinition;
+import com.liferay.portal.workflow.kaleo.service.KaleoDefinitionLocalService;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -567,7 +571,8 @@ public class DDMFormInstanceLocalServiceImpl
 	}
 
 	protected DDMFormValues getFormInstanceSettingsFormValues(
-		String serializedSettingsDDMFormValues) {
+			String serializedSettingsDDMFormValues)
+		throws PortalException {
 
 		DDMForm ddmForm = DDMFormFactory.create(DDMFormInstanceSettings.class);
 
@@ -579,7 +584,12 @@ public class DDMFormInstanceLocalServiceImpl
 			ddmFormValuesDeserializerDeserializeResponse =
 				_jsonDDMFormValuesDeserializer.deserialize(builder.build());
 
-		return ddmFormValuesDeserializerDeserializeResponse.getDDMFormValues();
+		DDMFormValues ddmFormValues =
+			ddmFormValuesDeserializerDeserializeResponse.getDDMFormValues();
+
+		_removeWorkflowDefinitionVersion(ddmFormValues);
+
+		return ddmFormValues;
 	}
 
 	protected String getNextVersion(String version, boolean majorVersion) {
@@ -670,11 +680,21 @@ public class DDMFormInstanceLocalServiceImpl
 			ServiceContext serviceContext)
 		throws PortalException {
 
-		String workflowDefinition = getWorkflowDefinition(
+		String workflowDefinitionName = getWorkflowDefinition(
 			settingsDDMFormValues);
 
-		if (workflowDefinition.equals("no-workflow")) {
-			workflowDefinition = "";
+		String workflowDefinition = "";
+
+		if (Validator.isNotNull(workflowDefinitionName) &&
+			!workflowDefinitionName.equals("no-workflow")) {
+
+			KaleoDefinition kaleoDefinition =
+				_kaleoDefinitionLocalService.getKaleoDefinition(
+					workflowDefinitionName, serviceContext);
+
+			workflowDefinition =
+				workflowDefinitionName + StringPool.AT +
+					kaleoDefinition.getVersion();
 		}
 
 		workflowDefinitionLinkLocalService.updateWorkflowDefinitionLink(
@@ -727,6 +747,24 @@ public class DDMFormInstanceLocalServiceImpl
 		}
 	}
 
+	private void _removeWorkflowDefinitionVersion(DDMFormValues ddmFormValues) {
+		Map<String, List<DDMFormFieldValue>> ddmFormFieldValuesMap =
+			ddmFormValues.getDDMFormFieldValuesMap(false);
+
+		List<DDMFormFieldValue> ddmFormFieldValues = ddmFormFieldValuesMap.get(
+			"workflowDefinition");
+
+		DDMFormFieldValue ddmFormFieldValue = ddmFormFieldValues.get(0);
+
+		UnlocalizedValue value = (UnlocalizedValue)ddmFormFieldValue.getValue();
+
+		String workflowDefinition = value.getString(value.getDefaultLocale());
+
+		value.addString(
+			value.getDefaultLocale(),
+			workflowDefinition.replaceAll("@\\d+", StringPool.BLANK));
+	}
+
 	private static final String _VERSION_DEFAULT = "1.0";
 
 	@Reference
@@ -748,6 +786,9 @@ public class DDMFormInstanceLocalServiceImpl
 
 	@Reference(target = "(ddm.form.values.serializer.type=json)")
 	private DDMFormValuesSerializer _jsonDDMFormValuesSerializer;
+
+	@Reference
+	private KaleoDefinitionLocalService _kaleoDefinitionLocalService;
 
 	@Reference
 	private MailService _mailService;


### PR DESCRIPTION
Related Issue: https://issues.liferay.com/browse/LPS-122906

**Notes about this fix:**
Before implementing this, I've considered 3 different approaches. Here are they:
1. First I thought about creating a listener that would update all the forms linked to a workflow definition. This idea fell through, because it would cause an overhead on the update action of the workflow component. All those forms would have to be searched, deserialized and updated every time a workflow definition changed;
2. The second idea is a combination of the following approach and creating an upgrade process with the purpose of removing all the version related data from the forms' workflow setting (example: from ["Single Approver@1"] to ["Single Approver"]). I also thought this would cause and overhead during DXP upgrades, because, since this needs to be backported all the way to 7.1, this upgrade would have to be executed every time a customer upgrades their Liferay version up until 7.4;
3. Finally, the chosen approach is the same as the previous one, but I've decided to change this information on demand. What you can see in [this part](https://github.com/liferay-forms/liferay-portal/pull/62/commits/93f3eaf384c6bef8be61add8b282af8d75ed87eb#diff-6661dadc6f2d46e211d21fbae3624bcac98af84b52c62ebbf0820c298e8f6ee9R750-R767) is the removal of the version data from the workflow setting. It doesn't cause any stress on the database connection and customers won't have to wait for a heavy fix pack release to get this fixed. Also, now that [the workflow select field won't pair the keys and values containing version information](https://github.com/liferay-forms/liferay-portal/pull/62/commits/93f3eaf384c6bef8be61add8b282af8d75ed87eb#diff-48509e0457aafbdbc5fbead9b277f375c35cf16e8d426e751d44fb1055c4efdcR80), and it's mandatory to pass that data when updating the link, I had to make this [cheap search for the latest available version](https://github.com/liferay-forms/liferay-portal/pull/62/commits/93f3eaf384c6bef8be61add8b282af8d75ed87eb#diff-6661dadc6f2d46e211d21fbae3624bcac98af84b52c62ebbf0820c298e8f6ee9R686-R697) before finishing the form update. This last part will only happen when the user saves a form with a workflow defined in their form's settings.

_Extra notes:_
I chose to use the [KaleoDefinitionLocalService](https://github.com/liferay-forms/liferay-portal/pull/62/commits/93f3eaf384c6bef8be61add8b282af8d75ed87eb#diff-6661dadc6f2d46e211d21fbae3624bcac98af84b52c62ebbf0820c298e8f6ee9R791) instead of the [WorkflowDefinitionManager](https://github.com/liferay-forms/liferay-portal/blob/master/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-integration-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/integration/internal/WorkflowDefinitionManagerImpl.java), because basically the last one eventually uses the first one and we wouldn't need to use more memory to convert a KaleoDefinition object into a WorkflowDefinition one. It looks kinda wasteful for this use case IMO.

This is it. Please reach out if you need further details about this. I'll be happy to provide them.
Thanks in advance.