### PR TITLE
LPS-129618 Fixes the error that prevents a field from having an empty value

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/core/reducers/fieldEditableReducer.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/core/reducers/fieldEditableReducer.es.js
@@ -343,7 +343,7 @@ export default (state, action, config) => {
 				generateFieldNameUsingFieldLabel
 			);
 
-			if (propertyName === 'name' || propertyValue === '') {
+			if (propertyName === 'name' && propertyValue === '') {
 				return state;
 			}
 


### PR DESCRIPTION

This was brought in from the old Metal.js implementation but the conditional was different and I made an error when translating.

Previously on LayoutProvider: `propertyName !== 'name' || propertyValue !== ''`

This conditional was used to decide whether to update the state of the field, now just invert that to fail earlier. This is the type of conditional that should not be inside the reducer but in the field that handles `name`. Keeping here for now because it requires a lot of changes.