### PR TITLE
LPS-128167 Exposes the unstable_onEventRef API in the form instance

### DIFF
--- a/modules/apps/commerce/commerce-frontend-js/src/main/resources/META-INF/resources/utilities/forms/DDMFormHandler.js
+++ b/modules/apps/commerce/commerce-frontend-js/src/main/resources/META-INF/resources/utilities/forms/DDMFormHandler.js
@@ -28,9 +28,11 @@ class DDMFormHandler {
 	}
 
 	_attachFormListener() {
-		this.DDMFormInstance.on('fieldEdited', (field) => {
-			this.fields = updateFields(this.fields, field);
-			this.checkCPInstance();
+		this.DDMFormInstance.unstable_onEvent(({payload, type}) => {
+			if (type === 'fieldEdited') {
+				this.fields = updateFields(this.fields, payload);
+				this.checkCPInstance();
+			}
 		});
 	}
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/containers/Form.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/containers/Form.es.js
@@ -258,6 +258,8 @@ const FormEditor = React.forwardRef(
 
 		const defaultRef = useRef(null);
 
+		const unstable_onEventRef = useRef(null);
+
 		const reactComponentRef = ref ?? defaultRef;
 
 		useEffect(() => {
@@ -265,16 +267,30 @@ const FormEditor = React.forwardRef(
 				containerId,
 				{
 					reactComponentRef,
+
+					// unstable_onEvent allows listening to internal events of the
+					// FormProvider through the public instance of the form. This
+					// is still unstable and can change at any time.
+
+					unstable_onEvent: (callback) => {
+						unstable_onEventRef.current = callback;
+					},
 				},
 				{
 					destroyOnNavigate: true,
 				}
 			);
-		}, [containerId, reactComponentRef]);
+		}, [unstable_onEventRef, containerId, reactComponentRef]);
 
 		return (
 			<FormProvider
-				onEvent={onEvent}
+				onEvent={(type, payload) => {
+					onEvent(type, payload);
+
+					if (unstable_onEventRef.current) {
+						unstable_onEventRef.current({payload, type});
+					}
+				}}
 				value={{...otherProps, activePage, defaultLanguageId}}
 			>
 				{(props) => <Form {...props} ref={reactComponentRef} />}


### PR DESCRIPTION
As described in the ticket and comment, this is a temporary API to cover the case of Commerce. Forms Team or Data Engine will still have a stable and official public API to handle the information from within a form.