### PR TITLE
LPS-123794 Rewrite form-builder DnD from `metal-drag-drop` to `react-dnd`

### DIFF
--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/form-view/CustomObjectFieldsList.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/form-view/CustomObjectFieldsList.es.js
@@ -123,8 +123,8 @@ const getFieldTypes = ({
 			disabled: DataLayoutVisitor.containsField(dataLayoutPages, name),
 			dragAlignment: 'right',
 			dragType: isFieldGroup
-				? DragTypes.DRAG_FIELDSET
-				: DragTypes.DRAG_DATA_DEFINITION_FIELD,
+				? DragTypes.DRAG_FIELDSET_MOVE
+				: DragTypes.DRAG_DATA_DEFINITION_FIELD_MOVE,
 			icon: fieldTypeSettings.icon,
 			isCustomField: !customProperties['nativeField'],
 			isFieldSet,
@@ -262,6 +262,21 @@ export default ({keywords}) => {
 	);
 	const showCategories =
 		!!customFieldTypes.length && !!nativeFieldTypes.length;
+	
+	const getDataDefinitionField = (fieldName) => {
+		const dataDefinitionField = dataDefinition.dataDefinitionFields.find(
+			(field) => field.name === fieldName
+		);
+
+		const settingsContext = dataLayoutBuilder.getDDMFormFieldSettingsContext(
+			dataDefinitionField
+		);
+
+		return {
+			...dataDefinitionField,
+			settingsContext,
+		};
+	};
 
 	const fieldTypeListProps = {
 		deleteLabel: Liferay.Language.get('delete-from-object'),
@@ -283,6 +298,7 @@ export default ({keywords}) => {
 			<FieldTypeList
 				{...fieldTypeListProps}
 				fieldTypes={customFieldTypes}
+				getDataDefinitionField={getDataDefinitionField}
 				showEmptyState={false}
 			/>
 
@@ -295,6 +311,7 @@ export default ({keywords}) => {
 			<FieldTypeList
 				{...fieldTypeListProps}
 				fieldTypes={nativeFieldTypes}
+				getDataDefinitionField={getDataDefinitionField}
 				showEmptyState={false}
 			/>
 		</>

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/table-view/DropZone.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/table-view/DropZone.es.js
@@ -46,7 +46,7 @@ const generateItems = (columns, rows = 10) => {
 
 const DropZone = ({fields, onAddFieldName, onRemoveFieldName}) => {
 	const [{canDrop, overTarget}, drop] = useDrop({
-		accept: DragTypes.DRAG_FIELD_TYPE,
+		accept: DragTypes.DRAG_FIELD_TYPE_ADD,
 		collect: (monitor) => ({
 			canDrop: monitor.canDrop(),
 			overTarget: monitor.isOver(),

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/table-view/DropZonePlaceholder.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/table-view/DropZonePlaceholder.es.js
@@ -65,7 +65,7 @@ const getStyle = (container, index, total) => {
 
 const Placeholder = ({container, index, onAddFieldName, total}) => {
 	const [{canDrop, overTarget}, drop] = useDrop({
-		accept: DragTypes.DRAG_FIELD_TYPE,
+		accept: DragTypes.DRAG_FIELD_TYPE_MOVE,
 		collect: (monitor) => ({
 			canDrop: monitor.canDrop(),
 			overTarget: monitor.isOver(),

--- a/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/table-view/TableViewSidebar.es.js
+++ b/modules/apps/app-builder/app-builder-web/src/main/resources/META-INF/resources/js/pages/table-view/TableViewSidebar.es.js
@@ -119,7 +119,7 @@ const FieldsTabContent = ({keywords, onAddFieldName}) => {
 
 	return (
 		<FieldTypeList
-			dragType={DragTypes.DRAG_FIELD_TYPE}
+			dragType={DragTypes.DRAG_FIELD_TYPE_ADD}
 			emptyState={{
 				description: Liferay.Language.get(
 					'columns-are-needed-to-create-table-views-for-this-object'

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/components/field-sets/FieldSets.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/components/field-sets/FieldSets.es.js
@@ -18,9 +18,10 @@ import React, {useContext, useState} from 'react';
 import AppContext from '../../AppContext.es';
 import {dropFieldSet} from '../../actions.es';
 import DataLayoutBuilderContext from '../../data-layout-builder/DataLayoutBuilderContext.es';
-import {DRAG_FIELDSET} from '../../drag-and-drop/dragTypes.es';
+import {DRAG_FIELDSET_ADD} from '../../drag-and-drop/dragTypes.es';
 import {containsFieldSet} from '../../utils/dataDefinition.es';
 import {getLocalizedValue} from '../../utils/lang.es';
+import {normalizeDataLayoutRows} from '../../utils/normalizers.es';
 import EmptyState from '../empty-state/EmptyState.es';
 import FieldType from '../field-types/FieldType.es';
 import {getPluralMessage} from './../../utils/lang.es';
@@ -133,6 +134,12 @@ export default function FieldSets({keywords}) {
 	const deleteFieldSet = useDeleteFieldSet({dataLayoutBuilder});
 	const propagateFieldSet = usePropagateFieldSet();
 
+	const getFieldSet = (fieldSet) => {
+		return dataLayoutBuilder.getFieldSetDDMForm(fieldSet, {
+			availableLanguageIds: dataDefinition.availableLanguageIds,
+		});
+	};
+
 	const onDoubleClick = ({fieldSet: {name: fieldName}, fieldSet}) => {
 		const {activePage, pages} = dataLayoutBuilder.getStore();
 
@@ -219,12 +226,16 @@ export default function FieldSets({keywords}) {
 											fieldSet.id
 										)
 									}
-									dragType={DRAG_FIELDSET}
-									fieldSet={fieldSet}
+									dragType={DRAG_FIELDSET_ADD}
+									fieldSet={getFieldSet(fieldSet)}
 									icon="forms"
 									key={fieldSet.dataDefinitionKey}
 									label={fieldSetName}
 									onDoubleClick={onDoubleClick}
+									rows={
+										fieldSet.id &&
+										normalizeDataLayoutRows(dataLayoutPages)
+									}
 								/>
 							);
 						})}

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/components/field-types/FieldType.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/components/field-types/FieldType.es.js
@@ -22,7 +22,7 @@ import React, {useEffect, useState} from 'react';
 import {useDrag} from 'react-dnd';
 import {getEmptyImage} from 'react-dnd-html5-backend';
 
-import {DRAG_FIELD_TYPE} from '../../drag-and-drop/dragTypes.es';
+import {DRAG_FIELD_TYPE_ADD} from '../../drag-and-drop/dragTypes.es';
 import Button from '../button/Button.es';
 import DropDown from '../drop-down/DropDown.es';
 import FieldTypeDragPreview from './FieldTypeDragPreview.es';
@@ -45,7 +45,7 @@ export default (props) => {
 		disabled,
 		dragAlignment = 'left',
 		draggable = true,
-		dragType = DRAG_FIELD_TYPE,
+		dragType = DRAG_FIELD_TYPE_ADD,
 		icon,
 		label,
 		name,

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/components/field-types/FieldTypeList.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/components/field-types/FieldTypeList.es.js
@@ -35,6 +35,7 @@ export default ({
 	deleteLabel,
 	emptyState,
 	fieldTypes,
+	getDataDefinitionField,
 	keywords,
 	onClick,
 	onDelete,
@@ -77,6 +78,7 @@ export default ({
 						...fieldType,
 						className: `${fieldType.className} field-type-header`,
 					}}
+					getDataDefinitionField={getDataDefinitionField}
 					onClick={(props) => {
 						setExpanded(!expanded);
 
@@ -107,6 +109,7 @@ export default ({
 											...nestedFieldType,
 											disabled: fieldType.disabled,
 										}}
+										getDataDefinitionField={getDataDefinitionField}
 										key={`${nestedFieldType.name}_${index}`}
 									/>
 								)
@@ -121,6 +124,7 @@ export default ({
 			<FieldTypeWrapper
 				deleteLabel={deleteLabel}
 				fieldType={fieldType}
+				getDataDefinitionField={getDataDefinitionField}
 				key={index}
 				onClick={handleOnClick}
 				onDelete={onDelete}

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/components/rule-builder/FormsRuleBuilder.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/components/rule-builder/FormsRuleBuilder.es.js
@@ -15,10 +15,8 @@
 import {useResource} from '@clayui/data-provider';
 import {ClayIconSpriteContext} from '@clayui/icon';
 import ClayLayout from '@clayui/layout';
-import {
-	PagesVisitor,
-	getConnectedReactComponentAdapter,
-} from 'dynamic-data-mapping-form-renderer';
+import {getConnectedReactComponentAdapter} from 'dynamic-data-mapping-form-renderer/js/util/ReactComponentAdapter.es';
+import {PagesVisitor} from 'dynamic-data-mapping-form-renderer/js/util/visitors.es';
 import {fetch} from 'frontend-js-web';
 import React, {useImperativeHandle, useMemo, useState} from 'react';
 

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/components/sidebar/MultiPanelSidebarFormsProxy.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/components/sidebar/MultiPanelSidebarFormsProxy.es.js
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {ClayIconSpriteContext} from '@clayui/icon';
+import {getConnectedReactComponentAdapter} from 'dynamic-data-mapping-form-renderer/js/util/ReactComponentAdapter.es';
+import React, {useState} from 'react';
+import {DndProvider} from 'react-dnd';
+import {HTML5Backend} from 'react-dnd-html5-backend';
+
+import DragLayer from '../../drag-and-drop/DragLayer.es';
+import MultiPanelSidebar from './MultiPanelSidebar.es';
+
+const FormsMultiPanelMock = {
+	panels: [['fields']],
+	sidebarPanels: {
+		fields: {
+			icon: 'forms',
+			isLink: false,
+			label: 'Builder',
+			pluginEntryPoint:
+				'data-engine-taglib@3.0.0/data_layout_builder/js/plugins/forms-field-sidebar/index.es',
+			sidebarPanelId: 'fields',
+		},
+	},
+	sidebarVariant: 'light',
+};
+
+const MultiPanelSidebarFormsProxy = React.forwardRef(
+	({
+		activePage,
+		dataProviderInstanceParameterSettingsURL,
+		dataProviderInstancesURL,
+		defaultLanguageId,
+		editingLanguageId,
+		fieldTypes,
+		focusedField,
+		functionsMetadata,
+		functionsURL,
+		instance,
+		onChange,
+		pages,
+		rules,
+		spritemap,
+	}) => {
+		const [{currentPanelId, open}, setStatus] = useState({
+			currentPanelId: 'fields',
+			open: true,
+		});
+
+		return (
+			<DndProvider backend={HTML5Backend} context={window}>
+				<ClayIconSpriteContext.Provider value={spritemap}>
+					<FormsSidebarPluginContext.Provider
+						value={{
+							activePage,
+							dataProviderInstanceParameterSettingsURL,
+							dataProviderInstancesURL,
+							defaultLanguageId,
+							dispatch: (type, payload) => {
+								instance.context.dispatch(type, payload);
+							},
+							editingLanguageId,
+							fieldTypes,
+							focusedCustomObjectField: {},
+							focusedField,
+							functionsMetadata,
+							functionsURL,
+							pages,
+							rules,
+						}}
+					>
+						<DragLayer></DragLayer>
+						<MultiPanelSidebar
+							createPlugin={({
+								panel,
+								sidebarOpen,
+								sidebarPanelId,
+							}) => ({
+								panel,
+								sidebarOpen,
+								sidebarPanelId,
+							})}
+							currentPanelId={currentPanelId}
+							onChange={({sidebarOpen, sidebarPanelId}) => {
+								onChange(sidebarOpen);
+								setStatus({
+									currentPanelId: sidebarPanelId,
+									open: sidebarOpen,
+								});
+							}}
+							open={open}
+							panels={FormsMultiPanelMock.panels}
+							sidebarPanels={FormsMultiPanelMock.sidebarPanels}
+							variant={FormsMultiPanelMock.sidebarVariant}
+						/>
+					</FormsSidebarPluginContext.Provider>
+				</ClayIconSpriteContext.Provider>
+			</DndProvider>
+		);
+	}
+);
+
+export const FormsSidebarPluginContext = React.createContext({});
+
+MultiPanelSidebarFormsProxy.displayName = 'MultiPanelSidebarFormsProxy';
+
+export const ReactMultiPanelSidebarAdapter = getConnectedReactComponentAdapter(
+	MultiPanelSidebarFormsProxy
+);

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/data-layout-builder/DataLayoutBuilder.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/data-layout-builder/DataLayoutBuilder.es.js
@@ -20,11 +20,6 @@ import FormBuilderWithLayoutProvider, {
 import {PagesVisitor} from 'dynamic-data-mapping-form-renderer';
 import React from 'react';
 
-import {
-	DRAG_DATA_DEFINITION_FIELD,
-	DRAG_FIELDSET,
-	DRAG_FIELD_TYPE,
-} from '../drag-and-drop/dragTypes.es';
 import {getDataDefinitionField} from '../utils/dataDefinition.es';
 import generateDataDefinitionFieldName from '../utils/generateDataDefinitionFieldName.es';
 import {
@@ -68,13 +63,6 @@ class DataLayoutBuilder extends React.Component {
 				},
 				formBuilderProps: {
 					allowNestedFields: config.allowNestedFields,
-					dnd: {
-						accept: [
-							DRAG_DATA_DEFINITION_FIELD,
-							DRAG_FIELDSET,
-							DRAG_FIELD_TYPE,
-						],
-					},
 					fieldTypes,
 					portletNamespace,
 					ref: 'builder',

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/drag-and-drop/getDropHandler.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/drag-and-drop/getDropHandler.es.js
@@ -17,11 +17,7 @@ import {
 	dropFieldSet,
 	dropLayoutBuilderField,
 } from '../actions.es';
-import {
-	DRAG_DATA_DEFINITION_FIELD,
-	DRAG_FIELDSET,
-	DRAG_FIELD_TYPE,
-} from './dragTypes.es';
+import {DRAG_FIELDSET_ADD} from './dragTypes.es';
 
 export const getDropHandler = ({dataDefinition, dataLayoutBuilder}) => {
 	return ({item, monitor, sourceItem}) => {
@@ -45,6 +41,19 @@ export const getDropHandler = ({dataDefinition, dataLayoutBuilder}) => {
 						)
 					);
 				}
+
+			// case DRAG_FIELD_TYPE: {
+			// 	if (
+			// 		parentField &&
+			// 		parentField.nestedFields &&
+			// 		parentField.type !== 'fieldset'
+			// 	) {
+			// 		throw new Error(
+			// 			Liferay.Language.get(
+			// 				'you-cannot-drop-new-fields-to-a-deprecated-field-group'
+			// 			)
+			// 		);
+			// 	}
 
 				const payload = dropLayoutBuilderField({
 					dataLayoutBuilder,
@@ -77,6 +86,14 @@ export const getDropHandler = ({dataDefinition, dataLayoutBuilder}) => {
 				break;
 			}
 			case DRAG_FIELDSET:
+			// 	dataLayoutBuilder.dispatch(
+			// 		origin === 'empty' ? 'fieldAdded' : 'sectionAdded',
+			// 		payload
+			// 	);
+			// 	break;
+			// }
+
+			case DRAG_FIELDSET_ADD:
 				dataLayoutBuilder.dispatch(
 					'fieldSetAdded',
 					dropFieldSet({

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/FormBuilder/FormBuilder.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/FormBuilder/FormBuilder.es.js
@@ -23,7 +23,6 @@ import {Config} from 'metal-state';
 
 import {pageStructure} from '../../util/config.es';
 import withEditablePageHeader from './withEditablePageHeader.es';
-import withMoveableFields from './withMoveableFields.es';
 import withMultiplePages from './withMultiplePages.es';
 import withResizeableColumns from './withResizeableColumns.es';
 
@@ -219,7 +218,6 @@ FormBuilderBase.PROPS = {
 
 export default compose(
 	withEditablePageHeader,
-	withMoveableFields,
 	withMultiplePages,
 	withResizeableColumns
 )(FormBuilderBase);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/FormBuilder/FormBuilderWithLayoutProvider.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/FormBuilder/FormBuilderWithLayoutProvider.es.js
@@ -19,7 +19,6 @@ import {Config} from 'metal-state';
 import LayoutProvider from '../LayoutProvider/LayoutProvider.es';
 import {FormBuilderBase} from './FormBuilder.es';
 import withEditablePageHeader from './withEditablePageHeader.es';
-import withMoveableFields from './withMoveableFields.es';
 import withMultiplePages from './withMultiplePages.es';
 import withResizeableColumns from './withResizeableColumns.es';
 
@@ -35,7 +34,7 @@ class FormBuilderWithLayoutProvider extends Component {
 
 		const LProvider = LayoutProvider;
 
-		const composeList = [withMoveableFields, withResizeableColumns];
+		const composeList = [withResizeableColumns];
 
 		if (layoutProviderProps.allowMultiplePages) {
 			composeList.push(withMultiplePages);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/LayoutProvider/LayoutProvider.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/LayoutProvider/LayoutProvider.es.js
@@ -20,7 +20,7 @@ import {
 	generateName,
 	getRepeatedIndex,
 } from 'dynamic-data-mapping-form-renderer';
-import {openModal, openToast} from 'frontend-js-web';
+import {openModal} from 'frontend-js-web';
 import Component from 'metal-jsx';
 import {Config} from 'metal-state';
 
@@ -72,10 +72,7 @@ class LayoutProvider extends Component {
 			this.emit(event, payload);
 		}
 		catch (e) {
-			openToast({
-				message: e.message,
-				type: 'danger',
-			});
+			console.error(e.message);
 		}
 	}
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/LayoutProvider/handlers/fieldSetAddedHandler.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/LayoutProvider/handlers/fieldSetAddedHandler.es.js
@@ -39,7 +39,10 @@ const handleFieldSetAdded = (props, state, event) => {
 
 	let fieldSetField = createFieldSet(
 		props,
-		{skipFieldNameGeneration: false, useFieldName},
+		{
+			skipFieldNameGeneration: false,
+			useFieldName: useFieldName[props.defaultLanguageId],
+		},
 		nestedFields
 	);
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldSet/FieldSet.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldSet/FieldSet.es.js
@@ -73,8 +73,8 @@ const FieldSet = ({
 	const {page} = usePage();
 	const repeatedIndex = useMemo(() => getRepeatedIndex(name), [name]);
 
-	const findFieldInsidePage = (fields) =>
-		fields?.find((field) => {
+	const findFieldInsidePage = (fields = []) =>
+		fields.find((field) => {
 			if (!belongsToFieldSet) {
 				belongsToFieldSet = !!field.ddmStructureId;
 			}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/.npmbundlerrc
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/.npmbundlerrc
@@ -1,6 +1,9 @@
 {
 	"config": {
 		"imports": {
+			"data-engine-taglib": {
+				"/": ">=2.0.0"
+			},
 			"dynamic-data-mapping-form-field-type": {
 				"/": ">=5.0.0"
 			}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/actions/eventTypes.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/actions/eventTypes.es.js
@@ -24,6 +24,7 @@ const PUBLIC_EVENTS = {
 	FIELD_EVALUATION_ERROR: 'evaluationError',
 	FIELD_FOCUS: 'fieldFocused',
 	FIELD_HOVERED: 'fieldHovered',
+	FIELD_MOVED: 'fieldMoved',
 	FIELD_REMOVED: 'fieldRemoved',
 	FIELD_REPEATED: 'fieldRepeated',
 	PAGE_ADDED: 'pageAdded',

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/components/PageRenderer/DefaultVariant.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/components/PageRenderer/DefaultVariant.es.js
@@ -102,7 +102,6 @@ export const Column = forwardRef(
 Column.displayName = 'DefaultVariant.Column';
 
 export const Page = ({
-	activePage,
 	children,
 	forceAriaUpdate,
 	header: Header,

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/hooks/useDrag.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/hooks/useDrag.es.js
@@ -12,10 +12,18 @@
  * details.
  */
 
-export const DRAG_DATA_DEFINITION_FIELD_MOVE = 'dataDefinitionField:move';
-export const DRAG_FIELD_TYPE_MOVE = 'fieldType:move';
-export const DRAG_FIELDSET_MOVE = 'fieldset:move';
+import {useDrag as useDndDrag} from 'react-dnd';
 
-export const DRAG_DATA_DEFINITION_FIELD_ADD = 'dataDefinitionField:add';
-export const DRAG_FIELD_TYPE_ADD = 'fieldType:add';
-export const DRAG_FIELDSET_ADD = 'fieldset:add';
+export const useDrag = ({item, pageIndex, type}) => {
+	const [, drag] = useDndDrag({
+		item: {
+			data: item,
+			pageIndex,
+			type,
+		},
+	});
+
+	return {
+		drag,
+	};
+};

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/hooks/useDrop.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/hooks/useDrop.es.js
@@ -12,38 +12,210 @@
  * details.
  */
 
+import {DragTypes} from 'data-engine-taglib';
 import {useDrop as useDndDrop} from 'react-dnd';
 
 import {EVENT_TYPES} from '../actions/eventTypes.es';
 import {useForm} from '../hooks/useForm.es';
 import {usePage} from './usePage.es';
 
-const defaultSpec = {
-	accept: [],
-};
-
 export const DND_ORIGIN_TYPE = {
 	EMPTY: 'empty',
 	FIELD: 'field',
 };
 
-export const useDrop = (sourceItem) => {
-	const {dnd} = usePage();
+export const useDrop = ({
+	columnIndex,
+	fieldName,
+	origin,
+	pageIndex,
+	parentField,
+	rowIndex,
+}) => {
+	const {fieldTypesMetadata} = usePage();
 	const dispatch = useForm();
 
-	const spec = dnd ?? defaultSpec;
-
 	const [{canDrop, overTarget}, drop] = useDndDrop({
-		...spec,
+		accept: [
+			DragTypes.DRAG_FIELD_TYPE_ADD,
+			DragTypes.DRAG_DATA_DEFINITION_FIELD_MOVE,
+			DragTypes.DRAG_FIELD_TYPE_MOVE,
+			DragTypes.DRAG_FIELDSET_MOVE,
+			DragTypes.DRAG_DATA_DEFINITION_FIELD_ADD,
+			DragTypes.DRAG_FIELD_TYPE_ADD,
+			DragTypes.DRAG_FIELDSET_ADD,
+		],
 		collect: (monitor) => ({
 			canDrop: monitor.canDrop(),
-			overTarget: monitor.isOver(),
+			overTarget: monitor.isOver({shallow: true}),
 		}),
-		drop: (item, monitor) =>
-			dispatch({
-				payload: {item, monitor, sourceItem},
-				type: EVENT_TYPES.FIELD_DROP,
-			}),
+		drop: (item, monitor) => {
+			if (monitor.didDrop()) {
+				return;
+			}
+
+			// const dataDefinitionField = item.data.getDataDefinitionField(
+			// 	item.data.name
+			// );
+
+			// const {label} = dataDefinitionField;
+
+			switch (item.type) {
+				case DragTypes.DRAG_FIELD_TYPE_ADD:
+					dispatch({
+						payload: {
+							data: {
+								fieldName,
+								parentFieldName: parentField?.fieldName,
+							},
+							fieldType: {
+								...fieldTypesMetadata.find(({name}) => {
+									return name === item.data.name;
+								}),
+								editable: true,
+							},
+							indexes: {columnIndex, pageIndex, rowIndex},
+						},
+						type:
+							origin === DND_ORIGIN_TYPE.EMPTY
+								? EVENT_TYPES.FIELD_ADD
+								: EVENT_TYPES.SECTION_ADD,
+					});
+					break;
+
+				case DragTypes.DRAG_FIELD_TYPE_MOVE:
+					dispatch({
+						payload: {
+							sourceFieldName: item.data.fieldName,
+							sourceFieldPage: item.pageIndex,
+							targetFieldName: fieldName,
+							targetIndexes: {
+								columnIndex,
+								pageIndex,
+								rowIndex,
+							},
+							targetParentFieldName: parentField.fieldName,
+						},
+						type: EVENT_TYPES.FIELD_MOVED,
+					});
+					break;
+				case DragTypes.DRAG_FIELDSET_ADD:
+					dispatch({
+						payload: {
+							availableLanguageIds:
+								item.data.fieldSet.availableLanguageIds,
+							defaultLanguageId:
+								item.data.fieldSet.defaultLanguageId,
+							fieldName,
+							fieldSet: item.data.fieldSet,
+							indexes: {columnIndex, pageIndex, rowIndex},
+							parentFieldName: parentField?.fieldName,
+							properties: item.data.properties,
+							rows: item.data.rows,
+							useFieldName: item.data.useFieldName,
+						},
+						type: EVENT_TYPES.FIELD_SET_ADD,
+					});
+					break;
+				case DragTypes.DRAG_FIELDSET_MOVE:
+					dispatch({
+						payload: {
+							sourceFieldName: item.data.fieldName,
+							sourceFieldPage: item.pageIndex,
+							targetFieldName: fieldName,
+							targetIndexes: {
+								columnIndex,
+								pageIndex,
+								rowIndex,
+							},
+							targetParentFieldName: parentField.fieldName,
+						},
+						type: EVENT_TYPES.FIELD_SET_ADD,
+					});
+					break;
+
+				// case DragTypes.DRAG_DATA_DEFINITION_FIELD_ADD:
+				// 	dispatch({
+				// 		payload: {
+				// 			data: {
+				// 				fieldName,
+				// 				parentFieldName: parentField?.fieldName,
+				// 			},
+				// 			fieldType: {
+				// 				...fieldTypesMetadata.find(({name}) => {
+				// 					return (
+				// 						name === dataDefinitionField.fieldType
+				// 					);
+				// 				}),
+				// 				editable: true,
+				// 				label:
+				// 					label[item.data.editingLanguageId] ||
+				// 					label[themeDisplay.getLanguageId()],
+				// 				settingsContext:
+				// 					dataDefinitionField.settingsContext,
+				// 			},
+				// 			indexes: {columnIndex, pageIndex, rowIndex},
+				// 			skipFieldNameGeneration: true,
+				// 		},
+				// 		type:
+				// 			origin === DND_ORIGIN_TYPE.EMPTY
+				// 				? EVENT_TYPES.FIELD_ADD
+				// 				: EVENT_TYPES.SECTION_ADD,
+				// 	});
+				// 	break;
+
+				// case DragTypes.DRAG_DATA_DEFINITION_FIELD_MOVE:
+				// 	dispatch({
+				// 		payload: {
+				// 			data: {
+				// 				fieldName,
+				// 				parentFieldName: parentField?.fieldName,
+				// 			},
+				// 			fieldType: {
+				// 				...fieldTypesMetadata.find(({name}) => {
+				// 					return (
+				// 						name === dataDefinitionField.fieldType
+				// 					);
+				// 				}),
+				// 				editable: true,
+				// 				label:
+				// 					label[item.data.editingLanguageId] ||
+				// 					label[themeDisplay.getLanguageId()],
+				// 				settingsContext:
+				// 					dataDefinitionField.settingsContext,
+				// 			},
+				// 			indexes: {columnIndex, pageIndex, rowIndex},
+				// 			skipFieldNameGeneration: true,
+				// 		},
+				// 		type:
+				// 			origin === DND_ORIGIN_TYPE.EMPTY
+				// 				? EVENT_TYPES.FIELD_ADD
+				// 				: EVENT_TYPES.SECTION_ADD,
+				// 	});
+				// 	break;
+
+				default:
+					break;
+			}
+
+			// dispatch({
+			// 	payload: {
+			// 		data: {
+			// 			fieldName,
+			// 			parentFieldName: parentField?.fieldName ,
+			// 		},
+			// 		fieldType: {
+			// 			...fieldTypesMetadata.find(({name}) => {
+			// 				return name === item.data.name;
+			// 			}),
+			// 			editable: true,
+			// 		},
+			// 		indexes: {columnIndex, pageIndex, rowIndex},
+			// 	},
+			// 	type: origin === DND_ORIGIN_TYPE.EMPTY ? EVENT_TYPES.FIELD_ADD : EVENT_TYPES.SECTION_ADD,
+			// });
+
+		},
 	});
 
 	return {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/util/fields.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/util/fields.es.js
@@ -51,4 +51,4 @@ export function normalizeFieldName(fieldName) {
 }
 
 export const hasFieldSet = (field) =>
-	field && field.type === 'fieldset' && field.ddmStructureId;
+	!!(field && field.type === 'fieldset' && field.ddmStructureId);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/main.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/main.es.js
@@ -16,7 +16,6 @@ import ClayModal from 'clay-modal';
 import {FormsRuleBuilder} from 'data-engine-taglib';
 import {FormBuilderBase} from 'dynamic-data-mapping-form-builder/js/components/FormBuilder/FormBuilder.es';
 import withEditablePageHeader from 'dynamic-data-mapping-form-builder/js/components/FormBuilder/withEditablePageHeader.es';
-import withMoveableFields from 'dynamic-data-mapping-form-builder/js/components/FormBuilder/withMoveableFields.es';
 import withMultiplePages from 'dynamic-data-mapping-form-builder/js/components/FormBuilder/withMultiplePages.es';
 import withResizeableColumns from 'dynamic-data-mapping-form-builder/js/components/FormBuilder/withResizeableColumns.es';
 import LayoutProvider from 'dynamic-data-mapping-form-builder/js/components/LayoutProvider/LayoutProvider.es';
@@ -454,7 +453,9 @@ class Form extends Component {
 	}
 
 	openSidebar() {
-		this.refs.sidebar.open();
+		if (!this.props.newReactForm) {
+			this.refs.sidebar.open();
+		}
 	}
 
 	preventCopyAndPaste(event, limit) {
@@ -554,20 +555,39 @@ class Form extends Component {
 							!this.isShowRuleBuilder() && !this.isShowReport()
 						}
 					/>
-
-					<Sidebar
-						defaultLanguageId={defaultLanguageId}
-						editingLanguageId={editingLanguageId}
-						fieldSetDefinitionURL={fieldSetDefinitionURL}
-						fieldSets={fieldSets}
-						fieldTypes={fieldTypes}
-						portletNamespace={namespace}
-						ref="sidebar"
-						spritemap={spritemap}
-						visible={
-							!this.isShowRuleBuilder() && !this.isShowReport()
-						}
-					/>
+					{newReactForm ? (
+						<ReactMultiPanelSidebarAdapter
+							dataProviderInstanceParameterSettingsURL={
+								dataProviderInstanceParameterSettingsURL
+							}
+							dataProviderInstancesURL={dataProviderInstancesURL}
+							defaultLanguageId={defaultLanguageId}
+							editingLanguageId={editingLanguageId}
+							fieldTypes={fieldTypes}
+							functionsMetadata={functionsMetadata}
+							functionsURL={functionsURL}
+							onChange={(sidebarOpen) =>
+								this.setState({sidebarOpen})
+							}
+							pages={pages}
+							rules={rules}
+						/>
+					) : (
+						<Sidebar
+							defaultLanguageId={defaultLanguageId}
+							editingLanguageId={editingLanguageId}
+							fieldSetDefinitionURL={fieldSetDefinitionURL}
+							fieldSets={fieldSets}
+							fieldTypes={fieldTypes}
+							portletNamespace={namespace}
+							ref="sidebar"
+							spritemap={spritemap}
+							visible={
+								!this.isShowRuleBuilder() &&
+								!this.isShowReport()
+							}
+						/>
+					)}
 				</LayoutProviderTag>
 
 				<div class="container container-fluid-1280">
@@ -721,11 +741,7 @@ class Form extends Component {
 	}
 
 	_createFormBuilder() {
-		const composeList = [
-			withMoveableFields,
-			withMultiplePages,
-			withResizeableColumns,
-		];
+		const composeList = [withMultiplePages, withResizeableColumns];
 
 		if (this.isFormBuilderView()) {
 			composeList.push(withEditablePageHeader);


### PR DESCRIPTION
# Drag and Drop:
/Current state of the WIP, 1st February 2021./

Before starting reading this, you need to be familiar with react-dnd[ `useDrag` ](https://react-dnd.github.io/react-dnd/docs/api/use-drag) and [ `useDrop`](https://react-dnd.github.io/react-dnd/docs/api/use-drop) hooks.

## What We already implemented:

Created a generic useDrop/useDrag hook for dispatching different actions depending of the type of the Drag.

You may notice We can have two types of Drag:

* You can drag between fields(useDrag from EditorVariant.Column and Pages)

* You can drag between a sidebar and a builder(useDrag defined on Sidebar components)

This knowledge is necessary for deciding which drag action I need to call. The main idea is to call the action ended with `MOVE` when dropping something initialized with values from the drag between fields and `ADD` when dropping something initialized with values from drag from the sidebar.

Also, We can have three different types of a drag item:

* `fieldType`:
When the item to be dragged is a field/sidebar field

* `dataDefinitionField`:
When the item to be dragged came from App Builder CustomObjectList sidebar(?) /cc @aline @matu

* `fieldset`:
When the item to be dragged came from a fieldset.

*Currently, there are 7 types of Drag, combining the already defined types of field/action:*

`DragTypes.DRAG_FIELD_TYPE_ADD`:
 `DragTypes.DRAG_DATA_DEFINITION_FIELD_MOVE`:

`DragTypes.DRAG_FIELD_TYPE_MOVE`: 

`DragTypes.DRAG_FIELDSET_MOVE`:

`DragTypes.DRAG_DATA_DEFINITION_FIELD_ADD`:

`DragTypes.DRAG_FIELD_TYPE_ADD`:

`DragTypes.DRAG_FIELDSET_ADD`:

## What need to be done:

* Sync with Sidebar migration PR initially sent by Aline for preventing type, origin and structure changes on useDrop/dnd actions. Since this part still In Progress there is some known bugs:

* We can’t move/drop fieldsets to the builder area(Can be reproduced on App Builder)
* We can’t move/drop FieldTypes from App Builder’s sidebar(Can be reproduced on App Builder)
* There isn’t a way to treat dataDefinitionField yet.
