### PR TITLE
LPS-129627 Prevents creating FieldGroup within another FieldGroup when there is only one Field

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/Sidebar/Sidebar.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/resources/META-INF/resources/js/components/Sidebar/Sidebar.es.js
@@ -605,6 +605,17 @@ class Sidebar extends Component {
 				'.ddm-field'
 			);
 
+			const totalFieldsInParentField = data.target
+				.closest('.ddm-field-types-fieldset__nested')
+				?.querySelectorAll('.col-ddm:not(.col-empty)').length;
+
+			if (
+				totalFieldsInParentField === 1 &&
+				data.target.dataset.fieldName
+			) {
+				return;
+			}
+
 			if (parentFieldNode) {
 				parentFieldName = parentFieldNode.dataset.fieldName;
 			}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/core/reducers/dragAndDropReducer.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/core/reducers/dragAndDropReducer.es.js
@@ -70,9 +70,9 @@ export default (state, action, config) => {
 			);
 
 			if (
-				sourceField &&
+				sourceParentField &&
 				targetFieldName &&
-				sourceField.fieldName === targetFieldName
+				sourceParentField.fieldName === targetFieldName
 			) {
 				return state;
 			}


### PR DESCRIPTION
This is dealing with two use cases:

- It will prevent creating a FieldGroup within another FieldGroup when there is only one Field
- It will prevent you from creating a FieldGroup within another FieldGroup when there are only 2 Fields and the source Field is one of them.
