### PR TITLE
LPS-123795 Rewrite field Resize logic from the DOM oriented calculation to a more smooth and simpler code

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/css/form-builder/_resizeable.scss
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/css/form-builder/_resizeable.scss
@@ -34,7 +34,7 @@ $c: '.ddm-form-builder';
 		}
 	}
 
-	.resizeable .ddm-field-container {
+	.ddm-field-container {
 		&.dragging,
 		&.expanded,
 		&.hovered,
@@ -48,7 +48,7 @@ $c: '.ddm-form-builder';
 		}
 	}
 
-	.resizeable .ddm-field-container {
+	.ddm-field-container {
 		&.ddm-fieldset {
 			&.hovered,
 			&.selected {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/FormBuilder/FormBuilder.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/FormBuilder/FormBuilder.es.js
@@ -23,7 +23,7 @@ import {Config} from 'metal-state';
 
 import {pageStructure} from '../../util/config.es';
 import withEditablePageHeader from './withEditablePageHeader.es';
-import withMoveableFields from './withMoveableFields.es';
+// import withMoveableFields from './withMoveableFields.es';
 import withMultiplePages from './withMultiplePages.es';
 
 const FormNoopAdapter = getConnectedReactComponentAdapter(FormNoop);
@@ -218,7 +218,6 @@ FormBuilderBase.PROPS = {
 
 export default compose(
 	withEditablePageHeader,
-	withMoveableFields,
 	withMultiplePages
 )(FormBuilderBase);
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/FormBuilder/FormBuilder.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/FormBuilder/FormBuilder.es.js
@@ -25,7 +25,6 @@ import {pageStructure} from '../../util/config.es';
 import withEditablePageHeader from './withEditablePageHeader.es';
 import withMoveableFields from './withMoveableFields.es';
 import withMultiplePages from './withMultiplePages.es';
-import withResizeableColumns from './withResizeableColumns.es';
 
 const FormNoopAdapter = getConnectedReactComponentAdapter(FormNoop);
 
@@ -220,8 +219,7 @@ FormBuilderBase.PROPS = {
 export default compose(
 	withEditablePageHeader,
 	withMoveableFields,
-	withMultiplePages,
-	withResizeableColumns
+	withMultiplePages
 )(FormBuilderBase);
 
 export {FormBuilderBase};

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/FormBuilder/FormBuilderWithLayoutProvider.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/FormBuilder/FormBuilderWithLayoutProvider.es.js
@@ -21,7 +21,6 @@ import {FormBuilderBase} from './FormBuilder.es';
 import withEditablePageHeader from './withEditablePageHeader.es';
 import withMoveableFields from './withMoveableFields.es';
 import withMultiplePages from './withMultiplePages.es';
-import withResizeableColumns from './withResizeableColumns.es';
 
 /**
  * LayoutProvider listens to your children's events to
@@ -35,7 +34,7 @@ class FormBuilderWithLayoutProvider extends Component {
 
 		const LProvider = LayoutProvider;
 
-		const composeList = [withMoveableFields, withResizeableColumns];
+		const composeList = [withMoveableFields];
 
 		if (layoutProviderProps.allowMultiplePages) {
 			composeList.push(withMultiplePages);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/FormBuilder/FormBuilderWithLayoutProvider.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/FormBuilder/FormBuilderWithLayoutProvider.es.js
@@ -19,7 +19,7 @@ import {Config} from 'metal-state';
 import LayoutProvider from '../LayoutProvider/LayoutProvider.es';
 import {FormBuilderBase} from './FormBuilder.es';
 import withEditablePageHeader from './withEditablePageHeader.es';
-import withMoveableFields from './withMoveableFields.es';
+// import withMoveableFields from './withMoveableFields.es';
 import withMultiplePages from './withMultiplePages.es';
 
 /**
@@ -34,7 +34,7 @@ class FormBuilderWithLayoutProvider extends Component {
 
 		const LProvider = LayoutProvider;
 
-		const composeList = [withMoveableFields];
+		const composeList = [];
 
 		if (layoutProviderProps.allowMultiplePages) {
 			composeList.push(withMultiplePages);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/LayoutProvider/LayoutProvider.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/LayoutProvider/LayoutProvider.es.js
@@ -359,18 +359,11 @@ class LayoutProvider extends Component {
 		});
 	}
 
-	_handleColumnResized({column, container, direction, source}) {
+	_handleColumnResized({column, direction, loc}) {
 		const {props, state} = this;
 
 		this.setState(
-			handleColumnResized(
-				props,
-				state,
-				source,
-				container,
-				column,
-				direction
-			)
+			handleColumnResized({column, direction, loc, props, state})
 		);
 	}
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/LayoutProvider/LayoutProvider.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/LayoutProvider/LayoutProvider.es.js
@@ -20,7 +20,7 @@ import {
 	generateName,
 	getRepeatedIndex,
 } from 'dynamic-data-mapping-form-renderer';
-import {openModal, openToast} from 'frontend-js-web';
+import {openModal} from 'frontend-js-web';
 import Component from 'metal-jsx';
 import {Config} from 'metal-state';
 
@@ -72,10 +72,7 @@ class LayoutProvider extends Component {
 			this.emit(event, payload);
 		}
 		catch (e) {
-			openToast({
-				message: e.message,
-				type: 'danger',
-			});
+			throw new Error(e.message);
 		}
 	}
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/LayoutProvider/handlers/columnResizedHandler.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/LayoutProvider/handlers/columnResizedHandler.es.js
@@ -82,7 +82,6 @@ const getColumnPosition = (context, indexes) => {
 export const handleResizeRight = (
 	props,
 	state,
-	source,
 	indexes,
 	columnTarget
 ) => {
@@ -216,7 +215,7 @@ export const handleResizeRight = (
 	return pages;
 };
 
-const handleResizeLeft = (props, state, source, indexes, columnTarget) => {
+const handleResizeLeft = (props, state, indexes, columnTarget) => {
 	const {pages} = state;
 
 	const {columnIndex, pageIndex, rowIndex} = indexes[indexes.length - 1];
@@ -265,8 +264,6 @@ const handleResizeLeft = (props, state, source, indexes, columnTarget) => {
 				size: currentColumn.size - columnTarget,
 			}
 		);
-
-		source.dataset.ddmFieldColumn = columnIndex + 1;
 	}
 	else if (
 		previousColumn &&
@@ -280,8 +277,6 @@ const handleResizeLeft = (props, state, source, indexes, columnTarget) => {
 			rowIndex,
 			columnIndex - 1
 		);
-
-		source.dataset.ddmFieldColumn = columnIndex - 1;
 
 		newContext = FormSupport.updateColumn(
 			newContext,
@@ -343,31 +338,22 @@ const handleResizeLeft = (props, state, source, indexes, columnTarget) => {
 	return pages;
 };
 
-export default (props, state, source, container, column, direction) => {
+export default ({column, direction, loc, props, state}) => {
 	const {pages} = state;
 
 	let newPages = [...pages];
 
-	const sourceIndexes = FormSupport.getNestedIndexes(container);
-
-	const currentColumn = getColumn(pages, sourceIndexes);
+	const currentColumn = getColumn(pages, loc);
 
 	if (currentColumn) {
 		if (direction === 'left') {
-			newPages = handleResizeLeft(
-				props,
-				state,
-				source,
-				sourceIndexes,
-				column
-			);
+			newPages = handleResizeLeft(props, state, loc, column);
 		}
 		else {
 			newPages = handleResizeRight(
 				props,
 				state,
-				source,
-				sourceIndexes,
+				loc,
 				column + 1
 			);
 		}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/actions/eventTypes.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/actions/eventTypes.es.js
@@ -14,6 +14,7 @@
 
 const PUBLIC_EVENTS = {
 	CHANGE_ACTIVE_PAGE: 'activePageUpdated',
+	COLUMN_RESIZED: 'columnResized',
 	FIELD_BLUR: 'fieldBlurred',
 	FIELD_CHANGE: 'fieldEdited',
 	FIELD_CLICKED: 'fieldClicked',

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/components/Field/Field.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/components/Field/Field.es.js
@@ -165,21 +165,23 @@ const FieldLazy = ({
 	);
 };
 
-const getRootParentField = (field, {root}) => {
+const getRootParentField = (field, currentLoc, {loc, root}) => {
 	if (root) {
 		return {
 			...field,
+			loc: [currentLoc, ...loc],
 			root,
 		};
 	}
 
 	return {
 		...field,
+		loc: [currentLoc],
 		root: field,
 	};
 };
 
-export const Field = ({field, ...otherProps}) => {
+export const Field = ({field, loc, ...otherProps}) => {
 	const parentField = useContext(ParentFieldContext);
 	const {fieldTypes} = usePage();
 	const [hasError, setHasError] = useState();
@@ -219,7 +221,7 @@ export const Field = ({field, ...otherProps}) => {
 				<div className="ddm-field" data-field-name={field.fieldName}>
 					<Suspense fallback={<ClayLoadingIndicator />}>
 						<ParentFieldContext.Provider
-							value={getRootParentField(field, parentField)}
+							value={getRootParentField(field, loc, parentField)}
 						>
 							<FieldLazy
 								field={field}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/components/PageRenderer/EditorVariant.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/components/PageRenderer/EditorVariant.es.js
@@ -14,14 +14,19 @@
 
 import ClayLayout from '@clayui/layout';
 import classNames from 'classnames';
-import React, {useContext, useRef} from 'react';
+import {useEventListener} from 'frontend-js-react-web';
+import React, {useContext, useRef, useState} from 'react';
 
+import {EVENT_TYPES} from '../../actions/eventTypes.es';
 import {DND_ORIGIN_TYPE, useDrop} from '../../hooks/useDrop.es';
+import {useForm} from '../../hooks/useForm.es';
 import {hasFieldSet} from '../../util/fields.es';
 import {Actions, ActionsControls, useActions} from '../Actions.es';
 import {ParentFieldContext} from '../Field/ParentFieldContext.es';
 import {Placeholder} from '../Placeholder.es';
 import * as DefaultVariant from './DefaultVariant.es';
+
+const MAX_COLUMNS = 12;
 
 export const Column = ({
 	activePage,
@@ -29,19 +34,22 @@ export const Column = ({
 	children,
 	column,
 	editable,
-	index,
+	index: columnIndex,
 	pageIndex,
 	rowIndex,
+	rowRef,
 }) => {
 	const parentField = useContext(ParentFieldContext);
 
 	const actionsRef = useRef(null);
 	const columnRef = useRef(null);
 
+	const [resizing, setResizing] = useState(false);
+
 	const [{activeId, hoveredId}] = useActions();
 
 	const {drop, overTarget} = useDrop({
-		columnIndex: index,
+		columnIndex,
 		fieldName: column.fields[0]?.fieldName,
 		origin: DND_ORIGIN_TYPE.FIELD,
 		pageIndex,
@@ -52,7 +60,7 @@ export const Column = ({
 	if (editable && column.fields.length === 0 && activePage === pageIndex) {
 		return (
 			<Placeholder
-				columnIndex={index}
+				columnIndex={columnIndex}
 				pageIndex={pageIndex}
 				rowIndex={rowIndex}
 				size={column.size}
@@ -68,7 +76,7 @@ export const Column = ({
 		firstField.fieldName === activeId || firstField.fieldName === hoveredId;
 
 	const addr = {
-		'data-ddm-field-column': index,
+		'data-ddm-field-column': columnIndex,
 		'data-ddm-field-page': pageIndex,
 		'data-ddm-field-row': rowIndex,
 	};
@@ -91,13 +99,14 @@ export const Column = ({
 						isFieldSetOrGroup &&
 						overTarget &&
 						!rootParentField.ddmStructureId,
+					dragging: resizing,
 					hovered: editable && firstField.fieldName === hoveredId,
 					selected: editable && firstField.fieldName === activeId,
 					'target-over targetOver':
 						!rootParentField.ddmStructureId && overTarget,
 				})}
 				column={column}
-				index={index}
+				index={columnIndex}
 				pageIndex={pageIndex}
 				ref={columnRef}
 				rowIndex={rowIndex}
@@ -112,46 +121,155 @@ export const Column = ({
 					/>
 				)}
 
-				<div
-					className={classNames(
-						'ddm-resize-handle ddm-resize-handle-left',
-						{
-							hide: !isFieldSelected || !editable,
-						}
-					)}
+				<ResizableColumn
 					{...addr}
-				/>
-
-				<div
-					className={classNames('ddm-drag', {
-						'py-0': isFieldSetOrGroup,
-					})}
-					ref={
-						allowNestedFields && !rootParentField.ddmStructureId
-							? drop
-							: undefined
-					}
+					allowNestedFields={allowNestedFields}
+					columnIndex={columnIndex}
+					drop={drop}
+					editable={editable}
+					isFieldSelected={isFieldSelected}
+					isFieldSetOrGroup={isFieldSetOrGroup}
+					onResizing={(resizing) => setResizing(resizing)}
+					pageIndex={pageIndex}
+					rootParentField={rootParentField}
+					rowIndex={rowIndex}
+					rowRef={rowRef}
 				>
 					{column.fields.map((field, index) =>
-						children({field, index})
+						children({
+							field,
+							index,
+							loc: {
+								columnIndex,
+								pageIndex,
+								rowIndex,
+							},
+						})
 					)}
-				</div>
-
-				<div
-					className={classNames(
-						'ddm-resize-handle ddm-resize-handle-right',
-						{
-							hide: !isFieldSelected || !editable,
-						}
-					)}
-					{...addr}
-				/>
+				</ResizableColumn>
 			</DefaultVariant.Column>
 		</ActionsControls>
 	);
 };
 
 Column.displayName = 'EditorVariant.Column';
+
+const DIRECTIONS = {
+	LEFT: 'left',
+	RIGHT: 'right',
+};
+
+const ResizableColumn = ({
+	allowNestedFields,
+	children,
+	columnIndex,
+	drop,
+	editable,
+	isFieldSelected,
+	isFieldSetOrGroup,
+	onResizing,
+	pageIndex,
+	rootParentField,
+	rowIndex,
+	rowRef,
+}) => {
+	const {loc = []} = useContext(ParentFieldContext);
+
+	const resizeInfo = useRef();
+
+	const dispatch = useForm();
+
+	const handleMouseDown = (event, direction) => {
+		event.preventDefault();
+		event.stopPropagation();
+
+		onResizing(true);
+
+		resizeInfo.current = {
+			direction,
+		};
+	};
+
+	const handleMouseMove = (event) => {
+		if (resizeInfo.current) {
+			let column = Math.floor(
+				((event.clientX -
+					rowRef.current?.getBoundingClientRect().left) *
+					(MAX_COLUMNS * 10)) /
+					rowRef.current?.clientWidth /
+					10
+			);
+
+			if (column > MAX_COLUMNS - 1) {
+				column = MAX_COLUMNS - 1;
+			}
+
+			if (column >= 0) {
+				const {direction} = resizeInfo.current;
+
+				dispatch({
+					payload: {
+						column,
+						direction,
+						loc: [...loc, {columnIndex, pageIndex, rowIndex}],
+					},
+					type: EVENT_TYPES.COLUMN_RESIZED,
+				});
+			}
+		}
+	};
+
+	useEventListener('mousemove', handleMouseMove, false, document.body);
+
+	useEventListener(
+		'mouseup',
+		() => {
+			onResizing(false);
+			resizeInfo.current = null;
+		},
+		false,
+		document.body
+	);
+
+	return (
+		<>
+			<div
+				className={classNames(
+					'ddm-resize-handle ddm-resize-handle-left',
+					{
+						hide: !isFieldSelected || !editable,
+					}
+				)}
+				onMouseDown={(event) => handleMouseDown(event, DIRECTIONS.LEFT)}
+			/>
+
+			<div
+				className={classNames('ddm-drag', {
+					'py-0': isFieldSetOrGroup,
+				})}
+				ref={
+					allowNestedFields && !rootParentField.ddmStructureId
+						? drop
+						: undefined
+				}
+			>
+				{children}
+			</div>
+
+			<div
+				className={classNames(
+					'ddm-resize-handle ddm-resize-handle-right',
+					{
+						hide: !isFieldSelected || !editable,
+					}
+				)}
+				onMouseDown={(event) =>
+					handleMouseDown(event, DIRECTIONS.RIGHT)
+				}
+			/>
+		</>
+	);
+};
 
 export const Page = ({
 	activePage,
@@ -241,3 +359,17 @@ export const Rows = ({children, editable, pageIndex, rows}) => {
 };
 
 Rows.displayName = 'EditorVariant.Rows';
+
+export const Row = ({children, index, row}) => {
+	const rowRef = useRef(null);
+
+	return (
+		<div className="position-relative row" key={index} ref={rowRef}>
+			{row.columns.map((column, index) =>
+				children({column, index, rowRef})
+			)}
+		</div>
+	);
+};
+
+Row.displayName = 'EditorVariant.Row';

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/components/PageRenderer/Layout.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/components/PageRenderer/Layout.es.js
@@ -48,7 +48,7 @@ export const Layout = ({components, editable, rows}) => {
 		>
 			{({index: rowIndex, row}) => (
 				<Components.Row key={rowIndex} row={row}>
-					{({column, index}) => (
+					{({column, index, rowRef}) => (
 						<Components.Column
 							activePage={activePage}
 							allowNestedFields={allowNestedFields}
@@ -57,7 +57,9 @@ export const Layout = ({components, editable, rows}) => {
 							index={index}
 							key={index}
 							pageIndex={pageIndex}
+							row={row}
 							rowIndex={rowIndex}
+							rowRef={rowRef}
 						>
 							{(fieldProps) => (
 								<Field

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/main.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/main.es.js
@@ -16,7 +16,7 @@ import ClayModal from 'clay-modal';
 import {FormsRuleBuilder} from 'data-engine-taglib';
 import {FormBuilderBase} from 'dynamic-data-mapping-form-builder/js/components/FormBuilder/FormBuilder.es';
 import withEditablePageHeader from 'dynamic-data-mapping-form-builder/js/components/FormBuilder/withEditablePageHeader.es';
-import withMoveableFields from 'dynamic-data-mapping-form-builder/js/components/FormBuilder/withMoveableFields.es';
+// import withMoveableFields from 'dynamic-data-mapping-form-builder/js/components/FormBuilder/withMoveableFields.es';
 import withMultiplePages from 'dynamic-data-mapping-form-builder/js/components/FormBuilder/withMultiplePages.es';
 import LayoutProvider from 'dynamic-data-mapping-form-builder/js/components/LayoutProvider/LayoutProvider.es';
 import Sidebar from 'dynamic-data-mapping-form-builder/js/components/Sidebar/Sidebar.es';
@@ -735,7 +735,7 @@ class Form extends Component {
 	}
 
 	_createFormBuilder() {
-		const composeList = [withMoveableFields, withMultiplePages];
+		const composeList = [withMultiplePages];
 
 		if (this.isFormBuilderView()) {
 			composeList.push(withEditablePageHeader);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/main.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/main.es.js
@@ -18,7 +18,6 @@ import {FormBuilderBase} from 'dynamic-data-mapping-form-builder/js/components/F
 import withEditablePageHeader from 'dynamic-data-mapping-form-builder/js/components/FormBuilder/withEditablePageHeader.es';
 import withMoveableFields from 'dynamic-data-mapping-form-builder/js/components/FormBuilder/withMoveableFields.es';
 import withMultiplePages from 'dynamic-data-mapping-form-builder/js/components/FormBuilder/withMultiplePages.es';
-import withResizeableColumns from 'dynamic-data-mapping-form-builder/js/components/FormBuilder/withResizeableColumns.es';
 import LayoutProvider from 'dynamic-data-mapping-form-builder/js/components/LayoutProvider/LayoutProvider.es';
 import Sidebar from 'dynamic-data-mapping-form-builder/js/components/Sidebar/Sidebar.es';
 import {pageStructure} from 'dynamic-data-mapping-form-builder/js/util/config.es';
@@ -736,11 +735,7 @@ class Form extends Component {
 	}
 
 	_createFormBuilder() {
-		const composeList = [
-			withMoveableFields,
-			withMultiplePages,
-			withResizeableColumns,
-		];
+		const composeList = [withMoveableFields, withMultiplePages];
 
 		if (this.isFormBuilderView()) {
 			composeList.push(withEditablePageHeader);


### PR DESCRIPTION
# Resize
## What We already done with this:
* We removed `withResizeableColumns`  HOC for disable the legacy implementation
* We needed to replace the [getIndexes](https://github.com/liferay/liferay-portal/blob/b316fa46842332f225925ae23d8e5352dfe82493/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/util/FormSupport.es.js#L366)/[getNestedIndexes](https://github.com/liferay/liferay-portal/blob/b316fa46842332f225925ae23d8e5352dfe82493/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/util/FormSupport.es.js#L376) by a React like solution. We don't need to pollute our elements with too much data-attrs*, so, We are using the `loc` property where it's defined on the ParentFieldContext.
* We are implementing the logic inside the ResizableColumn component inside EditorVariant.Column component 
* We needed to do some refactoring for traversing `rowRef` across the EditorVariant(row and column) for calculating the current hovered column.

## What need to be done:

* There is an error when trying to resize a field with the new resize when the withMoveableFields(metal-drag-drop) HOC is enabled. For testing the implementation I needed to disable manually the withMoveableFields component to see the goal implementation in action.
* There is an error when trying to resize using the left handler. I took down deeply on the resize reducer but it doesn’t look like a difference between 7.3 and the current implementation structure.

Possible troubleshooting for these errors:

Rebasing with the current Drag and Drop(using React and disabling the old implemented one using metal-drag-drop) may solve one or all these problems.