### PR TITLE
LPS-121896 Migrate management toolbar v2 usages in polls-web

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ManagementToolbarTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ManagementToolbarTag.java
@@ -768,7 +768,13 @@ public class ManagementToolbarTag extends BaseContainerTag {
 		if (!active && (getFilterDropdownItems() != null)) {
 			jspWriter.write("<li class=\"nav-item\"><div class=\"dropdown\">");
 			jspWriter.write("<button class=\"btn btn-unstyled dropdown-toggle");
-			jspWriter.write(" nav-link\" type=\"button\"><span class=\"");
+			jspWriter.write(" nav-link\"");
+
+			if (disabled) {
+				jspWriter.write(" disabled");
+			}
+
+			jspWriter.write(" type=\"button\"><span class=\"");
 			jspWriter.write("navbar-breakpoint-down-d-none\"><span class=\"");
 			jspWriter.write("navbar-text-truncate\">");
 			jspWriter.write(

--- a/modules/apps/polls/polls-web/package.json
+++ b/modules/apps/polls/polls-web/package.json
@@ -1,0 +1,13 @@
+{
+	"dependencies": {
+		"frontend-js-web": "*"
+	},
+	"name": "polls-web",
+	"private": true,
+	"scripts": {
+		"build": "liferay-npm-scripts build",
+		"checkFormat": "liferay-npm-scripts check",
+		"format": "liferay-npm-scripts fix"
+	},
+	"version": "6.0.0"
+}

--- a/modules/apps/polls/polls-web/src/main/resources/META-INF/resources/polls/init.jsp
+++ b/modules/apps/polls/polls-web/src/main/resources/META-INF/resources/polls/init.jsp
@@ -17,8 +17,8 @@
 <%@ include file="/init.jsp" %>
 
 <%@ page import="com.liferay.portal.kernel.dao.search.EmptyOnClickRowChecker" %><%@
-page import="com.liferay.portal.kernel.language.UnicodeLanguageUtil" %><%@
-page import="com.liferay.portal.kernel.model.ModelHintsUtil" %>
+page import="com.liferay.portal.kernel.model.ModelHintsUtil" %><%@
+page import="com.liferay.portal.kernel.util.HashMapBuilder" %>
 
 <%
 PollsDisplayContext pollsDisplayContext = (PollsDisplayContext)request.getAttribute(WebKeys.PORTLET_DISPLAY_CONTEXT);

--- a/modules/apps/polls/polls-web/src/main/resources/META-INF/resources/polls/js/PollsManagementToolbarPropsTransformer.js
+++ b/modules/apps/polls/polls-web/src/main/resources/META-INF/resources/polls/js/PollsManagementToolbarPropsTransformer.js
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {postForm} from 'frontend-js-web';
+
+export default function propsTransformer({
+	additionalProps: {deleteQuestionURL},
+	portletNamespace,
+	...props
+}) {
+	return {
+		...props,
+		onActionButtonClick(event, {item}) {
+			if (item.data?.action === 'deleteQuestions') {
+				if (
+					confirm(
+						Liferay.Language.get(
+							'are-you-sure-you-want-to-delete-this'
+						)
+					)
+				) {
+					const form = document.getElementById(
+						`${portletNamespace}fm`
+					);
+
+					const searchContainer = document.getElementById(
+						`${portletNamespace}poll`
+					);
+
+					if (form && searchContainer) {
+						postForm(form, {
+							data: {
+								deleteQuestionIds: Liferay.Util.listCheckedExcept(
+									searchContainer,
+									`${portletNamespace}allRowIds`
+								),
+							},
+							url: deleteQuestionURL,
+						});
+					}
+				}
+			}
+		},
+	};
+}

--- a/modules/apps/polls/polls-web/src/main/resources/META-INF/resources/polls/management_bar.jsp
+++ b/modules/apps/polls/polls-web/src/main/resources/META-INF/resources/polls/management_bar.jsp
@@ -16,66 +16,27 @@
 
 <%@ include file="/polls/init.jsp" %>
 
-<clay:management-toolbar-v2
+<portlet:actionURL name="/polls/delete_question" var="deleteQuestionURL">
+	<portlet:param name="mvcPath" value="/view.jsp" />
+	<portlet:param name="redirect" value="<%= currentURL %>" />
+</portlet:actionURL>
+
+<clay:management-toolbar
 	actionDropdownItems="<%= pollsDisplayContext.getActionItemsDropdownItems() %>"
+	additionalProps='<%=
+		HashMapBuilder.<String, Object>put(
+			"deleteQuestionURL", deleteQuestionURL.toString()
+		).build()
+	%>'
 	clearResultsURL="<%= pollsDisplayContext.getClearResultsURL() %>"
-	componentId="pollsManagementToolbar"
 	creationMenu="<%= pollsDisplayContext.getCreationMenu() %>"
 	disabled="<%= pollsDisplayContext.isDisabledManagementBar() %>"
 	filterDropdownItems="<%= pollsDisplayContext.getFilterItemsDropdownItems() %>"
 	itemsTotal="<%= pollsDisplayContext.getTotalItems() %>"
-	namespace="<%= liferayPortletResponse.getNamespace() %>"
+	propsTransformer="polls/js/PollsManagementToolbarPropsTransformer"
 	searchActionURL="<%= pollsDisplayContext.getSearchActionURL() %>"
 	searchContainerId="<%= pollsDisplayContext.getSearchContainerId() %>"
 	searchFormName="fm1"
 	sortingOrder="<%= pollsDisplayContext.getOrderByType() %>"
 	sortingURL="<%= pollsDisplayContext.getSortingURL() %>"
 />
-
-<aui:script>
-	var deleteQuestions = function () {
-		if (
-			confirm(
-				'<%= UnicodeLanguageUtil.get(request, "are-you-sure-you-want-to-delete-this") %>'
-			)
-		) {
-			var searchContainer = document.getElementById(
-				'<portlet:namespace />poll'
-			);
-
-			if (searchContainer) {
-				Liferay.Util.postForm(document.<portlet:namespace />fm, {
-					data: {
-						deleteQuestionIds: Liferay.Util.listCheckedExcept(
-							searchContainer,
-							'<portlet:namespace />allRowIds'
-						),
-					},
-
-					<portlet:actionURL name="/polls/delete_question" var="deleteQuestionURL">
-						<portlet:param name="mvcPath" value="/view.jsp" />
-						<portlet:param name="redirect" value="<%= currentURL %>" />
-					</portlet:actionURL>
-
-					url: '<%= deleteQuestionURL %>',
-				});
-			}
-		}
-	};
-
-	var ACTIONS = {
-		deleteQuestions: deleteQuestions,
-	};
-
-	Liferay.componentReady('pollsManagementToolbar').then(function (
-		managementToolbar
-	) {
-		managementToolbar.on(['actionItemClicked'], function (event) {
-			var itemData = event.data.item.data;
-
-			if (itemData && itemData.action && ACTIONS[itemData.action]) {
-				ACTIONS[itemData.action]();
-			}
-		});
-	});
-</aui:script>


### PR DESCRIPTION
@liferay-forms In this PR, we are replacing management toolbar based on Clay v2 (Soy) with management toolbar based on Clay v3 (React). See details in https://issues.liferay.com/browse/LPS-121896

In addition, I added a tiny fix to management toolbar tag, fixing SSR when toolbar is disabled.

To test:
1. Open Content & Data > Polls.
2. Make sure management toolbar retains all existing features. See gif.

![after](https://user-images.githubusercontent.com/5435511/107953845-fa9ae000-6f9b-11eb-92d6-7f9f653a32b6.gif)

@julien @jonmak08 @ambrinchaudhary
