### PR TITLE
[TS] LPS-131928 | master

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/ExportFormInstanceMVCResourceCommand.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/ExportFormInstanceMVCResourceCommand.java
@@ -23,6 +23,8 @@ import com.liferay.dynamic.data.mapping.io.exporter.DDMFormInstanceRecordExporte
 import com.liferay.dynamic.data.mapping.model.DDMFormInstance;
 import com.liferay.dynamic.data.mapping.service.DDMFormInstanceService;
 import com.liferay.petra.string.CharPool;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.portlet.PortletResponseUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCResourceCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
@@ -91,10 +93,22 @@ public class ExportFormInstanceMVCResourceCommand
 				WorkflowConstants.STATUS_APPROVED
 			).build();
 
-		DDMFormInstanceRecordExporterResponse
-			ddmFormInstanceRecordExporterResponse =
-				_ddmFormInstanceRecordExporter.export(
-					ddmFormInstanceRecordExporterRequest);
+		byte[] recordExporterResponse;
+
+		try {
+			DDMFormInstanceRecordExporterResponse
+				ddmFormInstanceRecordExporterResponse =
+					_ddmFormInstanceRecordExporter.export(
+						ddmFormInstanceRecordExporterRequest);
+
+			recordExporterResponse =
+				ddmFormInstanceRecordExporterResponse.getContent();
+		}
+		catch (Exception exception) {
+			recordExporterResponse = new byte[0];
+
+			_log.error(exception, exception);
+		}
 
 		DDMFormInstance formInstance = _ddmFormInstanceService.getFormInstance(
 			formInstanceId);
@@ -104,8 +118,7 @@ public class ExportFormInstanceMVCResourceCommand
 				fileExtension;
 
 		PortletResponseUtil.sendFile(
-			resourceRequest, resourceResponse, fileName,
-			ddmFormInstanceRecordExporterResponse.getContent(),
+			resourceRequest, resourceResponse, fileName, recordExporterResponse,
 			MimeTypesUtil.getContentType(fileName));
 	}
 
@@ -114,6 +127,9 @@ public class ExportFormInstanceMVCResourceCommand
 
 		_ddmFormWebConfigurationActivator = null;
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		ExportFormInstanceMVCResourceCommand.class);
 
 	@Reference
 	private DDMFormInstanceRecordExporter _ddmFormInstanceRecordExporter;


### PR DESCRIPTION
**Description**
Forms allows exporting entries to Microsoft Excel (XLS) format. In this case, XLS has a limitation in the number of characters that a cell can contain. This limit is 32,767 characters.
See https://support.microsoft.com/en-us/office/excel-specifications-and-limits-1672b34d-7043-467e-8e27-269d656771c3?ui=en-us&rs=en-us&ad=us
If a user tries to export a form with some entry that exceeds this value, export process will fail and user will be stuck on a blank page.

**Steps to reproduce**
1. Create a new form with a text field (Multiple lines).
2. Add some text in the field, with size > 32767 characters.
3. Navigate to Content & Data > Forms. On previous added form, click its kebab menu (three dots) and choose 'Export'.
4. A modal window appears: choose 'XLS' from 'File Extension' combo and click OK.

**Observed behavior**
1. Modal window hides.
2. **User gets a blank screen in browser.**
3. A stacktrace is dumped in product's log.

**Expected behavior**
1.  Modal window hides.
2.  User gets Content & Data > Forms page.
3.  A stacktrace is dumped in product's log.

**Solution proposed**
Catch the exception and send an empty content instead of propagate the exception and send an incomplete response that generates the black page (stuck)