### PR TITLE
LPS-129529 Adds the Data representation implementation of Forms to Data Engine

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/core/hooks/useDataView.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/core/hooks/useDataView.es.js
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {DataDefinitionSchema} from '../schema/DataDefinition.es';
+import {DataLayoutSchema} from '../schema/DataLayout.es';
+import {SYMBOL_RAW} from '../schema/Schema.es';
+
+const SCHEMAS_DICTIONARY = {
+	dataDefinition: DataDefinitionSchema,
+	dataLayout: DataLayoutSchema,
+};
+
+/**
+ * Context stores all instances of schemas created by key to avoid recreating
+ * a new instance of the same Schema in different components.
+ */
+const context = {};
+
+const getProps = (props, keys) =>
+	keys.reduce((prev, key) => {
+		prev[key] = props[key];
+
+		return prev;
+	}, {});
+
+/**
+ * Compare the values of the properties at the reference level, the properties
+ * should only be for readonly, the raw object and props will always be different
+ * objects because props contain all the properties of the store but raw only
+ * the properties that the schema needs.
+ */
+const isStaleRaw = (props, schema) =>
+	schema.props.some((key) => props[key] !== schema[SYMBOL_RAW][key]);
+
+const createSchema = (key, props) => {
+	const Schema = SCHEMAS_DICTIONARY[key];
+
+	const raw = getProps(props, Schema.props);
+	const instance = new Schema(raw);
+
+	context[key] = instance;
+
+	return instance;
+};
+
+const getSchema = (key, props) => {
+	if (key in context) {
+		if (isStaleRaw(props, context[key])) {
+			delete context[key];
+
+			return createSchema(key, props);
+		}
+
+		return context[key];
+	}
+	else {
+		return createSchema(key, props);
+	}
+};
+
+const parseSchema = (props, schema) =>
+	schema.reduce((prev, key) => {
+		const Schema = getSchema(key, props);
+
+		prev[key] = Schema;
+
+		return prev;
+	}, {});
+
+/**
+ * UseDataView creates a representation of the data based on the passed
+ * schema otherwise nothing is done. It should not be used directly, it
+ * is exposed through `useFormState`.
+ */
+export const useDataView = (props, schema) =>
+	schema ? parseSchema(props, schema) : props;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/core/hooks/useForm.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/core/hooks/useForm.es.js
@@ -17,6 +17,7 @@ import React, {useContext, useReducer, useRef} from 'react';
 
 import {createReducer} from '../reducers/createReducer.es';
 import {useConfig} from './useConfig.es';
+import {useDataView} from './useDataView.es';
 
 const FormDispatchContext = React.createContext(() => {});
 
@@ -163,6 +164,6 @@ export const useForm = () => {
 	return useContext(FormDispatchContext);
 };
 
