### PR TITLE
LPS-125821 Fixes error of breaking the rules page when trying to save the form with broken rule

### DIFF
--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/components/rule-builder/FormsRuleList.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/components/rule-builder/FormsRuleList.es.js
@@ -103,7 +103,7 @@ const Operand = ({field, left, type, value}) => {
 					(option) => value === option.value
 				)?.label;
 			case 'field':
-				return field.label;
+				return field?.label;
 			case 'list':
 				return value;
 			case 'json':


### PR DESCRIPTION
Ticket: https://issues.liferay.com/browse/LPS-125821

@natocesarrego I realized that when trying to save a form with a broken rule in the case of use of the ticket the rule that comes back from the backend is the rule saved previously. I think, should go back to the rules that was sent to the backend because otherwise, we cannot say if the rule is broken.

Simplifying, when deleting the field that was used in the rule, we show that the rule is broken by removing the field from the rule but when trying to save the form it should return without the field in the rule in the same way that the form returns without the field.