### PR TITLE
LPS-135419 The decimal separator is not aligned on the sidebar when using google chrome

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/NumericInputMask/NumericInputMask.tsx
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/NumericInputMask/NumericInputMask.tsx
@@ -120,8 +120,8 @@ const NumericInputMask: React.FC<IProps> = ({
 
 	return (
 		<>
-			<div className="position-relative row">
-				<div className="col-ddm col-md-6">
+			<div className="align-items-end d-flex position-relative">
+				<div className="pr-2 w-50">
 					<Select
 
 						// @ts-ignore
@@ -149,7 +149,7 @@ const NumericInputMask: React.FC<IProps> = ({
 						visible={visible}
 					/>
 				</div>
-				<div className="col-ddm col-md-6">
+				<div className="pl-2 w-50">
 					<Select
 
 						// @ts-ignore


### PR DESCRIPTION
Hi reviewer, the related issue [is here](https://issues.liferay.com/browse/LPS-135419).

I needed to revert [this commit](https://github.com/liferay-forms/liferay-portal/commit/e425fc4595eb1658868047361ff95607e18a6d16) for the feature to be visible.