### PR TITLE
[LPS-123964,LPS-124912] Migrate instances of AlloyEditor in Forms

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/css/_general.scss
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/css/_general.scss
@@ -468,3 +468,49 @@ td.lfr-name-column {
 .taglib-empty-result-message {
 	margin-top: 104px;
 }
+
+.portlet-forms {
+	.ddm-form-basic-info {
+		h1 > .form-group {
+			margin-bottom: 0;
+		}
+
+		.form-control {
+			background: transparent;
+			box-shadow: none;
+			font-weight: 600;
+			overflow: hidden;
+			resize: none;
+
+			&.ddm-form-name {
+				font-weight: 600;
+
+				&::placeholder {
+					color: #b0b4bb;
+					font-weight: 500;
+				}
+			}
+
+			&.ddm-form-description {
+				color: #000;
+				font-size: 14px;
+				font-weight: 400;
+				padding-top: 0;
+
+				&::placeholder {
+					color: #b0b4bb;
+				}
+			}
+		}
+
+		.ddm-placeholder {
+			&:focus::placeholder {
+				color: transparent;
+			}
+		}
+
+		.hidden {
+			display: none;
+		}
+	}
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/edit_element_set.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/edit_element_set.jsp
@@ -90,29 +90,13 @@ renderResponse.setTitle((structure == null) ? LanguageUtil.get(request, "new-ele
 		<div class="ddm-form-basic-info">
 			<clay:container-fluid>
 				<h1>
-					<liferay-editor:editor
-						autoCreate="<%= false %>"
-						contents="<%= HtmlUtil.escape(ddmFormAdminDisplayContext.getFormName()) %>"
-						cssClass="ddm-form-name"
-						editorName="alloyeditor"
-						name="nameEditor"
-						placeholder="untitled-element-set"
-						showSource="<%= false %>"
-					/>
+					<aui:input autoSize="<%= true %>" cssClass="ddm-form-name ddm-placeholder hidden" label="" name="nameEditor" placeholder='<%= LanguageUtil.get(request, "untitled-element-set") %>' type="textarea" value="<%= HtmlUtil.escape(ddmFormAdminDisplayContext.getFormName()) %>" />
 				</h1>
 
 				<aui:input name="name" type="hidden" />
 
 				<h5>
-					<liferay-editor:editor
-						autoCreate="<%= false %>"
-						contents="<%= HtmlUtil.escape(ddmFormAdminDisplayContext.getFormDescription()) %>"
-						cssClass="ddm-form-description h5"
-						editorName="alloyeditor"
-						name="descriptionEditor"
-						placeholder="add-a-short-description-for-this-element-set"
-						showSource="<%= false %>"
-					/>
+					<aui:input autoSize="<%= true %>" cssClass="ddm-form-description ddm-placeholder hidden" label="" name="descriptionEditor" placeholder='<%= LanguageUtil.get(request, "add-a-short-description-for-this-element-set") %>' type="textarea" value="<%= HtmlUtil.escape(ddmFormAdminDisplayContext.getFormDescription()) %>" />
 				</h5>
 
 				<aui:input name="description" type="hidden" />

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/edit_form_instance.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/edit_form_instance.jsp
@@ -133,27 +133,11 @@ renderResponse.setTitle((formInstance == null) ? LanguageUtil.get(request, "new-
 		<div class="ddm-form-basic-info">
 			<clay:container-fluid>
 				<h1>
-					<liferay-editor:editor
-						autoCreate="<%= false %>"
-						contents="<%= HtmlUtil.escapeAttribute(ddmFormAdminDisplayContext.getFormName()) %>"
-						cssClass="ddm-form-name"
-						editorName="alloyeditor"
-						name="nameEditor"
-						placeholder="untitled-form"
-						showSource="<%= false %>"
-					/>
+					<aui:input autoSize="<%= true %>" cssClass="ddm-form-name ddm-placeholder hidden" label="" name="nameEditor" placeholder='<%= LanguageUtil.get(request, "untitled-form") %>' type="textarea" value="<%= HtmlUtil.escapeAttribute(ddmFormAdminDisplayContext.getFormName()) %>" />
 				</h1>
 
 				<h5>
-					<liferay-editor:editor
-						autoCreate="<%= false %>"
-						contents="<%= HtmlUtil.escapeAttribute(ddmFormAdminDisplayContext.getFormDescription()) %>"
-						cssClass="ddm-form-description h5"
-						editorName="alloyeditor"
-						name="descriptionEditor"
-						placeholder="add-a-short-description-for-this-form"
-						showSource="<%= false %>"
-					/>
+					<aui:input autoSize="<%= true %>" cssClass="ddm-form-description ddm-placeholder hidden" label="" name="descriptionEditor" placeholder='<%= LanguageUtil.get(request, "add-a-short-description-for-this-form") %>' type="textarea" value="<%= HtmlUtil.escapeAttribute(ddmFormAdminDisplayContext.getFormDescription()) %>" />
 				</h5>
 			</clay:container-fluid>
 		</div>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/init.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/init.jsp
@@ -20,7 +20,6 @@
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
 taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
-taglib uri="http://liferay.com/tld/editor" prefix="liferay-editor" %><%@
 taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/portlet" prefix="liferay-portlet" %><%@
 taglib uri="http://liferay.com/tld/security" prefix="liferay-security" %><%@

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/main.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/main.es.js
@@ -46,8 +46,6 @@ const NAV_ITEMS = {
 	RULES: 1,
 };
 
-const EDITOR_NAME = 'nameEditor';
-
 /**
  * Form.
  * @extends Component
@@ -68,28 +66,23 @@ class Form extends Component {
 
 		this._eventHandler = new EventHandler();
 
-		const dependencies = [
-			this._createEditor(EDITOR_NAME).then((editor) => {
-				editor.element.$.addEventListener(
-					'keydown',
-					this._handleNameEditorKeydown
-				);
+		const nameEditor = document.getElementById(`${namespace}nameEditor`);
 
-				editor.element.$.addEventListener(
-					'keyup',
-					this._handleNameEditorCopyAndPaste
-				);
+		nameEditor.addEventListener('keydown', this._handleNameEditorKeydown);
+		nameEditor.addEventListener(
+			'keyup',
+			this._handleNameEditorCopyAndPaste
+		);
+		nameEditor.addEventListener(
+			'keypress',
+			this._handleNameEditorCopyAndPaste
+		);
 
-				editor.element.$.addEventListener(
-					'keypress',
-					this._handleNameEditorCopyAndPaste
-				);
+		const descriptionEditor = document.getElementById(
+			`${namespace}descriptionEditor`
+		);
 
-				return editor;
-			}),
-			this._createEditor('descriptionEditor'),
-			Liferay.componentReady('translationManager'),
-		];
+		const dependencies = [Liferay.componentReady('translationManager')];
 
 		if (this.isFormBuilderView()) {
 			dependencies.push(this._getSettingsDDMForm());
@@ -98,12 +91,11 @@ class Form extends Component {
 		}
 
 		Promise.all(dependencies).then(
-			([
-				nameEditor,
-				descriptionEditor,
-				translationManager,
-				settingsDDMForm,
-			]) => {
+			([translationManager, settingsDDMForm]) => {
+				nameEditor.classList.remove('hidden');
+
+				descriptionEditor.classList.remove('hidden');
+
 				if (translationManager) {
 					this.props.defaultLanguageId = translationManager.get(
 						'defaultLocale'
@@ -381,26 +373,20 @@ class Form extends Component {
 
 		const {namespace} = this.props;
 
-		const editorName = `${namespace}${EDITOR_NAME}`;
+		const nameEditor = document.getElementById(`${namespace}nameEditor`);
 
-		const editor = window[editorName];
-
-		if (editor) {
-			editor.element.$.removeEventListener(
-				'keydown',
-				this._handleNameEditorKeydown
-			);
-
-			editor.element.$.removeEventListener(
-				'keyup',
-				this._handleNameEditorCopyAndPaste
-			);
-
-			editor.element.$.removeEventListener(
-				'keypress',
-				this._handleNameEditorCopyAndPaste
-			);
-		}
+		nameEditor.removeEventListener(
+			'keydown',
+			this._handleNameEditorKeydown
+		);
+		nameEditor.removeEventListener(
+			'keyup',
+			this._handleNameEditorCopyAndPaste
+		);
+		nameEditor.removeEventListener(
+			'keypress',
+			this._handleNameEditorCopyAndPaste
+		);
 	}
 
 	hideAddButton() {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/util/StateSyncronizer.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/util/StateSyncronizer.es.js
@@ -13,7 +13,6 @@
  */
 
 import {FormSupport, PagesVisitor} from 'dynamic-data-mapping-form-renderer';
-import {EventHandler} from 'metal-events';
 import Component from 'metal-jsx';
 import {Config} from 'metal-state';
 
@@ -21,14 +20,14 @@ class StateSyncronizer extends Component {
 	created() {
 		const {descriptionEditor, nameEditor, translationManager} = this.props;
 
-		this._eventHandler = new EventHandler();
+		descriptionEditor.addEventListener(
+			'input',
+			this._handleDescriptionEditorChanged.bind(this)
+		);
 
-		this._eventHandler.add(
-			descriptionEditor.on(
-				'change',
-				this._handleDescriptionEditorChanged.bind(this)
-			),
-			nameEditor.on('change', this._handleNameEditorChanged.bind(this))
+		nameEditor.addEventListener(
+			'input',
+			this._handleNameEditorChanged.bind(this)
 		);
 
 		if (translationManager) {
@@ -54,7 +53,16 @@ class StateSyncronizer extends Component {
 	}
 
 	disposed() {
-		this._eventHandler.removeAllListeners();
+		const {descriptionEditor, nameEditor} = this.props;
+
+		nameEditor.removeEventListener(
+			'input',
+			this._handleNameEditorChanged.bind(this)
+		);
+		descriptionEditor.removeEventListener(
+			'input',
+			this._handleDescriptionEditorChanged.bind(this)
+		);
 
 		if (this._translationManagerHandles) {
 			this._translationManagerHandles.forEach((handle) =>
@@ -151,7 +159,7 @@ class StateSyncronizer extends Component {
 			description = localizedDescription[this.getDefaultLanguageId()];
 		}
 
-		window[descriptionEditor.name].setHTML(description);
+		descriptionEditor.value = description;
 
 		let name = localizedName[editingLanguageId];
 
@@ -159,7 +167,7 @@ class StateSyncronizer extends Component {
 			name = localizedName[this.getDefaultLanguageId()];
 		}
 
-		window[nameEditor.name].setHTML(name);
+		nameEditor.value = name;
 	}
 
 	syncInputs() {
@@ -260,16 +268,15 @@ class StateSyncronizer extends Component {
 
 	_handleDescriptionEditorChanged() {
 		const {descriptionEditor, localizedDescription} = this.props;
-		const editor = window[descriptionEditor.name];
 
-		localizedDescription[this.getEditingLanguageId()] = editor.getHTML();
+		localizedDescription[this.getEditingLanguageId()] =
+			descriptionEditor.value;
 	}
 
 	_handleNameEditorChanged() {
 		const {localizedName, nameEditor} = this.props;
-		const editor = window[nameEditor.name];
 
-		localizedName[this.getEditingLanguageId()] = editor.getHTML();
+		localizedName[this.getEditingLanguageId()] = nameEditor.value;
 	}
 }
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Form.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Form.macro
@@ -254,11 +254,9 @@ definition {
 
 		AssertVisible(locator1 = "Form#DESCRIPTION_FIELD");
 
-		Click(locator1 = "Form#NAME_FIELD");
-
-		AlloyEditor.typeEditor(
-			content = "${formName}",
-			editor = "name");
+		Type(
+			locator1 = "Form#NAME_FIELD",
+			value1 = "${formName}");
 	}
 
 	macro editNameLocalized {
@@ -270,11 +268,9 @@ definition {
 
 		AssertVisible(locator1 = "Form#DESCRIPTION_FIELD");
 
-		Click(locator1 = "Form#NAME_FIELD");
-
-		AlloyEditor.typeEditor(
-			content = "${formName}",
-			editor = "name");
+		Type(
+			locator1 = "Form#NAME_FIELD",
+			value1 = "${formName}");
 	}
 
 	macro editPageTitle {

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/forms/Form.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/forms/Form.path
@@ -35,12 +35,12 @@
 </tr>
 <tr>
     <td>NAME_FIELD</td>
-    <td>//div[contains(@id,'nameEditorContainer')]/div</td>
+    <td>//div[contains(@class,'ddm-form-basic-info')]//textarea[contains(@id, 'nameEditor')]</td>
     <td></td>
 </tr>
 <tr>
     <td>DESCRIPTION_FIELD</td>
-    <td>//div[contains(@id,'descriptionEditorContainer')]/div</td>
+    <td>//div[contains(@class,'ddm-form-basic-info')]//textarea[contains(@id, 'descriptionEditor')]</td>
     <td></td>
 </tr>
 <tr>


### PR DESCRIPTION
**LPS-123964**
In [`edit_form_instance.jsp`](https://github.com/liferay/liferay-portal/blob/f1dbd869c1036f3bc6379585b4c2a0293877d389/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/edit_form_instance.jsp), AlloyEditor instances
have been replaced with `<aui:input />`

**Test plan**
- Deploy the `dynamic-data-mapping-form-web` module
- Navigate to **Content & Data** > **Forms**
- Create a new form and save it

**Before**
![LPS-123964-before](https://user-images.githubusercontent.com/5572/102894966-2dc16700-4464-11eb-950b-85f2b7caf4bf.png)


**After**
![LPS-123964-after](https://user-images.githubusercontent.com/5572/102894975-3154ee00-4464-11eb-8502-dfb51ce9880d.png)

**LPS-124912**
In [`edit_element_set.jsp`](https://github.com/liferay/liferay-portal/blob/f1dbd869c1036f3bc6379585b4c2a0293877d389/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/edit_element_set.jsp), AlloyEditor instances
have also been replaced with `<aui:input />`

**Test plan**
- Deploy the `dynamic-data-mapping-form-web` module
- Navigate to **Content & Data** > **Forms**
- Select the **Element Sets** tab
- Create a new form and save it

**Before**
![LPS-124912-before](https://user-images.githubusercontent.com/5572/102894981-34e87500-4464-11eb-931c-02051da03869.png)

**After**
![LPS-124912-after](https://user-images.githubusercontent.com/5572/102894992-387bfc00-4464-11eb-98ac-af40f6881625.png)

**Additional notes**
Initially reviewed by the @liferay-frontend team [here](https://github.com/liferay-frontend/liferay-portal/pull/624)