### PR TITLE
LPS-131824 Fix alert message container sizing

### DIFF
--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/end.jsp
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/end.jsp
@@ -18,7 +18,7 @@
 
 <portlet:renderURL var="basePortletURL" />
 
-<div class="data-engine-form-builder-messages data-engine-form-builder-messages--collapsed">
+<div class="data-engine-form-builder-messages">
 	<liferay-ui:error exception="<%= DataDefinitionValidationException.class %>" message="please-enter-a-valid-form-definition" />
 
 	<liferay-ui:error exception="<%= DataDefinitionValidationException.MustNotDuplicateFieldName.class %>">

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/css/_portlet-forms-admin.scss
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/css/_portlet-forms-admin.scss
@@ -15,8 +15,17 @@
 	margin-right: 5px;
 }
 
-.exception-container > div:first-child {
-	margin-top: 24px;
+.ddm-form-web__exception-container {
+	transition: padding ease $transition-time;
+
+	.alert-dismissible:first-child {
+		margin-top: 24px;
+	}
+
+	&--sidebar-open {
+		padding-left: 0;
+		padding-right: 338px;
+	}
 }
 
 .invalid-form-instance {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/edit_form_instance.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/edit_form_instance.jsp
@@ -142,11 +142,7 @@ renderResponse.setTitle((formInstance == null) ? LanguageUtil.get(request, "new-
 		<aui:input name="serializedFormBuilderContext" type="hidden" value="<%= formBuilderContextJSONObject %>" />
 		<aui:input name="serializedSettingsContext" type="hidden" value="" />
 
-		<clay:container-fluid>
-			<div class="exception-container">
-				<%@ include file="/admin/exceptions.jspf" %>
-			</div>
-		</clay:container-fluid>
+		<%@ include file="/admin/exceptions.jspf" %>
 
 		<div id="<portlet:namespace />-container">
 			<react:component

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/exceptions.jspf
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/exceptions.jspf
@@ -14,103 +14,107 @@
  */
 --%>
 
-<liferay-ui:error exception="<%= DDMFormLayoutValidationException.class %>" message="please-enter-a-valid-form-layout" />
+<clay:container-fluid>
+	<div class="ddm-form-web__exception-container ddm-form-web__exception-container--sidebar-open">
+		<liferay-ui:error exception="<%= DDMFormLayoutValidationException.class %>" message="please-enter-a-valid-form-layout" />
 
-<liferay-ui:error exception="<%= DDMFormLayoutValidationException.MustNotDuplicateFieldName.class %>">
+		<liferay-ui:error exception="<%= DDMFormLayoutValidationException.MustNotDuplicateFieldName.class %>">
 
-	<%
-	DDMFormLayoutValidationException.MustNotDuplicateFieldName mndfn = (DDMFormLayoutValidationException.MustNotDuplicateFieldName)errorException;
-	%>
+			<%
+			DDMFormLayoutValidationException.MustNotDuplicateFieldName mndfn = (DDMFormLayoutValidationException.MustNotDuplicateFieldName)errorException;
+			%>
 
-	<liferay-ui:message arguments="<%= HtmlUtil.escape(StringUtil.merge(mndfn.getDuplicatedFieldNames(), StringPool.COMMA_AND_SPACE)) %>" key="the-definition-field-name-x-was-defined-more-than-once" translateArguments="<%= false %>" />
-</liferay-ui:error>
+			<liferay-ui:message arguments="<%= HtmlUtil.escape(StringUtil.merge(mndfn.getDuplicatedFieldNames(), StringPool.COMMA_AND_SPACE)) %>" key="the-definition-field-name-x-was-defined-more-than-once" translateArguments="<%= false %>" />
+		</liferay-ui:error>
 
-<liferay-ui:error exception="<%= DDMFormValidationException.class %>" message="please-enter-a-valid-form-definition" />
+		<liferay-ui:error exception="<%= DDMFormValidationException.class %>" message="please-enter-a-valid-form-definition" />
 
-<liferay-ui:error exception="<%= DDMFormValidationException.MustNotDuplicateFieldName.class %>">
+		<liferay-ui:error exception="<%= DDMFormValidationException.MustNotDuplicateFieldName.class %>">
 
-	<%
-	DDMFormValidationException.MustNotDuplicateFieldName mndfn = (DDMFormValidationException.MustNotDuplicateFieldName)errorException;
-	%>
+			<%
+			DDMFormValidationException.MustNotDuplicateFieldName mndfn = (DDMFormValidationException.MustNotDuplicateFieldName)errorException;
+			%>
 
-	<liferay-ui:message arguments="<%= HtmlUtil.escape(mndfn.getFieldName()) %>" key="the-definition-field-name-x-was-defined-more-than-once" translateArguments="<%= false %>" />
-</liferay-ui:error>
+			<liferay-ui:message arguments="<%= HtmlUtil.escape(mndfn.getFieldName()) %>" key="the-definition-field-name-x-was-defined-more-than-once" translateArguments="<%= false %>" />
+		</liferay-ui:error>
 
-<liferay-ui:error exception="<%= DDMFormValidationException.MustSetFieldsForForm.class %>" message="please-add-at-least-one-field" />
+		<liferay-ui:error exception="<%= DDMFormValidationException.MustSetFieldsForForm.class %>" message="please-add-at-least-one-field" />
 
-<liferay-ui:error exception="<%= DDMFormValidationException.MustSetOptionsForField.class %>">
+		<liferay-ui:error exception="<%= DDMFormValidationException.MustSetOptionsForField.class %>">
 
-	<%
-	DDMFormValidationException.MustSetOptionsForField msoff = (DDMFormValidationException.MustSetOptionsForField)errorException;
-	%>
+			<%
+			DDMFormValidationException.MustSetOptionsForField msoff = (DDMFormValidationException.MustSetOptionsForField)errorException;
+			%>
 
-	<liferay-ui:message arguments="<%= HtmlUtil.escape(msoff.getFieldLabel()) %>" key="at-least-one-option-should-be-set-for-field-x" translateArguments="<%= false %>" />
-</liferay-ui:error>
+			<liferay-ui:message arguments="<%= HtmlUtil.escape(msoff.getFieldLabel()) %>" key="at-least-one-option-should-be-set-for-field-x" translateArguments="<%= false %>" />
+		</liferay-ui:error>
 
-<liferay-ui:error exception="<%= DDMFormValidationException.MustSetValidCharactersForFieldName.class %>">
+		<liferay-ui:error exception="<%= DDMFormValidationException.MustSetValidCharactersForFieldName.class %>">
 
-	<%
-	DDMFormValidationException.MustSetValidCharactersForFieldName msvcffn = (DDMFormValidationException.MustSetValidCharactersForFieldName)errorException;
-	%>
+			<%
+			DDMFormValidationException.MustSetValidCharactersForFieldName msvcffn = (DDMFormValidationException.MustSetValidCharactersForFieldName)errorException;
+			%>
 
-	<liferay-ui:message arguments="<%= HtmlUtil.escape(msvcffn.getFieldName()) %>" key="invalid-characters-were-defined-for-field-name-x" translateArguments="<%= false %>" />
-</liferay-ui:error>
+			<liferay-ui:message arguments="<%= HtmlUtil.escape(msvcffn.getFieldName()) %>" key="invalid-characters-were-defined-for-field-name-x" translateArguments="<%= false %>" />
+		</liferay-ui:error>
 
-<liferay-ui:error exception="<%= DDMFormValidationException.MustSetValidFormRuleExpression.class %>" message="there-are-invalid-rule-expressions" />
+		<liferay-ui:error exception="<%= DDMFormValidationException.MustSetValidFormRuleExpression.class %>" message="there-are-invalid-rule-expressions" />
 
-<liferay-ui:error exception="<%= DDMFormValidationException.MustSetValidValidationExpression.class %>">
+		<liferay-ui:error exception="<%= DDMFormValidationException.MustSetValidValidationExpression.class %>">
 
-	<%
-	DDMFormValidationException.MustSetValidValidationExpression msvve = (DDMFormValidationException.MustSetValidValidationExpression)errorException;
-	%>
+			<%
+			DDMFormValidationException.MustSetValidValidationExpression msvve = (DDMFormValidationException.MustSetValidValidationExpression)errorException;
+			%>
 
-	<liferay-ui:message arguments='<%= new Object[] {StringBundler.concat("<b>", HtmlUtil.escape(msvve.getValidationExpressionArgument()), "</b>"), StringBundler.concat("<b>", HtmlUtil.escape(msvve.getFieldName()), "</b>")} %>' key="the-validation-expression-x-set-for-field-x-is-invalid" translateArguments="<%= false %>" />
-</liferay-ui:error>
+			<liferay-ui:message arguments='<%= new Object[] {StringBundler.concat("<b>", HtmlUtil.escape(msvve.getValidationExpressionArgument()), "</b>"), StringBundler.concat("<b>", HtmlUtil.escape(msvve.getFieldName()), "</b>")} %>' key="the-validation-expression-x-set-for-field-x-is-invalid" translateArguments="<%= false %>" />
+		</liferay-ui:error>
 
-<liferay-ui:error exception="<%= DDMFormValidationException.MustSetValidVisibilityExpression.class %>">
+		<liferay-ui:error exception="<%= DDMFormValidationException.MustSetValidVisibilityExpression.class %>">
 
-	<%
-	DDMFormValidationException.MustSetValidVisibilityExpression msvve = (DDMFormValidationException.MustSetValidVisibilityExpression)errorException;
-	%>
+			<%
+			DDMFormValidationException.MustSetValidVisibilityExpression msvve = (DDMFormValidationException.MustSetValidVisibilityExpression)errorException;
+			%>
 
-	<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(msvve.getVisibilityExpression()), HtmlUtil.escape(msvve.getFieldName())} %>" key="the-visibility-expression-x-set-for-field-x-is-invalid" translateArguments="<%= false %>" />
-</liferay-ui:error>
+			<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(msvve.getVisibilityExpression()), HtmlUtil.escape(msvve.getFieldName())} %>" key="the-visibility-expression-x-set-for-field-x-is-invalid" translateArguments="<%= false %>" />
+		</liferay-ui:error>
 
-<liferay-ui:error exception="<%= FormInstanceFieldSettingsException.MustSetValidValueForProperties.class %>">
+		<liferay-ui:error exception="<%= FormInstanceFieldSettingsException.MustSetValidValueForProperties.class %>">
 
-	<%
-	FormInstanceFieldSettingsException.MustSetValidValueForProperties msvvfp = (FormInstanceFieldSettingsException.MustSetValidValueForProperties)errorException;
+			<%
+			FormInstanceFieldSettingsException.MustSetValidValueForProperties msvvfp = (FormInstanceFieldSettingsException.MustSetValidValueForProperties)errorException;
 
-	Map<String, Set<String>> fieldNamePropertiesMap = msvvfp.getFieldNamePropertiesMap();
+			Map<String, Set<String>> fieldNamePropertiesMap = msvvfp.getFieldNamePropertiesMap();
 
-	StringBundler sb = new StringBundler(fieldNamePropertiesMap.size());
+			StringBundler sb = new StringBundler(fieldNamePropertiesMap.size());
 
-	for (Entry<String, Set<String>> fieldNameProperties : fieldNamePropertiesMap.entrySet()) {
-		Set<String> value = fieldNameProperties.getValue();
+			for (Entry<String, Set<String>> fieldNameProperties : fieldNamePropertiesMap.entrySet()) {
+				Set<String> value = fieldNameProperties.getValue();
 
-		sb.append(LanguageUtil.format(request, (value.size() == 1) ? "the-setting-x-set-for-field-x-is-invalid" : "the-settings-x-set-for-field-x-are-invalid", new Object[] {HtmlUtil.escape(StringUtil.merge(value, StringPool.COMMA_AND_SPACE)), HtmlUtil.escape(fieldNameProperties.getKey())}, false));
+				sb.append(LanguageUtil.format(request, (value.size() == 1) ? "the-setting-x-set-for-field-x-is-invalid" : "the-settings-x-set-for-field-x-are-invalid", new Object[] {HtmlUtil.escape(StringUtil.merge(value, StringPool.COMMA_AND_SPACE)), HtmlUtil.escape(fieldNameProperties.getKey())}, false));
 
-		sb.append(StringPool.SPACE);
-	}
+				sb.append(StringPool.SPACE);
+			}
 
-	sb.setIndex(sb.index() - 1);
-	%>
+			sb.setIndex(sb.index() - 1);
+			%>
 
-	<%= sb.toString() %>
-</liferay-ui:error>
+			<%= sb.toString() %>
+		</liferay-ui:error>
 
-<liferay-ui:error exception="<%= FormInstanceNameException.class %>" message="please-enter-a-valid-form-name" />
+		<liferay-ui:error exception="<%= FormInstanceNameException.class %>" message="please-enter-a-valid-form-name" />
 
-<liferay-ui:error exception="<%= FormInstanceSettingsRedirectURLException.class %>">
+		<liferay-ui:error exception="<%= FormInstanceSettingsRedirectURLException.class %>">
 
-	<%
-	FormInstanceSettingsRedirectURLException formInstanceSettingsRedirectURLException = (FormInstanceSettingsRedirectURLException)errorException;
-	%>
+			<%
+			FormInstanceSettingsRedirectURLException formInstanceSettingsRedirectURLException = (FormInstanceSettingsRedirectURLException)errorException;
+			%>
 
-	<%= formInstanceSettingsRedirectURLException.getMessage() %>
-</liferay-ui:error>
+			<%= formInstanceSettingsRedirectURLException.getMessage() %>
+		</liferay-ui:error>
 
-<liferay-ui:error exception="<%= StorageException.class %>" message="please-enter-a-valid-form-settings" />
-<liferay-ui:error exception="<%= StructureDefinitionException.class %>" message="please-enter-a-valid-form-definition" />
-<liferay-ui:error exception="<%= StructureLayoutException.class %>" message="please-enter-a-valid-form-layout" />
-<liferay-ui:error exception="<%= StructureNameException.class %>" message="please-enter-a-valid-form-name" />
+		<liferay-ui:error exception="<%= StorageException.class %>" message="please-enter-a-valid-form-settings" />
+		<liferay-ui:error exception="<%= StructureDefinitionException.class %>" message="please-enter-a-valid-form-definition" />
+		<liferay-ui:error exception="<%= StructureLayoutException.class %>" message="please-enter-a-valid-form-layout" />
+		<liferay-ui:error exception="<%= StructureNameException.class %>" message="please-enter-a-valid-form-name" />
+	</div>
+</clay:container-fluid>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/pages/FormBuilder.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/pages/FormBuilder.es.js
@@ -101,6 +101,21 @@ export const FormBuilder = () => {
 		}
 	}, [focusedField]);
 
