### PR TITLE
LPS-137917 Since when we delete a DDMFormInstance we are deleting also de DDMStructure, it should not be considered as a Dependent, so remove that code

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/exportimport/data/handler/test/DDMFormInstanceRecordStagedModelDataHandlerTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/exportimport/data/handler/test/DDMFormInstanceRecordStagedModelDataHandlerTest.java
@@ -53,7 +53,6 @@ import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -70,13 +69,6 @@ public class DDMFormInstanceRecordStagedModelDataHandlerTest
 	@Rule
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
-
-	@Ignore
-	@Override
-	@Test
-	public void testCleanStagedModelDataHandler() throws Exception {
-		super.testCleanStagedModelDataHandler();
-	}
 
 	@Test
 	public void testVersionMatchingAfterExportImport() throws Exception {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/exportimport/data/handler/test/DDMFormInstanceRecordStagedModelDataHandlerTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/exportimport/data/handler/test/DDMFormInstanceRecordStagedModelDataHandlerTest.java
@@ -130,10 +130,6 @@ public class DDMFormInstanceRecordStagedModelDataHandlerTest
 		addDependentStagedModel(
 			dependentStagedModelsMap, DDMFormInstance.class, ddmFormInstance);
 
-		addDependentStagedModel(
-			dependentStagedModelsMap, DDMStructure.class,
-			ddmFormInstance.getStructure());
-
 		return dependentStagedModelsMap;
 	}
 
@@ -215,19 +211,6 @@ public class DDMFormInstanceRecordStagedModelDataHandlerTest
 			Map<String, List<StagedModel>> dependentStagedModelsMap,
 			Group group)
 		throws Exception {
-
-		List<StagedModel> ddmStructureDependentStagedModels =
-			dependentStagedModelsMap.get(DDMStructure.class.getSimpleName());
-
-		Assert.assertEquals(
-			ddmStructureDependentStagedModels.toString(), 1,
-			ddmStructureDependentStagedModels.size());
-
-		DDMStructure ddmStructure =
-			(DDMStructure)ddmStructureDependentStagedModels.get(0);
-
-		DDMStructureLocalServiceUtil.getDDMStructureByUuidAndGroupId(
-			ddmStructure.getUuid(), group.getGroupId());
 
 		List<StagedModel> formInstanceDependentStagedModels =
 			dependentStagedModelsMap.get(DDMFormInstance.class.getSimpleName());

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/exportimport/data/handler/test/DDMFormInstanceStagedModelDataHandlerTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/exportimport/data/handler/test/DDMFormInstanceStagedModelDataHandlerTest.java
@@ -34,8 +34,6 @@ import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
@@ -54,13 +52,6 @@ public class DDMFormInstanceStagedModelDataHandlerTest
 
 		_settingsDDMFormValues =
 			DDMFormInstanceTestUtil.createSettingsDDMFormValues();
-	}
-
-	@Ignore
-	@Override
-	@Test
-	public void testCleanStagedModelDataHandler() throws Exception {
-		super.testCleanStagedModelDataHandler();
 	}
 
 	@Override

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/exportimport/data/handler/test/DDMFormInstanceStagedModelDataHandlerTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/exportimport/data/handler/test/DDMFormInstanceStagedModelDataHandlerTest.java
@@ -28,7 +28,6 @@ import com.liferay.portal.kernel.model.StagedModel;
 import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -55,32 +54,13 @@ public class DDMFormInstanceStagedModelDataHandlerTest
 	}
 
 	@Override
-	protected Map<String, List<StagedModel>> addDependentStagedModelsMap(
-			Group group)
-		throws Exception {
-
-		Map<String, List<StagedModel>> dependentStagedModelsMap =
-			new LinkedHashMap<>();
-
-		DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
-			group.getGroupId(), DDMFormInstance.class.getName());
-
-		addDependentStagedModel(
-			dependentStagedModelsMap, DDMStructure.class, ddmStructure);
-
-		return dependentStagedModelsMap;
-	}
-
-	@Override
 	protected StagedModel addStagedModel(
 			Group group,
 			Map<String, List<StagedModel>> dependentStagedModelsMap)
 		throws Exception {
 
-		List<StagedModel> dependentStagedModels = dependentStagedModelsMap.get(
-			DDMStructure.class.getSimpleName());
-
-		DDMStructure ddmStructure = (DDMStructure)dependentStagedModels.get(0);
+		DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
+			group.getGroupId(), DDMFormInstance.class.getName());
 
 		DDMFormInstance ddmFormInstance =
 			DDMFormInstanceTestUtil.addDDMFormInstance(


### PR DESCRIPTION
Hey guys,

Related Issue: https://issues.liferay.com/browse/LPS-137917

I'm sending it to you since the problem seems to be related with the tests. 

After taking a look to the code, I saw that the problem is because when we are calling 

```
public void onAfterRemove(DDMStructure ddmStructure)
		throws ModelListenerException {
```
on **DDMStructureModelListener** the ddmStructure is null, and it should never be null.

It is happening because when we are deleting the DDMFormInstance we are also deleting the DDMStructures on **DDMFormInstanceLocalServiceImpl.deleteFormInstance**, so when we call the method:

```
protected void deleteStagedModel(
			StagedModel stagedModel,
			Map<String, List<StagedModel>> dependentStagedModelsMap,
			Group group)
		throws Exception
```
on **BaseStagedModelDataHandlerTestCase** we are going to delete the DependentStagedModel and in this case we are going to delete the DDMStructure again.

So, we have two options:

1. Update the tests to not add the DDMStructure as DependentStagedModel
2. Don't delete the DDMStructure when we are deleting the DDMFormInstance

I decided to implement the **1** removing the code related with DependentStagedModels in that pull, since I don't know if the relationship between DDMFormInstance and DDMStructure is one to one or not, if we can have the same DDMStructure for multiple DDMFormInstances then the solution should be **2**

Please let me know if you have any question.

Regards,
Eudaldo.