### PR TITLE
LPS-125695 Fixes error when changing variable of the expression to fieldName instead of fieldLabel when the field is selected

### DIFF
--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/components/rule-builder/editor/Actions.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/components/rule-builder/editor/Actions.es.js
@@ -41,11 +41,15 @@ const ActionContentCalculate = ({
 		link: location.origin + functionsURL,
 	});
 
-	const options = useMemo(() => {
-		return fields.filter(
-			({fieldName, type}) => type === 'numeric' && fieldName !== target
-		);
-	}, [fields, target]);
+	const numericFields = useMemo(
+		() => fields.filter(({type}) => type === 'numeric'),
+		[fields]
+	);
+
+	const options = useMemo(
+		() => numericFields.filter(({fieldName}) => fieldName !== target),
+		[numericFields, target]
+	);
 
 	if (!resource) {
 		return null;
@@ -54,7 +58,7 @@ const ActionContentCalculate = ({
 	return (
 		<Calculator
 			expression={expression}
-			fields={options}
+			fields={numericFields}
 			functions={resource}
 			onChange={(newExpression) =>
 				onChange({
@@ -64,6 +68,7 @@ const ActionContentCalculate = ({
 					type: ACTIONS_TYPES.CHANGE_ACTION_CALCULATE,
 				})
 			}
+			options={options}
 		/>
 	);
 };

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/components/rule-builder/editor/Calculator.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/components/rule-builder/editor/Calculator.es.js
@@ -193,7 +193,10 @@ function FieldsDropdown({items, onFieldSelected = () => {}, ...otherProps}) {
 }
 
 const Calculator = forwardRef(
-	({expression: initialExpression, fields, functions, onChange}, ref) => {
+	(
+		{expression: initialExpression, fields, functions, onChange, options},
+		ref
+	) => {
 		const [expression, setExpression] = useState(initialExpression);
 
 		const {
@@ -204,8 +207,8 @@ const Calculator = forwardRef(
 			showOnlyRepeatableFields,
 		} = useMemo(() => getStateBasedOnExpression(expression), [expression]);
 
-		const repeatableFields = useMemo(() => getRepeatableFields(fields), [
-			fields,
+		const repeatableFields = useMemo(() => getRepeatableFields(options), [
+			options,
 		]);
 
 		const value = useMemo(() => {
@@ -221,7 +224,7 @@ const Calculator = forwardRef(
 
 		const dropdownItems = showOnlyRepeatableFields
 			? repeatableFields
-			: fields;
+			: options;
 
 		const updateExpression = (newExpression) => {
 			setExpression(newExpression);

--- a/modules/apps/data-engine/data-engine-taglib/test/js/data-layout-builder/components/rule-builder/editor/Calculator.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/test/js/data-layout-builder/components/rule-builder/editor/Calculator.es.js
@@ -83,6 +83,7 @@ const defaultProps = (fieldsList = fields) => {
 			},
 		],
 		index: 0,
+		options: fieldsList,
 	};
 };
 


### PR DESCRIPTION
Fixes the problem when the field is in the calculator expression and it is selected changes to `fieldName` instead of using `label`. What has been done here has always been to use the `label`, but it does not block the user from selecting the field being used in the expression.