+	/**
+	 * Adjusts alert messages size according to sidebarOpen state
+	 */
+	useEffect(() => {
+		const alerts = document.querySelector(
+			'.ddm-form-web__exception-container'
+		);
+
+		if (alerts) {
+			alerts.className = classNames('ddm-form-web__exception-container', {
+				'ddm-form-web__exception-container--sidebar-open': sidebarOpen,
+			});
+		}
+	}, [sidebarOpen]);
+
 	useEffect(() => {
 		const currentPage = pages[activePage];
 		const isEmpty = currentPage.rows[0]?.columns[0].fields.length === 0;


### PR DESCRIPTION
**Ticket**: [LPS-131824](https://issues.liferay.com/browse/LPS-131824)
### Forms
#### Before
![Screenshot from 2021-05-14 10-19-24](https://user-images.githubusercontent.com/10508566/118277295-07e24080-b49f-11eb-86ef-2aa45c9d851d.png)
#### After
![Screenshot from 2021-05-14 10-20-51](https://user-images.githubusercontent.com/10508566/118277370-1c263d80-b49f-11eb-939b-b4cbc6ffa361.png)

### Data Engine
#### Before
![Screenshot from 2021-05-14 10-04-53](https://user-images.githubusercontent.com/10508566/118277501-395b0c00-b49f-11eb-8d47-e1a720ff4a78.png)
#### After
![Screenshot from 2021-05-14 09-59-06](https://user-images.githubusercontent.com/10508566/118277536-4677fb00-b49f-11eb-967f-b911460de51d.png)

### Notes
Since I was not able to identify any CSS class naming pattern for the Form's code, I thought would be good to starting adopt the [BEM — Block Element Modifier methodology](http://getbem.com/introduction/) to the project.

E.g.: `block-name__element-name--modifier-name`

Note that `alert-container` can be implemented by any module, causing class name collision and enforcing the use of class nesting  to avoid that (it makes the class precedence harder to understand, leading developer to errors manipulating the CSS). In other hand, by using  the prefix `ddm-form-web__` we can consistently identify the module this class belongs, drastically reducing the chance of a class collision and the need of nesting classes. If a collision happen will be an  internal module's issue with no impact to the other modules.

A proper naming would be `ddm-form-web__alert-container--collapsed`. Where:
- `ddm-form-web` is the block (or module)
- `alert-container` is the element
- `collapsed` is the modifier (state of the element)

This methodology is already been used in the [Commerce's CSS](https://github.com/liferay-forms/liferay-portal/blob/2b3674ff72353a861931a2597469ef6d93c8ff9e/modules/apps/commerce/commerce-theme-minium/commerce-theme-minium/src/css/_custom.scss#L19-L99).