-export const useFormState = () => {
-	return useContext(FormStateContext);
+export const useFormState = ({schema} = {}) => {
+	return useDataView(useContext(FormStateContext), schema);
 };

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/core/schema/DataDefinition.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/core/schema/DataDefinition.es.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {SYMBOL_RAW, Schema} from './Schema.es';
+
+export class DataDefinitionSchema extends Schema {
+	static props = ['availableLanguageIds'];
+
+	constructor(raw) {
+		super('data_engine', 'dataDefinition', raw);
+	}
+
+	get availableLanguageIds() {
+		return this[SYMBOL_RAW].availableLanguageIds;
+	}
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/core/schema/DataLayout.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/core/schema/DataLayout.es.js
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {SYMBOL_RAW, Schema} from './Schema.es';
+
+export class DataLayoutRowSchema extends Schema {
+	constructor(raw) {
+		super('data_engine', 'dataLayoutRow', raw);
+	}
+
+	get dataLayoutColumns() {
+		return this[SYMBOL_RAW].columns.map((column) => ({
+			columnSize: column.size,
+			fieldNames: column.fields.map(({fieldName}) => fieldName),
+		}));
+	}
+}
+
+export class DataLayoutPageSchema extends Schema {
+	constructor(raw) {
+		super('data_engine', 'dataLayoutPage', raw);
+	}
+
+	get dataLayoutRows() {
+		return this[SYMBOL_RAW].rows.map((row) => new DataLayoutRowSchema(row));
+	}
+
+	get description() {
+		return this[SYMBOL_RAW].localizedDescription;
+	}
+
+	get title() {
+		return this[SYMBOL_RAW].localizedTitle;
+	}
+}
+
+export class DataLayoutSchema extends Schema {
+	static props = ['pages', 'rules'];
+
+	constructor(raw) {
+		super('data_engine', 'dataLayout', raw);
+	}
+
+	get dataRules() {
+		return this[SYMBOL_RAW].rules;
+	}
+
+	get dataLayoutPages() {
+		return this[SYMBOL_RAW].pages.map(
+			(page) => new DataLayoutPageSchema(page)
+		);
+	}
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/core/schema/Schema.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/core/schema/Schema.es.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+const SYMBOL_CONTEXT = Symbol('schema.context');
+
+const SYMBOL_TYPE = Symbol('schema.type');
+
+export const SYMBOL_RAW = Symbol('schema.raw');
+
+export class Schema {
+	constructor(context, type, raw) {
+		this[SYMBOL_CONTEXT] = context;
+		this[SYMBOL_TYPE] = type;
+		this[SYMBOL_RAW] = raw;
+	}
+}


### PR DESCRIPTION
To understand more about the reason for this implementation read the ticket: https://issues.liferay.com/browse/LPS-129529

The `useDataView` hook is the component that ends up doing the entire orchestration of creating the representation of the data, reusing, revalidating, caching, and returning the output of the representation.

## Key ideas

Some resources make it very valuable and significant for the growth of the application and how it makes it easier for two different structures to coexist but with the same raw data.

- The components never know that these two different structures exist, because there is no need to call any method to convert the data.
- It is easy to slowly migrate components to use the new data structure.
- It will be simpler to maintain data representations based on the implementation of "schema" compared to data conversion.
- We don't couple any method or class to the components that we need to call for every corner, like DataLayoutBuilder that was done before.
- It is not necessary to wait to convert all the data before starting to render the component or to call any other method.
- We create data representation whenever a possible using reference to avoid overloading the creation of new objects being allocated in the heap.
- When a Schema is created for the first time it is reused so we don't need to create another one again, there is a reuse of schema in different instances of the components if you use the same representation.
- There is a revalidation of the raw data to avoid loss of reference.
- For nested data such as `dataLayout.dataLayoutPages` there is a great benefit for the implementation of getter, it will be invoked only when it is used, if you only need to get only the title of the page the representation/conversion in the structure of `dataLayoutRows` will not be done, so we have the benefit of creating the lazy representation here.

Despite having a lot of good things with this implementation I would say that there is no contraindication just that it adds minimal overhead to the data output which is incredibly small in the 100ns range but that this is a great pros due to the previous implementation that did a lot data conversion all the time which was considerably noticeable at times the slowness.

## Design decision

The `useDataView` hook is not used directly, it is built into `useFormState` to avoid coupling its use to the components. The logic is not done on top of `useFormState` because it is based on principles of responsibility, this helps when all components are using the Data Engine data structure, the swap will be easy to do.

Components that already consume useFormState, can already benefit from this.

```js
const {dataLayout} = useFormState({schema: ['dataLayout']});
```

There may be cases where components consume the data in the Forms and Data Engine structure, although this is not a good practice you can instantiate two useFormState to consume the data in a different way or if the component needs information that does not compare.

```js
const {focusedField} = useFormState();
const {dataLayout} = useFormState({schema: ['dataLayout']});
```

### Drawbacks

- Having to define which data will be used, avoids having to create all schemes at once.
- When the Schema is defined, only the schema is returned, no merge is made with the rest of the store, in case it is necessary to instantiate a new `useFormState` to get the data.
- Undeclared data within the Schema are not exposed at the exit, just expose the methods that are used.

## Notes

- This implementation is not yet complete, it does not cover the case of creating a reducer using the state represented in the Data Engine structure. Adding in next interactions.
- Also, not all data representations were added, just adding the representation for **DataLayout** and **DataDefinition** initially. Add more methods or more Schemas as needed.