### PR TITLE
LPS-128053 Adds reducers for dataDefinition and dataLayout

### DIFF
--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/new-js/App.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/new-js/App.js
@@ -19,6 +19,8 @@ import {
 	parseProps,
 } from 'dynamic-data-mapping-form-renderer';
 import {
+	dataDefinitionReducer,
+	dataLayoutReducer,
 	dragAndDropReducer,
 	fieldEditableReducer,
 	languageReducer,
@@ -58,6 +60,8 @@ const App = (props) => {
 					<FormProvider
 						initialState={INITIAL_STATE}
 						reducers={[
+							dataDefinitionReducer,
+							dataLayoutReducer,
 							dragAndDropReducer,
 							fieldEditableReducer,
 							languageReducer,

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/core/actions/eventTypes.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/core/actions/eventTypes.es.js
@@ -36,6 +36,16 @@ const FIELD = {
 	REPEATED: 'field_repeated',
 };
 
+const DATA_DEFINITION = {
+	ADD: 'data_definition_add',
+	CHANGE: 'data_definition_change',
+	DELETE: 'data_definition_delete',
+};
+
+const DATA_LAYOUT = {
+	NAME: 'data_layout_name',
+};
+
 const DND = {
 	MOVE: 'field_move',
 	RESIZE: 'field_resize',
@@ -77,6 +87,8 @@ export const MAPPED_EVENT_TYPES = {
 
 export const EVENT_TYPES = {
 	...LEGACY_EVENTS,
+	DATA_DEFINITION,
+	DATA_LAYOUT,
 	DND,
 	FIELD,
 	FIELD_SET,

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/core/reducers/dataDefinitionReducer.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/core/reducers/dataDefinitionReducer.es.js
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {DataConverter} from 'data-engine-taglib';
+import {FieldSupport} from 'dynamic-data-mapping-form-builder';
+
+import {PagesVisitor} from '../../util/visitors.es';
+import {EVENT_TYPES} from '../actions/eventTypes.es';
+
+export default (state, action, config) => {
+	switch (action.type) {
+		case EVENT_TYPES.DATA_DEFINITION.ADD: {
+			const {type} = action.payload;
+
+			const {
+				dataDefinition,
+				defaultLanguageId,
+				editingLanguageId,
+				pages,
+			} = state;
+
+			const {
+				fieldTypes,
+				generateFieldNameUsingFieldLabel,
+				getFieldNameGenerator,
+			} = config;
+
+			const fieldNameGenerator = getFieldNameGenerator(
+				pages,
+				generateFieldNameUsingFieldLabel
+			);
+
+			const fieldType = fieldTypes.find(({name}) => name === type);
+
+			const field = FieldSupport.createField(
+				{defaultLanguageId, editingLanguageId, fieldNameGenerator},
+				{fieldType}
+			);
+
+			const dataDefinitionField = DataConverter.getDataDefinitionField(
+				field
+			);
+
+			return {
+				dataDefinition: {
+					...dataDefinition,
+					dataDefinitionFields: [
+						...dataDefinition.dataDefinitionFields,
+						dataDefinitionField,
+					],
+				},
+				focusedField: {
+					...dataDefinitionField,
+					settingsContext: field.settingsContext,
+				},
+			};
+		}
+		case EVENT_TYPES.DATA_DEFINITION.CHANGE: {
+			const {
+				dataDefinition,
+				defaultLanguageId,
+				editingLanguageId,
+				focusedField,
+			} = state;
+			const {propertyName, propertyValue} = action.payload;
+
+			const visitor = new PagesVisitor(
+				focusedField.settingsContext.pages
+			);
+
+			const settingsContext = {
+				...focusedField.settingsContext,
+				pages: visitor.mapFields((field) => {
+					const {fieldName} = field;
+
+					if (fieldName === propertyName) {
+						const localizedValue = {
+							...field.localizedValue,
+							[editingLanguageId ||
+							defaultLanguageId]: propertyValue,
+						};
+
+						return {
+							...field,
+							localizedValue,
+							value: propertyValue,
+						};
+					}
+
+					return field;
+				}),
+			};
+
+			const dataDefinitionField = {
+				...DataConverter.getDataDefinitionField({
+					nestedFields: focusedField.nestedFields,
+					settingsContext,
+				}),
+				settingsContext,
+			};
+
+			return {
+				dataDefinition: {
+					...dataDefinition,
+					dataDefinitionFields: dataDefinition.dataDefinitionFields.map(
+						(field) => {
+							if (field.name === dataDefinitionField.name) {
+								return dataDefinitionField;
+							}
+
+							return field;
+						}
+					),
+				},
+				focusedField: dataDefinitionField,
+			};
+		}
+		case EVENT_TYPES.DATA_DEFINITION.DELETE: {
+			const {fieldName} = action.payload;
+			const {dataDefinition} = state;
+
+			return {
+				dataDefinition: {
+					...dataDefinition,
+					dataDefinitionFields: dataDefinition.dataDefinitionFields.filter(
+						(field) => field.name !== fieldName
+					),
+				},
+			};
+		}
+		default:
+			return state;
+	}
+};

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/core/reducers/dataLayoutReducer.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/core/reducers/dataLayoutReducer.es.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {EVENT_TYPES} from '../actions/eventTypes.es';
+
+export default (state, action) => {
+	switch (action.type) {
+		case EVENT_TYPES.DATA_LAYOUT.NAME: {
+			const {name} = action.payload;
+
+			return {
+				dataLayout: {
+					...state.dataLayout,
+					name,
+				},
+			};
+		}
+		default:
+			return state;
+	}
+};

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/core/reducers/index.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/core/reducers/index.es.js
@@ -13,6 +13,8 @@
  */
 
 export {default as activePageReducer} from './activePageReducer.es';
+export {default as dataDefinitionReducer} from './dataDefinitionReducer.es';
+export {default as dataLayoutReducer} from './dataLayoutReducer.es';
 export {default as dragAndDropReducer} from './dragAndDropReducer.es';
 export {default as fieldEditableReducer} from './fieldEditableReducer.es';
 export {default as fieldReducer} from './fieldReducer.es';


### PR DESCRIPTION
I'm Just moving some actions to the new base, nothing much different from what existed in the previous implementation.

The action `EVENT_TYPES.DATA_DEFINITION.CHANGE` looked something very similar to what we have with `CORE_EVENT_TYPES.FIELD.CHANGE` but does less checks, it is difficult to know if it is enough but this will only be used by the App Builder today, perhaps in the future the two can merge in some way to simplify things.

A mapping of the old event to the new one implementing in the new base:

- **_ADD_CUSTOM_OBJECT_FIELD_** to **_CORE_EVENT_TYPES.DATA_DEFINITION.ADD_**
- **_DELETE_DATA_DEFINITION_FIELD_** to **_CORE_EVENT_TYPES.DATA_DEFINITION.DELETE_**
- **_EDIT_CUSTOM_OBJECT_FIELD_** to **_CORE_EVENT_TYPES.DATA_DEFINITION.CHANGE_**
- **_UPDATE_DATA_LAYOUT_NAME_** to **_CORE_EVENT_TYPES.DATA_LAYOUT.NAME_**

Some reducers are discarded because they are redundant and we can send other CORE events to have the same effect.

The implementation to deal with updating the field value at the level of `DataLayout` or `DataDefinition` was not implemented but maybe we were able to reach the same goal using `DATA_DEFINITION.CHANGE` to update the field value only at the structure level and create a new reducer to update the field at the level of `DataLayout`. Consider reevaluating this when implementing the ticket https://issues.liferay.com/browse/LPS-130483