### PR TITLE
LPS-129340 Serialize the form builder context in-depth to avoid JSONArray and JSONObject in the structure

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormAdminDisplayContext.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormAdminDisplayContext.java
@@ -601,7 +601,8 @@ public class DDMFormAdminDisplayContext {
 			_ddmFormBuilderContextFactory.create(ddmFormBuilderContextRequest);
 
 		return jsonFactory.createJSONObject(
-			ddmFormBuilderContextResponse.getContext());
+			jsonFactory.looseSerializeDeep(
+				ddmFormBuilderContextResponse.getContext()));
 	}
 
 	public List<NavigationItem> getFormBuilderNavigationItems() {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/config/initialState.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/config/initialState.es.js
@@ -78,7 +78,7 @@ const normalizePages = (pages) => {
 	const visitor = new PagesVisitor(pages);
 
 	return visitor.mapFields(
-		({rows, settingsContext, ...otherProps}) => {
+		({settingsContext, ...otherProps}) => {
 			const visitor = new PagesVisitor(settingsContext.pages);
 
 			// Inferences the edited property to `true` of the options of a Field with
@@ -86,50 +86,33 @@ const normalizePages = (pages) => {
 			// implementation of the LayoutProvider, to remove this it is necessary
 			// to refactor the Options field to better deal with states and location.
 
-			settingsContext = {
-				...settingsContext,
-				pages: visitor.mapFields((field) => {
-					if (field.type === 'options') {
-						const languageIds = Object.keys(field.value);
-
-						return {
-							...field,
-							value: languageIds.reduce(
-								(previousValue, currentLanguageId) => ({
-									...previousValue,
-									[currentLanguageId]: field.value[
-										currentLanguageId
-									].map((option) => ({
-										...option,
-										edited: true,
-									})),
-								}),
-								{}
-							),
-						};
-					}
-
-					return field;
-				}),
-			};
-
-			if (!rows) {
-				return {
-					settingsContext,
-					...otherProps,
-				};
-			}
-
-			// Fixes the row structure of a FieldGroup to make the rest of the
-			// application unaware of the state of JSONArray or any other
-			// peculiarity of the backend.
-			//
-			// NOTE: This is considered a stopgap so that the backend can better
-			// deal with the structure.
-
 			return {
-				rows: rows.JSONArray ?? rows,
-				settingsContext,
+				settingsContext: {
+					...settingsContext,
+					pages: visitor.mapFields((field) => {
+						if (field.type === 'options') {
+							const languageIds = Object.keys(field.value);
+
+							return {
+								...field,
+								value: languageIds.reduce(
+									(previousValue, currentLanguageId) => ({
+										...previousValue,
+										[currentLanguageId]: field.value[
+											currentLanguageId
+										].map((option) => ({
+											...option,
+											edited: true,
+										})),
+									}),
+									{}
+								),
+							};
+						}
+
+						return field;
+					}),
+				},
 				...otherProps,
 			};
 		},


### PR DESCRIPTION
It seems that just getting `getContext` does not bring the context fully serialized and when we try to create a new `JSONObject` from it, some properties of some Fields that use `jsonFactory` end up being added as part of the structure, as an example `rows: {JSONArray: []}` instead of `rows: []`.

The solution here was to serialize the context in-depth and then create a JSONObject, this seems to have removed the use cases known above. This also removes the palliative from the Frontend side 🙌