### PR TITLE
LPS-30938

### DIFF
--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/resources/resource-actions/default.xml
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/resources/resource-actions/default.xml
@@ -40,12 +40,8 @@
 				<action-key>UPDATE</action-key>
 				<action-key>VIEW</action-key>
 			</supports>
-			<site-member-defaults>
-				<action-key>VIEW</action-key>
-			</site-member-defaults>
-			<guest-defaults>
-				<action-key>VIEW</action-key>
-			</guest-defaults>
+			<site-member-defaults />
+			<guest-defaults />
 			<guest-unsupported>
 				<action-key>UPDATE</action-key>
 			</guest-unsupported>
@@ -68,12 +64,8 @@
 				<action-key>UPDATE</action-key>
 				<action-key>VIEW</action-key>
 			</supports>
-			<site-member-defaults>
-				<action-key>VIEW</action-key>
-			</site-member-defaults>
-			<guest-defaults>
-				<action-key>VIEW</action-key>
-			</guest-defaults>
+			<site-member-defaults />
+			<guest-defaults />
 			<guest-unsupported>
 				<action-key>UPDATE</action-key>
 			</guest-unsupported>
@@ -96,12 +88,8 @@
 				<action-key>UPDATE</action-key>
 				<action-key>VIEW</action-key>
 			</supports>
-			<site-member-defaults>
-				<action-key>VIEW</action-key>
-			</site-member-defaults>
-			<guest-defaults>
-				<action-key>VIEW</action-key>
-			</guest-defaults>
+			<site-member-defaults />
+			<guest-defaults />
 			<guest-unsupported>
 				<action-key>UPDATE</action-key>
 			</guest-unsupported>

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/helper/DDLRecordSetTestHelper.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/helper/DDLRecordSetTestHelper.java
@@ -99,7 +99,7 @@ public class DDLRecordSetTestHelper {
 			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 	}
 
-	private final long _userId;
 	private final Group _group;
