### PR TITLE
[TECHNICAL-SUPPORT] LPS-136626

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -3168,6 +3168,14 @@ AUI.add(
 					}
 				},
 
+				getAltRuleInputName() {
+					var instance = this;
+
+					var inputName = instance.getInputName();
+
+					return inputName + 'Alt';
+				},
+
 				getDocumentLibrarySelectorURL() {
 					var instance = this;
 
@@ -3844,6 +3852,19 @@ AUI.add(
 								validatorRules[
 									field.getRuleInputName()
 								] = originalFieldRules;
+							}
+
+							if (field.get('dataType') === 'image') {
+								var originalAltRuleInputName = originalField.getAltRuleInputName();
+
+								originalFieldRules =
+									validatorRules[originalAltRuleInputName];
+
+								if (originalFieldRules) {
+									validatorRules[
+										field.getAltRuleInputName()
+									] = originalFieldRules;
+								}
 							}
 						}
 						else if (event.type === 'liferay-ddm-field:remove') {


### PR DESCRIPTION
Related Issue: https://issues.liferay.com/browse/LPS-136626

https://issues.liferay.com/browse/LPS-136626

Issue is not reproducible in master, but based on feedback provided on https://github.com/dacousalr/liferay-portal-ee/pull/236, we concluded it would be better to fix the problematic code in master in case it gets invoked in the future. Based on feedback from https://github.com/liferay-data-engine/liferay-portal/pull/580, we're routing it through the forms team.

## Reason for changes

In 7.3.x, the rendering of the image type uses the following call stack:

* [DDMFormRendererUtil](https://github.com/liferay/liferay-portal/blob/7.3.1-ga2/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/render/DDMFormRendererUtil.java) (core method responsible for looking up what renders the image field)
* [DDMFormFieldFreeMarkerRenderer](https://github.com/liferay/liferay-portal/blob/7.3.1-ga2/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/render/DDMFormFieldFreeMarkerRenderer.java) (renderer invoked in order to render the image field)
* [image.ftl](https://github.com/liferay/liferay-portal/blob/7.3.1-ga2/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/com/liferay/dynamic/data/mapping/service/dependencies/ddm/image.ftl) (template responsible for generating the HTML for the image field)

In master, the rendering of the image type uses the following call stack:

* [useResource.es.js](modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/hooks/useResource.es.js) (performs the lookup for different DDM types)
* [ImageDDMFormFieldType](https://github.com/liferay/liferay-portal/blob/master/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/image/ImageDDMFormFieldType.java) (registers the path used for the "image" type)
* [DDMFormFieldTypesServlet](https://github.com/liferay/liferay-portal/blob/master/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/java/com/liferay/dynamic/data/mapping/form/renderer/internal/servlet/DDMFormFieldTypesServlet.java) (describes the different DDM types in response to the resource request)
* [ImagePicker.es.js](https://github.com/liferay/liferay-portal/blob/master/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/ImagePicker/ImagePicker.es.js) (retrieved after the lookup of different DDM types)

This change in behavior occurs due to [LPS-129530](https://issues.liferay.com/browse/LPS-129530), which moves the handling of DDM rendering from ddm-form-renderer to data-engine, which makes it so that the problematic code that was invoked in 7.3.x is no longer invoked in master. However, this is a large scale refactoring that we can't backport to an earlier branch, leading to the need for a unique fix.

## Additional notes from TSEs

The TSEs who originally provided the fix have this to add:

(from @quanhuynhces)
> The issue is not reproducible on master (7.4) because there is a big different between the Image Field of 7.4 version and those ones of older versions (7.3, 7.2, ...). On version 7.4, new image fields show only the sub-field to select the image. After selecting the image, the rest sub-field to fill image description appears. But on the older versions, new image field show all two sub-fields. So to me, I think on the version 7.4 before showing the image description sub-field, it has been validated but not on the older versions because that big different.

(from @HuongNguyen-gs)
> On 7.3.x and 7.2.x the "Image" and "Image description" fields are generated at the same time when we click the "Duplicate" button. ([generatingImageFields](https://github.com/liferay/liferay-portal-ee/blob/7.3.x/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js#L1754-L1760)) . At that time we have 2 elements, one is the image title (identify name ='instance.getInputName() + 'title') another is image description (identify name ='instance.getInputName() + 'alt').
> 
> When duplicating an element we need to apply the rules of the original element to the new element, but in this case, the portal only applies the rules for the image title and forget the image description ([applyRules](https://github.com/liferay/liferay-portal-ee/blob/7.3.x/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js#L1677-L1683)). This is the root cause of this issue.
> 
> On Master, when you click the "Duplicate" button then only the "Image" field appears. The "Image Description" won't be generated until your select your photo. ([masterGenerateImageField](https://github.com/liferay/liferay-portal-ee/blob/master/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/ImagePicker/ImagePicker.es.js#L195-L225)).
> 
> And the "Image description" field has the 'identify name' = {`${name}-description`}. The difference in this is the '**identify name**', it's '**description**' not the '**alt**' anymore ([masterImagedscription](https://github.com/liferay/liferay-portal-ee/blob/master/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/ImagePicker/ImagePicker.es.js#L215)). So if we change the 'identify name' to either of them it may affect other behaviors on the Image element.
> 
> Besides, 7.3.x and 7.2.x used the AUI taglibs but Master used Clay taglibs So it can not bring back the changes from Master to the earlier branchs.
