### PR TITLE
LPS-133385 update leaflet to 1.7.1

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/package.json
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/package.json
@@ -11,7 +11,7 @@
 		"clay-icon": "2.22.2",
 		"frontend-editor-ckeditor-web": "*",
 		"frontend-js-web": "*",
-		"leaflet": "1.2.0",
+		"leaflet": "1.7.1",
 		"map-google-maps": "*",
 		"map-openstreetmap": "*",
 		"metal-component": "2.16.8",

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Geolocation/useGeolocation.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Geolocation/useGeolocation.es.js
@@ -55,7 +55,7 @@ const parseJSONValue = (value) => {
 
 const setupMapOpenStreetMaps = (callback) => {
 	Leaflet.Icon.Default.imagePath =
-		'https://npmcdn.com/leaflet@1.2.0/dist/images/';
+		'https://npmcdn.com/leaflet@1.7.1/dist/images/';
 
 	if (!window['L']) {
 		window['L'] = Leaflet;

--- a/modules/apps/map/map-openstreetmap/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/map/map-openstreetmap/src/main/resources/META-INF/resources/view.jsp
@@ -30,9 +30,9 @@ name = AUIUtil.getNamespace(liferayPortletRequest, liferayPortletResponse) + nam
 <liferay-util:html-top
 	outputKey="js_maps_openstreet_skip_loading"
 >
-	<link href="https://npmcdn.com/leaflet@1.2.0/dist/leaflet.css" rel="stylesheet" />
+	<link href="https://npmcdn.com/leaflet@1.7.1/dist/leaflet.css" rel="stylesheet" />
 
-	<script src="https://npmcdn.com/leaflet@1.2.0/dist/leaflet.js" type="text/javascript"></script>
+	<script src="https://npmcdn.com/leaflet@1.7.1/dist/leaflet.js" type="text/javascript"></script>
 </liferay-util:html-top>
 
 <aui:script require="<%= bootstrapRequire %>">

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -1671,7 +1671,7 @@
     liferay-npm-bundler-plugin-namespace-packages "2.24.2"
     liferay-npm-bundler-plugin-replace-browser-modules "2.24.2"
     liferay-npm-bundler-plugin-resolve-linked-dependencies "2.24.2"
-    liferay-theme-tasks "10.3.0"
+    liferay-theme-tasks "10.4.0"
     metal-tools-soy "4.3.2"
     mini-css-extract-plugin "0.11.2"
     minimist "^1.2.0"
@@ -9504,10 +9504,10 @@ lead@^1.0.0:
   dependencies:
     flush-write-stream "^1.0.2"
 
-leaflet@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/leaflet/-/leaflet-1.2.0.tgz#fd5d93d9cb00091f5f8a69206d0d6744c1c82697"
-  integrity sha512-Bold8phAE6WcRsuwhofrQ7cOK1REFHaYIkKuj7+TBYK3ONKRpGGIb5oXR5akYotFnrWN0TWKh6Svlhflm3dogg==
+leaflet@1.7.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/leaflet/-/leaflet-1.7.1.tgz#10d684916edfe1bf41d688a3b97127c0322a2a19"
+  integrity sha512-/xwPEBidtg69Q3HlqPdU3DnrXQOvQU/CCHA1tcDQVzOwm91YMYaILjNp7L4Eaw5Z4sOYdbBz6koWyibppd8Zqw==
 
 less@1.4.1:
   version "1.4.1"


### PR DESCRIPTION
LPS-133385 Upgrade leaflet library from 1.2.0 to the latest version 1.7.1 because there are major fixes related to accessibility that our client needs, please check link https://github.com/Leaflet/Leaflet/issues?q=is%3Aopen+is%3Aissue+label%3Aaccessibility

While testing, I discover https://issues.liferay.com/browse/LPS-133544 is happening with the actual version leaflet 1.2.0 on master only

Not sure if this is for Forms team or should go to Data Engine or Echo 