### PR TITLE
LPS-135604 | Master [TS]

### DIFF
--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/components/PageRenderer/DefaultVariant.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/components/PageRenderer/DefaultVariant.es.js
@@ -90,7 +90,7 @@ export const Column = forwardRef(
 						data-field-name={firstField.fieldName}
 					>
 						{column.fields.map((field, index) => {
-							if (viewMode) {
+							if (viewMode && field.type !== 'numeric') {
 								field.predefinedValue = '';
 							}
 

--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/utils/evaluation.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/utils/evaluation.es.js
@@ -103,6 +103,14 @@ export const mergePages = (
 			}
 
 			if (newField.localizable) {
+				if (
+					field.type === 'numeric' &&
+					field.valueChanged &&
+					field.value != field.localizedValue[editingLanguageId]
+				) {
+					sourceField.localizedValue[editingLanguageId] = field.value;
+				}
+
 				newField = {
 					...newField,
 					localizedValue: {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-evaluator-impl/src/main/java/com/liferay/dynamic/data/mapping/form/evaluator/internal/helper/DDMFormEvaluatorRuleHelper.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-evaluator-impl/src/main/java/com/liferay/dynamic/data/mapping/form/evaluator/internal/helper/DDMFormEvaluatorRuleHelper.java
@@ -18,6 +18,8 @@ import com.liferay.dynamic.data.mapping.expression.UpdateFieldPropertyRequest;
 import com.liferay.dynamic.data.mapping.form.evaluator.internal.expression.DDMFormEvaluatorExpressionObserver;
 import com.liferay.dynamic.data.mapping.model.DDMFormField;
 import com.liferay.dynamic.data.mapping.model.DDMFormRule;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.GetterUtil;
 
 import java.util.Collection;
 import java.util.List;
@@ -53,6 +55,33 @@ public class DDMFormEvaluatorRuleHelper {
 		checkFieldAffectedBySetReadOnlyAction(ddmFormRule, ddmFormField);
 		checkFieldAffectedBySetRequiredAction(ddmFormRule, ddmFormField);
 		checkFieldAffectedBySetVisibleAction(ddmFormRule, ddmFormField);
+		checkFieldAffectedByCalculateAction(ddmFormRule, ddmFormField);
+	}
+
+	protected void checkFieldAffectedByCalculateAction(
+		DDMFormRule ddmFormRule, DDMFormField ddmFormField) {
+
+		Map<String, Object> properties = ddmFormField.getProperties();
+
+		if (containsAction(
+				ddmFormRule, "calculate", ddmFormField.getName(),
+				GetterUtil.getString(properties.get("value")))) {
+
+			String value = StringPool.BLANK;
+
+			if (GetterUtil.getString(properties.get("predefinedValue")) !=
+					null) {
+
+				value = GetterUtil.getString(properties.get("predefinedValue"));
+			}
+
+			UpdateFieldPropertyRequest.Builder builder =
+				UpdateFieldPropertyRequest.Builder.newBuilder(
+					ddmFormField.getName(), "value", value);
+
+			_ddmFormEvaluatorExpressionObserver.updateFieldProperty(
+				builder.build());
+		}
 	}
 
 	protected void checkFieldAffectedBySetReadOnlyAction(
@@ -106,9 +135,9 @@ public class DDMFormEvaluatorRuleHelper {
 
 	protected boolean containsAction(
 		DDMFormRule ddmFormRule, String functionName, String ddmFormFieldName,
-		boolean defaultValue) {
+		Object defaultValue) {
 
-		String setBooleanPropertyAction = String.format(
+		String setPropertyAction = String.format(
 			"%s('%s', %s)", functionName, ddmFormFieldName, defaultValue);
 
 		List<String> actions = ddmFormRule.getActions();
@@ -116,7 +145,7 @@ public class DDMFormEvaluatorRuleHelper {
 		Stream<String> stream = actions.stream();
 
 		return stream.anyMatch(
-			action -> Objects.equals(setBooleanPropertyAction, action));
+			action -> Objects.equals(setPropertyAction, action));
 	}
 
 	private final DDMFormEvaluatorExpressionObserver

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-evaluator-impl/src/main/java/com/liferay/dynamic/data/mapping/form/evaluator/internal/helper/DDMFormEvaluatorRuleHelper.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-evaluator-impl/src/main/java/com/liferay/dynamic/data/mapping/form/evaluator/internal/helper/DDMFormEvaluatorRuleHelper.java
@@ -18,11 +18,13 @@ import com.liferay.dynamic.data.mapping.expression.UpdateFieldPropertyRequest;
 import com.liferay.dynamic.data.mapping.form.evaluator.internal.expression.DDMFormEvaluatorExpressionObserver;
 import com.liferay.dynamic.data.mapping.model.DDMFormField;
 import com.liferay.dynamic.data.mapping.model.DDMFormRule;
+import com.liferay.dynamic.data.mapping.model.LocalizedValue;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.GetterUtil;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
@@ -52,32 +54,33 @@ public class DDMFormEvaluatorRuleHelper {
 	protected void checkFieldAffectedByAction(
 		DDMFormRule ddmFormRule, DDMFormField ddmFormField) {
 
+		checkFieldAffectedByCalculateAction(ddmFormRule, ddmFormField);
 		checkFieldAffectedBySetReadOnlyAction(ddmFormRule, ddmFormField);
 		checkFieldAffectedBySetRequiredAction(ddmFormRule, ddmFormField);
 		checkFieldAffectedBySetVisibleAction(ddmFormRule, ddmFormField);
-		checkFieldAffectedByCalculateAction(ddmFormRule, ddmFormField);
 	}
 
 	protected void checkFieldAffectedByCalculateAction(
 		DDMFormRule ddmFormRule, DDMFormField ddmFormField) {
 
-		Map<String, Object> properties = ddmFormField.getProperties();
-
 		if (containsAction(
 				ddmFormRule, "calculate", ddmFormField.getName(),
-				GetterUtil.getString(properties.get("value")))) {
+				GetterUtil.getString(ddmFormField.getProperty("value")))) {
 
-			String value = StringPool.BLANK;
+			String newValue = StringPool.BLANK;
 
-			if (GetterUtil.getString(properties.get("predefinedValue")) !=
-					null) {
+			LocalizedValue predefinedValue = ddmFormField.getPredefinedValue();
 
-				value = GetterUtil.getString(properties.get("predefinedValue"));
+			if (predefinedValue != null) {
+				newValue = GetterUtil.getString(
+					predefinedValue.getString(
+						new Locale(
+							(String)ddmFormField.getProperty("locale"))));
 			}
 
 			UpdateFieldPropertyRequest.Builder builder =
 				UpdateFieldPropertyRequest.Builder.newBuilder(
-					ddmFormField.getName(), "value", value);
+					ddmFormField.getName(), "value", newValue);
 
 			_ddmFormEvaluatorExpressionObserver.updateFieldProperty(
 				builder.build());

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/numeric/NumericDDMFormFieldTemplateContextContributor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/numeric/NumericDDMFormFieldTemplateContextContributor.java
@@ -120,8 +120,9 @@ public class NumericDDMFormFieldTemplateContextContributor
 			"predefinedValue",
 			getFormattedValue(
 				ddmFormFieldRenderingContext, locale,
-				DDMFormFieldTypeUtil.getPredefinedValue(
-					ddmFormField, ddmFormFieldRenderingContext))
+				DDMFormFieldTypeUtil.getPropertyValue(
+					ddmFormField, ddmFormFieldRenderingContext.getLocale(),
+					"predefinedValue"))
 		).put(
 			"requireConfirmation",
 			GetterUtil.getBoolean(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Text/Text.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Text/Text.es.js
@@ -403,7 +403,7 @@ const Main = ({
 				placeholder={placeholder}
 				shouldUpdateValue={shouldUpdateValue}
 				syncDelay={syncDelay}
-				value={value ? value : predefinedValue}
+				value={value ?? predefinedValue}
 			/>
 		</FieldBase>
 	);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/test/java/com/liferay/dynamic/data/mapping/form/field/type/internal/numeric/NumericDDMFormFieldTemplateContextContributorTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/test/java/com/liferay/dynamic/data/mapping/form/field/type/internal/numeric/NumericDDMFormFieldTemplateContextContributorTest.java
@@ -243,6 +243,28 @@ public class NumericDDMFormFieldTemplateContextContributorTest
 	}
 
 	@Test
+	public void testGetPredefinedValue() {
+		DDMFormField ddmFormField = new DDMFormField("field", "numeric");
+
+		ddmFormField.setProperty(
+			"predefinedValue",
+			DDMFormValuesTestUtil.createLocalizedValue("42", _locale));
+
+		DDMFormFieldRenderingContext ddmFormFieldRenderingContext =
+			new DDMFormFieldRenderingContext();
+
+		ddmFormFieldRenderingContext.setLocale(_locale);
+		ddmFormFieldRenderingContext.setViewMode(true);
+
+		Map<String, Object> parameters =
+			_numericDDMFormFieldTemplateContextContributor.getParameters(
+				ddmFormField, ddmFormFieldRenderingContext);
+
+		Assert.assertEquals(
+			"42", String.valueOf(parameters.get("predefinedValue")));
+	}
+
+	@Test
 	public void testGetSymbols() {
 		Map<String, String> symbolsMap =
 			_numericDDMFormFieldTemplateContextContributor.getSymbolsMap(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/java/com/liferay/dynamic/data/mapping/form/renderer/internal/DDMFormFieldTemplateContextFactory.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/java/com/liferay/dynamic/data/mapping/form/renderer/internal/DDMFormFieldTemplateContextFactory.java
@@ -724,7 +724,7 @@ public class DDMFormFieldTemplateContextFactory {
 		Map<String, Object> changedProperties,
 		Map<String, Object> ddmFormFieldTemplateContext, Value value) {
 
-		if (Validator.isNotNull(changedProperties.get("value"))) {
+		if (changedProperties.get("value") != null) {
 			ddmFormFieldTemplateContext.put(
 				"value", changedProperties.get("value"));
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/java/com/liferay/dynamic/data/mapping/form/renderer/internal/servlet/DDMFormTemplateContextProcessor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/java/com/liferay/dynamic/data/mapping/form/renderer/internal/servlet/DDMFormTemplateContextProcessor.java
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Validator;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -127,6 +128,8 @@ public class DDMFormTemplateContextProcessor {
 			jsonObject.getString("numericInputMask"), ddmFormField);
 		setDDMFormFieldOptions(
 			jsonObject.getJSONArray("options"), ddmFormField);
+		setDDMFormFieldPredefinedValue(
+			jsonObject.getString("predefinedValue"), ddmFormField);
 		setDDMFormFieldPlaceholder(
 			jsonObject.getString("placeholder"), ddmFormField);
 		setDDMFormFieldProperty(
@@ -383,6 +386,18 @@ public class DDMFormTemplateContextProcessor {
 		ddmFormField.setProperty(
 			"placeholder",
 			getLocalizedValue(GetterUtil.getString(placeholder)));
+	}
+
+	protected void setDDMFormFieldPredefinedValue(
+		String predefinedValue, DDMFormField ddmFormField) {
+
+		if (Validator.isNull(predefinedValue)) {
+			return;
+		}
+
+		ddmFormField.setProperty(
+			"predefinedValue",
+			getLocalizedValue(GetterUtil.getString(predefinedValue)));
 	}
 
 	protected void setDDMFormFieldProperty(


### PR DESCRIPTION
Click [here](https://issues.liferay.com/browse/LPS-135604) to see the LPS.

The reason to revert some commits:

[LPS-122337](https://issues.liferay.com/browse/LPS-122337) was not considering empty values with LPS changes, so the field was not getting the correct value.

[LPS-129665](https://issues.liferay.com/browse/LPS-129665) wasn't working with the predefined value as it should. The predefined value shouldn't be deleted from the field properties. The steps to reproduce of this LPS says that the expected result is that the predefined value should be displayed, but once the predefined value isn't seemed in the form while submitting, they shouldn't be displayed too.

Thank you.

Last PR was #793 and #764