### PR TITLE
LPS-136094 Create standard types and variables on global scope

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Numeric/Numeric.tsx
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Numeric/Numeric.tsx
@@ -153,7 +153,7 @@ const Numeric: React.FC<IProps> = ({
 	value,
 	...otherProps
 }) => {
-	const {editingLanguageId} = useFormState();
+	const {editingLanguageId}: {editingLanguageId: Locale} = useFormState();
 	const symbols = useMemo<ISymbols>(() => {
 		return inputMask
 			? {
@@ -259,9 +259,6 @@ const Numeric: React.FC<IProps> = ({
 			readOnly={readOnly}
 		>
 			<ClayInput
-
-				// @ts-ignore
-
 				dir={Liferay.Language.direction[editingLanguageId]}
 				disabled={readOnly}
 				id={id}
@@ -304,11 +301,11 @@ interface IProps {
 	append: string;
 	appendType: 'prefix' | 'suffix';
 	dataType: NumericDataType;
-	defaultLanguageId: string;
+	defaultLanguageId: Locale;
 	id: string;
 	inputMask?: boolean;
 	inputMaskFormat?: string;
-	localizedValue?: {[key: string]: string};
+	localizedValue?: LocalizedValue<string>;
 	name: string;
 	onBlur: FocusEventHandler<HTMLInputElement>;
 	onChange: (event: {target: {value: string}}) => void;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/NumericInputMask/NumericInputMask.tsx
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/NumericInputMask/NumericInputMask.tsx
@@ -123,9 +123,6 @@ const NumericInputMask: React.FC<IProps> = ({
 			<div className="align-items-end d-flex position-relative">
 				<div className="pr-2 w-50">
 					<Select
-
-						// @ts-ignore
-
 						label={Liferay.Language.get('thousands-separator')}
 						name="thousandsSeparator"
 						onBlur={onBlur}
@@ -139,9 +136,6 @@ const NumericInputMask: React.FC<IProps> = ({
 						}}
 						onFocus={onFocus}
 						options={thousandsSeparators}
-
-						// @ts-ignore
-
 						placeholder={Liferay.Language.get('choose-an-option')}
 						readOnly={readOnly}
 						showEmptyOption={false}
@@ -151,9 +145,6 @@ const NumericInputMask: React.FC<IProps> = ({
 				</div>
 				<div className="pl-2 w-50">
 					<Select
-
-						// @ts-ignore
-
 						label={Liferay.Language.get('decimal-separator')}
 						name="decimalSymbol"
 						onBlur={onBlur}
@@ -171,9 +162,6 @@ const NumericInputMask: React.FC<IProps> = ({
 						}}
 						onFocus={onFocus}
 						options={decimalSymbols}
-
-						// @ts-ignore
-
 						placeholder={Liferay.Language.get('choose-an-option')}
 						readOnly={readOnly}
 						showEmptyOption={false}
@@ -183,9 +171,6 @@ const NumericInputMask: React.FC<IProps> = ({
 				</div>
 			</div>
 			<Text
-
-				// @ts-ignore
-
 				label={Liferay.Language.get('prefix-or-suffix')}
 				name="append"
 				onBlur={onBlur}
@@ -195,17 +180,11 @@ const NumericInputMask: React.FC<IProps> = ({
 					setAppend(event.target.value);
 				}}
 				onFocus={onFocus}
-
-				// @ts-ignore
-
 				placeholder={Liferay.Language.get(
 					'input-mask-append-placeholder'
 				)}
 				readOnly={readOnly}
 				required={false}
-
-				// @ts-ignore
-
 				tip={Liferay.Language.get(
 					'the-maximum-length-is-10-characters'
 				)}
@@ -225,16 +204,10 @@ const NumericInputMask: React.FC<IProps> = ({
 					onFocus={onFocus}
 					options={[
 						{
-
-							// @ts-ignore
-
 							label: Liferay.Language.get('prefix'),
 							value: 'prefix',
 						},
 						{
-
-							// @ts-ignore
-
 							label: Liferay.Language.get('suffix'),
 							value: 'suffix',
 						},

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/index.ts
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/index.ts
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+// @ts-ignore
+
+export {FieldBase as ReactFieldBase} from './FieldBase/ReactFieldBase.es';
+
+// @ts-ignore
+
+export {default as FieldBase} from './FieldBase/FieldBase.es';
+
+declare global {
+
+	// Global Types
+
+	type Direction = 'ltr' | 'rtl';
+
+	type Locale =
+		| 'ar_SA'
+		| 'ca_ES'
+		| 'de_DE'
+		| 'en_US'
+		| 'es_ES'
+		| 'fi_FI'
+		| 'fr_FR'
+		| 'hu_HU'
+		| 'nl_NL'
+		| 'ja_JP'
+		| 'pt_BR'
+		| 'sv_SE'
+		| 'zh_CN';
+
+	type LocalizedTextKey =
+		| 'choose-an-option'
+		| 'decimal-separator'
+		| 'input-mask-append-placeholder'
+		| 'prefix'
+		| 'prefix-or-suffix'
+		| 'suffix'
+		| 'the-maximum-length-is-10-characters'
+		| 'thousands-separator';
+
+	type LocalizedValue<T> = {[key in Locale]?: T};
+
+	// Global Variables
+
+	const Liferay: {
+		Language: {
+			direction: LocalizedValue<Direction>;
+			get: (key: LocalizedTextKey) => string;
+		};
+	};
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/types/src/main/resources/META-INF/resources/Numeric/Numeric.d.ts
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/types/src/main/resources/META-INF/resources/Numeric/Numeric.d.ts
@@ -22,13 +22,11 @@ interface IProps {
 	append: string;
 	appendType: 'prefix' | 'suffix';
 	dataType: NumericDataType;
-	defaultLanguageId: string;
+	defaultLanguageId: Locale;
 	id: string;
 	inputMask?: boolean;
 	inputMaskFormat?: string;
-	localizedValue?: {
-		[key: string]: string;
-	};
+	localizedValue?: LocalizedValue<string>;
 	name: string;
 	onBlur: FocusEventHandler<HTMLInputElement>;
 	onChange: (event: {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/types/src/main/resources/META-INF/resources/index.d.ts
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/types/src/main/resources/META-INF/resources/index.d.ts
@@ -14,3 +14,38 @@
 
 export {FieldBase as ReactFieldBase} from './FieldBase/ReactFieldBase.es';
 export {default as FieldBase} from './FieldBase/FieldBase.es';
+declare global {
+	type Direction = 'ltr' | 'rtl';
+	type Locale =
+		| 'ar_SA'
+		| 'ca_ES'
+		| 'de_DE'
+		| 'en_US'
+		| 'es_ES'
+		| 'fi_FI'
+		| 'fr_FR'
+		| 'hu_HU'
+		| 'nl_NL'
+		| 'ja_JP'
+		| 'pt_BR'
+		| 'sv_SE'
+		| 'zh_CN';
+	type LocalizedTextKey =
+		| 'choose-an-option'
+		| 'decimal-separator'
+		| 'input-mask-append-placeholder'
+		| 'prefix'
+		| 'prefix-or-suffix'
+		| 'suffix'
+		| 'the-maximum-length-is-10-characters'
+		| 'thousands-separator';
+	type LocalizedValue<T> = {
+		[key in Locale]?: T;
+	};
+	const Liferay: {
+		Language: {
+			direction: LocalizedValue<Direction>;
+			get: (key: LocalizedTextKey) => string;
+		};
+	};
+}


### PR DESCRIPTION
**Ticket**: [LPS-136094](https://issues.liferay.com/browse/LPS-136094)

### Description 
- Create standard types and variables on global scope in order to avoid code repetition and also avoid ignoring things on TypeScript (the use of `// @ts-ignore`).