+	private final long _userId;
 
 }

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/helper/DDLRecordSetTestHelper.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/helper/DDLRecordSetTestHelper.java
@@ -38,6 +38,13 @@ import com.liferay.portal.kernel.util.PortalUtil;
 public class DDLRecordSetTestHelper {
 
 	public DDLRecordSetTestHelper(Group group) throws Exception {
+		_userId = TestPropsValues.getUserId();
+
+		_group = group;
+	}
+
+	public DDLRecordSetTestHelper(long userId, Group group) throws Exception {
+		_userId = userId;
 		_group = group;
 	}
 
@@ -63,8 +70,7 @@ public class DDLRecordSetTestHelper {
 		throws Exception {
 
 		return DDLRecordSetLocalServiceUtil.addRecordSet(
-			TestPropsValues.getUserId(), _group.getGroupId(),
-			ddmStructure.getStructureId(), null,
+			_userId, _group.getGroupId(), ddmStructure.getStructureId(), null,
 			HashMapBuilder.put(
 				LocaleUtil.US, RandomTestUtil.randomString()
 			).build(),
@@ -93,6 +99,7 @@ public class DDLRecordSetTestHelper {
 			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 	}
 
+	private final long _userId;
 	private final Group _group;
 
 }

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/helper/DDLRecordTestHelper.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/helper/DDLRecordTestHelper.java
@@ -125,8 +125,8 @@ public class DDLRecordTestHelper {
 		return ddmStructure.getDDMForm();
 	}
 
-	private final long _userId;
 	private final Group _group;
 	private final DDLRecordSet _recordSet;
+	private final long _userId;
 
 }

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/helper/DDLRecordTestHelper.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/helper/DDLRecordTestHelper.java
@@ -40,6 +40,16 @@ public class DDLRecordTestHelper {
 	public DDLRecordTestHelper(Group group, DDLRecordSet recordSet)
 		throws Exception {
 
+		_userId = TestPropsValues.getUserId();
+
+		_group = group;
+		_recordSet = recordSet;
+	}
+
+	public DDLRecordTestHelper(long userId, Group group, DDLRecordSet recordSet)
+		throws Exception {
+
+		_userId = userId;
 		_group = group;
 		_recordSet = recordSet;
 	}
@@ -72,8 +82,7 @@ public class DDLRecordTestHelper {
 		throws Exception {
 
 		return DDLRecordLocalServiceUtil.addRecord(
-			TestPropsValues.getUserId(), _group.getGroupId(),
-			_recordSet.getRecordSetId(),
+			_userId, _group.getGroupId(), _recordSet.getRecordSetId(),
 			DDLRecordConstants.DISPLAY_INDEX_DEFAULT, ddmFormValues,
 			DDLRecordTestUtil.getServiceContext(workflowAction));
 	}
@@ -92,8 +101,8 @@ public class DDLRecordTestHelper {
 		throws Exception {
 
 		return DDLRecordLocalServiceUtil.updateRecord(
-			TestPropsValues.getUserId(), recordId, majorVersion, displayIndex,
-			ddmFormValues, DDLRecordTestUtil.getServiceContext(workflowAction));
+			_userId, recordId, majorVersion, displayIndex, ddmFormValues,
+			DDLRecordTestUtil.getServiceContext(workflowAction));
 	}
 
 	protected DDMFormFieldValue createLocalizedDDMFormFieldValue(
@@ -116,6 +125,7 @@ public class DDLRecordTestHelper {
 		return ddmStructure.getDDMForm();
 	}
 
+	private final long _userId;
 	private final Group _group;
 	private final DDLRecordSet _recordSet;
 

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/search/test/DDLRecordSearchTest.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/search/test/DDLRecordSearchTest.java
@@ -87,7 +87,8 @@ public class DDLRecordSearchTest {
 
 		DDLRecordSet recordSet = addRecordSet();
 
-		_recordTestHelper = new DDLRecordTestHelper(_group, recordSet);
+		_recordTestHelper = new DDLRecordTestHelper(
+			_user.getUserId(), _group, recordSet);
 		_searchContext = getSearchContext(_group, _user, recordSet);
 	}
 
@@ -193,16 +194,17 @@ public class DDLRecordSearchTest {
 
 		User user = UserLocalServiceUtil.getDefaultUser(companyId);
 
+		long userId = user.getUserId();
+
 		Group group = GroupTestUtil.addGroup(
-			companyId, user.getUserId(),
-			GroupConstants.DEFAULT_PARENT_GROUP_ID);
+			companyId, userId, GroupConstants.DEFAULT_PARENT_GROUP_ID);
 
 		DDLRecordSetTestHelper recordSetTestHelper = new DDLRecordSetTestHelper(
-			group);
+			userId, group);
 
 		DDMStructureTestHelper ddmStructureTestHelper =
 			new DDMStructureTestHelper(
-				PortalUtil.getClassNameId(DDLRecordSet.class), group);
+				userId, PortalUtil.getClassNameId(DDLRecordSet.class), group);
 
 		Set<Locale> locales = DDMFormTestUtil.createAvailableLocales(
 			new Locale[] {LocaleUtil.US, LocaleUtil.JAPAN});
@@ -247,7 +249,7 @@ public class DDLRecordSearchTest {
 			ddmFormValues, WorkflowConstants.ACTION_PUBLISH);
 
 		DDLRecordTestHelper recordTestHelper = new DDLRecordTestHelper(
-			group, recordSet);
+			userId, group, recordSet);
 
 		recordTestHelper.addRecord(
 			ddmFormValues, WorkflowConstants.ACTION_PUBLISH);
@@ -414,10 +416,11 @@ public class DDLRecordSearchTest {
 
 	protected DDLRecordSet addRecordSet() throws Exception {
 		DDLRecordSetTestHelper recordSetTestHelper = new DDLRecordSetTestHelper(
-			_group);
+			_user.getUserId(), _group);
 
 		DDMStructureTestHelper ddmStructureTestHelper =
 			new DDMStructureTestHelper(
+				_user.getUserId(),
 				PortalUtil.getClassNameId(DDLRecordSet.class), _group);
 
 		DDMStructure ddmStructure = ddmStructureTestHelper.addStructure(

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/search/test/DDLRecordSearchTest.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/search/test/DDLRecordSearchTest.java
@@ -146,7 +146,7 @@ public class DDLRecordSearchTest {
 
 		Hits hits = DDLRecordLocalServiceUtil.search(searchContext);
 
-		Assert.assertEquals(hits.toString(), 1, hits.getLength());
+		Assert.assertEquals(hits.toString(), 0, hits.getLength());
 	}
 
 	@Test

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/resource-actions/default.xml
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/resource-actions/default.xml
@@ -84,12 +84,8 @@
 				<action-key>UPDATE</action-key>
 				<action-key>VIEW</action-key>
 			</supports>
-			<site-member-defaults>
-				<action-key>VIEW</action-key>
-			</site-member-defaults>
-			<guest-defaults>
-				<action-key>VIEW</action-key>
-			</guest-defaults>
+			<site-member-defaults />
+			<guest-defaults />
 			<guest-unsupported>
 				<action-key>UPDATE</action-key>
 			</guest-unsupported>
@@ -108,12 +104,8 @@
 				<action-key>UPDATE</action-key>
 				<action-key>VIEW</action-key>
 			</supports>
-			<site-member-defaults>
-				<action-key>VIEW</action-key>
-			</site-member-defaults>
-			<guest-defaults>
-				<action-key>VIEW</action-key>
-			</guest-defaults>
+			<site-member-defaults />
+			<guest-defaults />
 			<guest-unsupported>
 				<action-key>UPDATE</action-key>
 			</guest-unsupported>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/resource-actions/default.xml
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/resource-actions/default.xml
@@ -62,9 +62,7 @@
 				<action-key>UPDATE</action-key>
 				<action-key>VIEW</action-key>
 			</supports>
-			<site-member-defaults>
-				<action-key>VIEW</action-key>
-			</site-member-defaults>
+			<site-member-defaults />
 			<guest-defaults />
 			<guest-unsupported>
 				<action-key>DELETE</action-key>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test-util/bnd.bnd
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test-util/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Dynamic Data Mapping Test Utilities
 Bundle-SymbolicName: com.liferay.dynamic.data.mapping.test.util
-Bundle-Version: 7.0.2
+Bundle-Version: 7.1.0
 Export-Package:\
 	com.liferay.dynamic.data.mapping.test.util,\
 	com.liferay.dynamic.data.mapping.test.util.search,\

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test-util/src/main/java/com/liferay/dynamic/data/mapping/test/util/DDMStructureTestHelper.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test-util/src/main/java/com/liferay/dynamic/data/mapping/test/util/DDMStructureTestHelper.java
@@ -51,6 +51,16 @@ public class DDMStructureTestHelper {
 	public DDMStructureTestHelper(long classNameId, Group group)
 		throws Exception {
 
+		_userId = TestPropsValues.getUserId();
+
+		_classNameId = classNameId;
+		_group = group;
+	}
+
+	public DDMStructureTestHelper(long userId, long classNameId, Group group)
+		throws Exception {
+
+		_userId = userId;
 		_classNameId = classNameId;
 		_group = group;
 	}
@@ -86,8 +96,8 @@ public class DDMStructureTestHelper {
 		serviceContext.setAttribute("status", status);
 
 		return DDMStructureLocalServiceUtil.addStructure(
-			TestPropsValues.getUserId(), group.getGroupId(), parentStructureId,
-			classNameId, structureKey, getDefaultLocaleMap(name),
+			_userId, group.getGroupId(), parentStructureId, classNameId,
+			structureKey, getDefaultLocaleMap(name),
 			getDefaultLocaleMap(description), ddmForm, ddmFormLayout,
 			storageType, type, serviceContext);
 	}
@@ -135,7 +145,7 @@ public class DDMStructureTestHelper {
 		throws Exception {
 
 		return DDMStructureLocalServiceUtil.addStructure(
-			TestPropsValues.getUserId(), _group.getGroupId(),
+			_userId, _group.getGroupId(),
 			DDMStructureConstants.DEFAULT_PARENT_STRUCTURE_ID, classNameId,
 			structureKey, getDefaultLocaleMap(name),
 			getDefaultLocaleMap(StringPool.BLANK), definition, storageType,
@@ -165,7 +175,7 @@ public class DDMStructureTestHelper {
 		throws Exception {
 
 		return DDMStructureLocalServiceUtil.updateStructure(
-			TestPropsValues.getUserId(), structureId,
+			_userId, structureId,
 			DDMStructureConstants.DEFAULT_PARENT_STRUCTURE_ID,
 			getDefaultLocaleMap(name), getDefaultLocaleMap(description),
 			ddmForm, ddmFormLayout,
@@ -174,5 +184,6 @@ public class DDMStructureTestHelper {
 
 	private final long _classNameId;
 	private final Group _group;
+	private final long _userId;
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test-util/src/main/resources/com/liferay/dynamic/data/mapping/test/util/packageinfo
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test-util/src/main/resources/com/liferay/dynamic/data/mapping/test/util/packageinfo
@@ -1,1 +1,1 @@
-version 2.2.0
+version 2.3.0

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/search/test/DDMFormInstanceRecordSearchTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/search/test/DDMFormInstanceRecordSearchTest.java
@@ -114,7 +114,7 @@ public class DDMFormInstanceRecordSearchTest {
 		_searchContext.setKeywords("Simple description");
 		_searchContext.setUserId(user.getUserId());
 
-		assertSearch("description", 1);
+		assertSearch("description", 0);
 	}
 
 	@Test

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/test/DDMStructureLocalServiceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/test/DDMStructureLocalServiceTest.java
@@ -717,9 +717,7 @@ public class DDMStructureLocalServiceTest extends BaseDDMServiceTestCase {
 			QueryUtil.ALL_POS, QueryUtil.ALL_POS,
 			new StructureIdComparator(true));
 
-		Assert.assertEquals(structures.toString(), 1, structures.size());
-		Assert.assertEquals(
-			"Global Structure", getStructureName(structures.get(0)));
+		Assert.assertEquals(structures.toString(), 0, structures.size());
 
 		PermissionThreadLocal.setPermissionChecker(originalPermissionChecker);
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/test/DDMStructureServiceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/test/DDMStructureServiceTest.java
@@ -390,7 +390,7 @@ public class DDMStructureServiceTest extends BaseDDMServiceTestCase {
 			StringPool.BLANK, WorkflowConstants.STATUS_ANY, QueryUtil.ALL_POS,
 			QueryUtil.ALL_POS, null);
 
-		Assert.assertEquals(structures.toString(), 1, structures.size());
+		Assert.assertEquals(structures.toString(), 0, structures.size());
 	}
 
 	@Rule


### PR DESCRIPTION
- LPS-30938 Do not provide VIEW permission to Site Members in Forms by default
- LPS-30938 Do not provide VIEW permission to Guests and Site Members in DDMStructures and DDMTemplates by default
- LPS-30938 Do not provide VIEW permission to Guests and Site Members in DDL and its Definitions by default
- LPS-30938 Allow the DDMStructureTestHelper manipulate Structures considering the userId
- LPS-30938 Baseline
- LPS-30938 Allow the DDLRecordSetTestHelper manipulate Record Sets considering the userId
- LPS-30938 Allow the DDLRecordTestHelper manipulate Records considering the userId
- LPS-30938 Initialize Test Helpers using userId
- LPS-30938 Update search tests which won't find the searched resources due to the lack of VIEW permission
- LPS-30938 Auto SF
