### PR TITLE
LPS-129393 Render the Placeholder component independent of the editable

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/core/components/PageRenderer/EditorVariant.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/core/components/PageRenderer/EditorVariant.es.js
@@ -83,7 +83,7 @@ export const Column = ({
 
 	const handleResize = useCallback((resizing) => setResizing(resizing), []);
 
-	if (editable && column.fields.length === 0) {
+	if (column.fields.length === 0) {
 		return (
 			<Placeholder
 				columnIndex={columnIndex}


### PR DESCRIPTION

Some behavior changes were made in the editable property, once we have the EditorVariant, we can render the Placeholder without problems for the Column so that it can be an empty space.