### PR TITLE
LPS-129941 Add condition to fix empty element ddm-form-description

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/display/view.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/display/view.jsp
@@ -170,7 +170,7 @@ long formInstanceId = ddmFormDisplayContext.getFormInstanceId();
 								String description = HtmlUtil.escape(formInstance.getDescription(displayLocale));
 								%>
 
-								<c:if test="<%= Validator.isNotNull(description) %>">
+								<c:if test="<%= Validator.isNotNull(description) && Validator.isNotNull(description.trim()) %>">
 									<p class="ddm-form-description"><%= description %></p>
 								</c:if>
 							</clay:container-fluid>


### PR DESCRIPTION
LPS-129941 Add condition to fix empty element ddm-form-description when remove it after being set up, comes as new line char "\n" that needs to be trim it (found while testing LPS-129896)