### PR TITLE
[Technical Support] LPS-137356 Data provider timeout change does not take effect

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-impl/src/main/java/com/liferay/dynamic/data/mapping/data/provider/internal/DDMDataProviderInvokeCommand.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-impl/src/main/java/com/liferay/dynamic/data/mapping/data/provider/internal/DDMDataProviderInvokeCommand.java
@@ -26,6 +26,8 @@ import com.netflix.hystrix.HystrixCommand;
 import com.netflix.hystrix.HystrixCommandGroupKey;
 import com.netflix.hystrix.HystrixCommandKey;
 import com.netflix.hystrix.HystrixCommandProperties;
+import com.netflix.hystrix.strategy.HystrixPlugins;
+import com.netflix.hystrix.strategy.properties.HystrixPropertiesStrategy;
 
 /**
  * @author Marcellus Tavares
@@ -85,6 +87,22 @@ public class DDMDataProviderInvokeCommand
 	private static final HystrixCommandGroupKey _hystrixCommandGroupKey =
 		HystrixCommandGroupKey.Factory.asKey(
 			"DDMDataProviderInvokeCommandGroup");
+
+	static {
+		HystrixPlugins histrixPlugins = HystrixPlugins.getInstance();
+
+		histrixPlugins.registerPropertiesStrategy(
+			new HystrixPropertiesStrategy() {
+
+				public String getCommandPropertiesCacheKey(
+					HystrixCommandKey commandKey,
+					HystrixCommandProperties.Setter builder) {
+
+					return null;
+				}
+
+			});
+	}
 
 	private final DDMDataProvider _ddmDataProvider;
 	private final DDMDataProviderRequest _ddmDataProviderRequest;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-impl/src/test/java/com/liferay/dynamic/data/mapping/data/provider/internal/DDMDataProviderInvokerImplTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-impl/src/test/java/com/liferay/dynamic/data/mapping/data/provider/internal/DDMDataProviderInvokerImplTest.java
@@ -599,9 +599,9 @@ public class DDMDataProviderInvokerImplTest extends PowerMockito {
 	}
 
 	private int _getExecutionTimeoutInMilliseconds(
-		DDMDataProviderInvokeCommand command1) {
+		DDMDataProviderInvokeCommand command) {
 
-		HystrixCommandProperties properties = command1.getProperties();
+		HystrixCommandProperties properties = command.getProperties();
 
 		HystrixProperty<Integer> executionTimeoutInMilliseconds =
 			properties.executionTimeoutInMilliseconds();

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-impl/src/test/java/com/liferay/dynamic/data/mapping/data/provider/internal/DDMDataProviderInvokerImplTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-impl/src/test/java/com/liferay/dynamic/data/mapping/data/provider/internal/DDMDataProviderInvokerImplTest.java
@@ -494,31 +494,29 @@ public class DDMDataProviderInvokerImplTest extends PowerMockito {
 
 		DDMDataProviderRequest ddmDataProviderRequest = builder.build();
 
-		int timeout1 = 10000;
+		int timeout = 10000;
 
-		DDMDataProviderInvokeCommand command1 =
-			new DDMDataProviderInvokeCommand(
-				"ddmDataProviderInstanceName", ddmDataProvider,
-				ddmDataProviderRequest,
-				_createDDMRESTDataProviderSettingsWithTimeout(timeout1));
+		DDMDataProviderInvokeCommand command = new DDMDataProviderInvokeCommand(
+			"ddmDataProviderInstanceName", ddmDataProvider,
+			ddmDataProviderRequest,
+			_createDDMRESTDataProviderSettingsWithTimeout(timeout));
 
-		int executionTimeoutInMilliseconds1 =
-			_getExecutionTimeoutInMilliseconds(command1);
+		int executionTimeoutInMilliseconds = _getExecutionTimeoutInMilliseconds(
+			command);
 
-		Assert.assertEquals(timeout1, executionTimeoutInMilliseconds1);
+		Assert.assertEquals(timeout, executionTimeoutInMilliseconds);
 
-		int timeout2 = 15000;
+		timeout = 15000;
 
-		DDMDataProviderInvokeCommand command2 =
-			new DDMDataProviderInvokeCommand(
-				"ddmDataProviderInstanceName", ddmDataProvider,
-				ddmDataProviderRequest,
-				_createDDMRESTDataProviderSettingsWithTimeout(timeout2));
+		command = new DDMDataProviderInvokeCommand(
+			"ddmDataProviderInstanceName", ddmDataProvider,
+			ddmDataProviderRequest,
+			_createDDMRESTDataProviderSettingsWithTimeout(timeout));
 
-		int executionTimeoutInMilliseconds2 =
-			_getExecutionTimeoutInMilliseconds(command2);
+		executionTimeoutInMilliseconds = _getExecutionTimeoutInMilliseconds(
+			command);
 
-		Assert.assertEquals(timeout2, executionTimeoutInMilliseconds2);
+		Assert.assertEquals(timeout, executionTimeoutInMilliseconds);
 	}
 
 	@Test

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-impl/src/test/java/com/liferay/dynamic/data/mapping/data/provider/internal/DDMDataProviderInvokerImplTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-impl/src/test/java/com/liferay/dynamic/data/mapping/data/provider/internal/DDMDataProviderInvokerImplTest.java
@@ -599,12 +599,13 @@ public class DDMDataProviderInvokerImplTest extends PowerMockito {
 	}
 
 	private int _getExecutionTimeoutInMilliseconds(
-		DDMDataProviderInvokeCommand command) {
+		DDMDataProviderInvokeCommand ddmDataProviderInvokeCommand) {
 
-		HystrixCommandProperties properties = command.getProperties();
+		HystrixCommandProperties hystrixCommandProperties =
+			ddmDataProviderInvokeCommand.getProperties();
 
 		HystrixProperty<Integer> executionTimeoutInMilliseconds =
-			properties.executionTimeoutInMilliseconds();
+			hystrixCommandProperties.executionTimeoutInMilliseconds();
 
 		return executionTimeoutInMilliseconds.get();
 	}


### PR DESCRIPTION
Here are the relevant commits:
- LPS-137356 use Hystrix plugin to override default properties strategy
- LPS-137356 add tests

The main idea is to use the Hystrix Plugins functionality to circumvent the default properties strategy, which will cache the property for a given command name, no matter what property setter you pass in the HystrixCommand constructor.

Though we're talking about circumventing a caching mechanism, I believe the impact in performance is minimal (see [relevant code in HystrixPropertiesFactory.java](https://github.com/Netflix/Hystrix/blob/v1.5.11/hystrix-core/src/main/java/com/netflix/hystrix/strategy/properties/HystrixPropertiesFactory.java#L61-L86)). Currently it goes most of the time inside the if block in line 64 then inside the if block in line 66. The proposed changes makes it always use the default properties strategy method getCommandProperties (which is not touched) and only returns a new instance of a HysrtrixCommandProperties object (which is likely to be GCed after the request is completed).