### PR TITLE
LPS-129899 Reassemble the components of the variant in the Layout respecting the editable property in the nesting level

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/core/components/PageRenderer/EditorVariant.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/core/components/PageRenderer/EditorVariant.es.js
@@ -26,7 +26,6 @@ import {useDrag} from 'react-dnd';
 import {getEmptyImage} from 'react-dnd-html5-backend';
 
 import {hasFieldSet} from '../../../util/fields.es';
-import {PagesVisitor} from '../../../util/visitors.es';
 import {DND_ORIGIN_TYPE, useDrop} from '../../hooks/useDrop.es';
 import {Actions, ActionsControls, useActions} from '../Actions.es';
 import {ParentFieldContext} from '../Field/ParentFieldContext.es';
@@ -113,54 +112,6 @@ export const Column = ({
 			? parentField.root
 			: firstField;
 
-	const getSingleFieldVisitor = (field) => {
-		return new PagesVisitor([
-			{
-				rows: [
-					{
-						columns: [
-							{
-								fields: [field],
-							},
-						],
-					},
-				],
-			},
-		]);
-	};
-
-	const getFieldSets = () => {
-		const visitor = getSingleFieldVisitor(rootParentField);
-
-		let fieldSets = [];
-
-		visitor.mapFields(
-			(field) => {
-				if (hasFieldSet(field)) {
-					fieldSets = [...fieldSets, field];
-				}
-			},
-			true,
-			true
-		);
-
-		return fieldSets;
-	};
-
-	const belongsToFieldSet = (field) => {
-		if (!field.fieldName) {
-			return false;
-		}
-
-		const fieldSets = getFieldSets();
-
-		return !!fieldSets.find((fieldSet) => {
-			const visitor = getSingleFieldVisitor(fieldSet);
-
-			return visitor.containsField(field.fieldName);
-		});
-	};
-
 	return (
 		<ActionsControls
 			actionsRef={actionsRef}
@@ -214,16 +165,14 @@ export const Column = ({
 							'py-0': isFieldSetOrGroup,
 						})}
 						ref={(node) => {
-							if (!belongsToFieldSet(parentField)) {
-								if (
-									allowNestedFields &&
-									!rootParentField.ddmStructureId
-								) {
-									drag(drop(node));
-								}
-								else if (!hasFieldSet(parentField)) {
-									drag(node);
-								}
+							if (
+								allowNestedFields &&
+								!rootParentField.ddmStructureId
+							) {
+								drag(drop(node));
+							}
+							else if (!hasFieldSet(parentField)) {
+								drag(node);
 							}
 							resizeRef.current = node;
 						}}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/core/components/PageRenderer/EditorVariant.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/core/components/PageRenderer/EditorVariant.es.js
@@ -217,7 +217,7 @@ export const Column = ({
 							if (!belongsToFieldSet(parentField)) {
 								if (
 									allowNestedFields &&
-									!parentField.ddmStructureId
+									!rootParentField.ddmStructureId
 								) {
 									drag(drop(node));
 								}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/core/components/PageRenderer/Layout.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/core/components/PageRenderer/Layout.es.js
@@ -22,6 +22,7 @@ import {usePage} from '../../hooks/usePage.es';
 import fieldBlur from '../../thunks/fieldBlur.es';
 import fieldChange from '../../thunks/fieldChange.es';
 import fieldFocus from '../../thunks/fieldFocus.es';
+import {mergeVariants} from '../../utils/merge-variants.es';
 import {Field} from '../Field/Field.es';
 import {VariantsContext} from './VariantsContext.es';
 
@@ -33,9 +34,9 @@ export const Layout = ({components, editable, rows}) => {
 	const createFieldChange = useEvaluate(fieldChange);
 	const dispatch = useForm();
 
-	const defaultComponents = useContext(VariantsContext);
+	const variants = useContext(VariantsContext);
 
-	const Components = components ?? defaultComponents;
+	const Components = components ?? mergeVariants(editable, variants);
 
 	return (
 		<Components.Rows

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/core/components/PageRenderer/Page.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/core/components/PageRenderer/Page.es.js
@@ -22,8 +22,8 @@ import * as SuccessPage from '../../../custom/form/renderer/SuccessVariant.es';
 import * as Wizard from '../../../custom/form/renderer/WizardVariant.es';
 import {PagesVisitor} from '../../../util/visitors.es';
 import {PageProvider} from '../../hooks/usePage.es';
+import {mergeVariants} from '../../utils/merge-variants.es';
 import * as DefaultVariant from './DefaultVariant.es';
-import * as EditorVariant from './EditorVariant.es';
 import {Layout} from './Layout.es';
 import * as Tabbed from './TabbedVariant.es';
 import {VariantsProvider} from './VariantsContext.es';
@@ -159,17 +159,16 @@ const Page = ({
 	const empty = isEmptyPage(defaultPage);
 	const page = normalizePage(defaultPage, editingLanguageId);
 
-	const variant = getVariant({page, pages, paginationMode});
-	const variantComponents = LAYOUT_COMPONENTS_TYPES[variant] || {};
+	const variantName = getVariant({page, pages, paginationMode});
+	const variantComponents = LAYOUT_COMPONENTS_TYPES[variantName] || {};
 
-	const variantEditable = editable ? EditorVariant : {};
-
-	const Components = {
-		...DefaultVariant,
-		...variantEditable,
-		...variantComponents,
-		...overrides,
+	const variants = {
+		defaults: DefaultVariant,
+		overrides,
+		variant: variantComponents,
 	};
+
+	const Components = mergeVariants(editable, variants);
 
 	let hasFieldRequired = false;
 
@@ -187,7 +186,7 @@ const Page = ({
 		DDM_FORM_PORTLET_NAMESPACE === portletNamespace;
 
 	return (
-		<VariantsProvider components={Components}>
+		<VariantsProvider components={variants}>
 			<Components.Container
 				activePage={activePage}
 				editable={editable}
@@ -204,7 +203,7 @@ const Page = ({
 					empty={empty}
 					forceAriaUpdate={forceAriaUpdate}
 					header={
-						variant === LAYOUT_TYPES.SINGLE_PAGE ? null : (
+						variantName === LAYOUT_TYPES.SINGLE_PAGE ? null : (
 							<Components.PageHeader {...page} />
 						)
 					}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/core/utils/merge-variants.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/core/utils/merge-variants.es.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import * as EditorVariant from '../components/PageRenderer/EditorVariant.es';
+
+export const mergeVariants = (editable, {defaults, overrides, variant}) => ({
+	...defaults,
+	...(editable ? EditorVariant : {}),
+	...variant,
+	...overrides,
+});


### PR DESCRIPTION
This corrects only a part of the Form Builder's performance problem, I added more comments about the problem in the ticket related to the problem https://issues.liferay.com/browse/LPS-129899, initially, I will not fixes all of them, but we must make people aware not to continue using PageVisitor in hot paths that is causing big performance problems as more fields are added to the form. Just correcting a case of them to alleviate this problem.

The Layout component is used nested to render elements of the FieldGroup or FieldSet. FieldSet component uses Layout to render nested fields but disables the editable option to disable any features for elements within the FieldSet.

The strategy here is simple, to avoid analyzing all fields or nested fields as was being done in a hot path that can generate performance problems and delay the rendering of the elements, we just revalidated the merge of the variants within the Layout component. Because once the editable is false for FieldSet the component will only use the default variants, without DnD, Resizable...

Try to avoid using visitors as much as possible for these hot path cases.