### PR TITLE
LPS-124604 Clean up the rule when changing the type of the Field

### DIFF
--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/components/rule-builder/FormsRuleList.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/components/rule-builder/FormsRuleList.es.js
@@ -100,7 +100,7 @@ const Operand = ({field, left, type, value}) => {
 			case 'option':
 				return left.field.options.find(
 					(option) => value === option.value
-				).label;
+				)?.label;
 			case 'field':
 				return field.label;
 			case 'list':

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/components/rule-builder/editor/Conditions.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/components/rule-builder/editor/Conditions.es.js
@@ -238,7 +238,7 @@ export function Conditions({
 							readOnly={!left.value}
 							right={right}
 						/>
-						{right && (
+						{right && right.type && (
 							<FieldRight
 								fields={fields}
 								left={left}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/LayoutProvider/handlers/focusedFieldEvaluationEndedHandler.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/LayoutProvider/handlers/focusedFieldEvaluationEndedHandler.es.js
@@ -14,6 +14,7 @@
 
 import {PagesVisitor} from 'dynamic-data-mapping-form-renderer';
 
+import RulesSupport from '../../RuleBuilder/RulesSupport.es';
 import {getField} from '../util/fields.es';
 import handleFieldEdited from './fieldEditedHandler.es';
 
@@ -43,7 +44,7 @@ const handleFocusedFieldEvaluationEnded = (
 		return state;
 	}
 
-	state = {
+	let newState = {
 		...state,
 		focusedField: {
 			...focusedField,
@@ -55,13 +56,18 @@ const handleFocusedFieldEvaluationEnded = (
 	const visitor = new PagesVisitor(settingsContext.pages);
 
 	visitor.mapFields(({fieldName, value}) => {
-		state = handleFieldEdited(props, state, {
+		newState = handleFieldEdited(props, newState, {
 			propertyName: fieldName,
 			propertyValue: value,
 		});
 	});
 
-	return state;
+	return {
+		...newState,
+		rules: changedFieldType
+			? RulesSupport.formatRules(newState.pages, state.rules)
+			: state.rules,
+	};
 };
 
 export default handleFocusedFieldEvaluationEnded;


### PR DESCRIPTION
The implementation of "Broken Rules" was not checking the rules after a field type change happened, I just called the function when it happened, but maybe the `formatRules` function needs more attention or refactored to handle more cases, I think there may still be bugs in this implementation, I did not refactor here because it is not the intention of this ticket.