### PR TITLE
LPS-124207 Add to Forms context parameters related to Data Engine

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/build.gradle
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/build.gradle
@@ -5,6 +5,7 @@ buildCSS {
 }
 
 dependencies {
+	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bnd.annotation", version: "4.2.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.1"
@@ -13,6 +14,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
 	compileOnly project(":apps:dynamic-data-mapping:dynamic-data-mapping-spi")
+	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":core:osgi-service-tracker-collections")
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-reflect")

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/build.gradle
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/build.gradle
@@ -14,6 +14,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
 	compileOnly project(":apps:dynamic-data-mapping:dynamic-data-mapping-spi")
+	compileOnly project(":apps:frontend-js:frontend-js-loader-modules-extender-api")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":core:osgi-service-tracker-collections")
 	compileOnly project(":core:petra:petra-lang")

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/java/com/liferay/dynamic/data/mapping/form/builder/internal/configuration/DDMFormSidebarConfiguration.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/java/com/liferay/dynamic/data/mapping/form/builder/internal/configuration/DDMFormSidebarConfiguration.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.dynamic.data.mapping.form.builder.internal.configuration;
+
+import aQute.bnd.annotation.metatype.Meta;
+
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
+
+/**
+ * @author Renato Rego
+ */
+@ExtendedObjectClassDefinition(generateUI = false)
+@Meta.OCD(
+	id = "com.liferay.dynamic.data.mapping.form.builder.internal.configuration.DDMFormSidebarConfiguration"
+)
+public interface DDMFormSidebarConfiguration {
+
+	@Meta.AD(deflt = "false", required = false)
+	public boolean isDataEngineSidebar();
+
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/java/com/liferay/dynamic/data/mapping/form/builder/internal/configuration/DDMFormSidebarConfigurationActivator.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/java/com/liferay/dynamic/data/mapping/form/builder/internal/configuration/DDMFormSidebarConfigurationActivator.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.dynamic.data.mapping.form.builder.internal.configuration;
+
+import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
+
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Modified;
+
+/**
+ * @author Renato Rego
+ */
+@Component(
+	configurationPid = "com.liferay.dynamic.data.mapping.form.builder.internal.configuration.DDMFormSidebarConfiguration",
+	immediate = true, service = DDMFormSidebarConfigurationActivator.class
+)
+public class DDMFormSidebarConfigurationActivator {
+
+	public boolean isDataEngineSidebar() {
+		return _ddmFormSidebarConfiguration.isDataEngineSidebar();
+	}
+
+	@Activate
+	@Modified
+	protected void activate(Map<String, Object> properties) {
+		_ddmFormSidebarConfiguration = ConfigurableUtil.createConfigurable(
+			DDMFormSidebarConfiguration.class, properties);
+	}
+
+	private volatile DDMFormSidebarConfiguration _ddmFormSidebarConfiguration;
+
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/java/com/liferay/dynamic/data/mapping/form/builder/internal/context/DDMFormBuilderContextFactoryImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/java/com/liferay/dynamic/data/mapping/form/builder/internal/context/DDMFormBuilderContextFactoryImpl.java
@@ -17,10 +17,12 @@ package com.liferay.dynamic.data.mapping.form.builder.internal.context;
 import com.liferay.dynamic.data.mapping.form.builder.context.DDMFormBuilderContextFactory;
 import com.liferay.dynamic.data.mapping.form.builder.context.DDMFormBuilderContextRequest;
 import com.liferay.dynamic.data.mapping.form.builder.context.DDMFormBuilderContextResponse;
+import com.liferay.dynamic.data.mapping.form.builder.internal.configuration.DDMFormSidebarConfigurationActivator;
 import com.liferay.dynamic.data.mapping.form.field.type.DDMFormFieldTypeServicesTracker;
 import com.liferay.dynamic.data.mapping.form.renderer.DDMFormTemplateContextFactory;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.model.DDMStructureVersion;
+import com.liferay.frontend.js.loader.modules.extender.npm.NPMResolver;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.util.GetterUtil;
 
@@ -53,11 +55,13 @@ public class DDMFormBuilderContextFactoryImpl
 			new DDMFormBuilderContextFactoryHelper(
 				ddmStructureOptional, ddmStructureVersionOptional,
 				_ddmFormFieldTypeServicesTracker,
+				_ddmFormSidebarConfigurationActivator,
 				_ddmFormTemplateContextFactory,
 				ddmFormBuilderContextRequest.getHttpServletRequest(),
 				ddmFormBuilderContextRequest.getHttpServletResponse(),
 				_jsonFactory, ddmFormBuilderContextRequest.getLocale(),
-				portletNamespace, ddmFormBuilderContextRequest.getReadOnly());
+				_npmResolver, portletNamespace,
+				ddmFormBuilderContextRequest.getReadOnly());
 
 		DDMFormBuilderContextResponse ddmFormBuilderContextResponse =
 			new DDMFormBuilderContextResponse();
@@ -72,9 +76,16 @@ public class DDMFormBuilderContextFactoryImpl
 	private DDMFormFieldTypeServicesTracker _ddmFormFieldTypeServicesTracker;
 
 	@Reference
+	private DDMFormSidebarConfigurationActivator
+		_ddmFormSidebarConfigurationActivator;
+
+	@Reference
 	private DDMFormTemplateContextFactory _ddmFormTemplateContextFactory;
 
 	@Reference
 	private JSONFactory _jsonFactory;
+
+	@Reference
+	private NPMResolver _npmResolver;
 
 }


### PR DESCRIPTION
@alinedoleron, this is the pull request which will add two new attributes to Forms context (`this.props.context`), please check below their purpose:

- `dataEngineSidebar` =  boolean flag to determine if Forms is using the Data Engine Sidebar or not. `true` means Data Engine Sidebar is being used. By default, the value will be `false`. The value of this flag is determined by a file named `com.liferay.dynamic.data.mapping.form.builder.internal.configuration.DDMFormSidebarConfiguration` which needs to be created before portal startup and under `[LIFERAY_HOME]/osgi/configs` with the following content:
```
isDataEngineSidebar="false"
```

**Note:** LIFERAY_HOME is the folder where the portal was deployed.

- `sidebarPanels` = provides the information related to the panels which will be used by Data Engine Sidebar. This `prop` should be processed by the method `initializeSidebarConfig`, as demonstrated [here](https://github.com/liferay/liferay-portal/blob/18e79919ade7778ac12befa6874daf792f8e1a67/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/App.es.js#L129), for example, and the output of this method should be used as parameters to the `MultiPanelSidebar`, as you can see [here](https://github.com/liferay/liferay-portal/blob/18e79919ade7778ac12befa6874daf792f8e1a67/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/App.es.js#L52) and [here](https://github.com/liferay/liferay-portal/blob/18e79919ade7778ac12befa6874daf792f8e1a67/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/App.es.js#L108-L110).

If you need any assistance regarding this pull, please talk to Carolzinha. In addition, do you mind to forward this pull once the tests finish to run?

Thanks in advance. 🙂 