### PR TITLE
LPS-135713 The rich text field has inconsistent behaviour on forms when typing the predefined field

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/RichText/RichText.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/RichText/RichText.es.js
@@ -17,6 +17,21 @@ import React, {useEffect, useRef, useState} from 'react';
 
 import {FieldBase} from '../FieldBase/ReactFieldBase.es';
 
+const getCurrentValue = ({predefinedValue, previousPredefinedValue, value}) => {
+	let currentValue = value;
+
+	if (predefinedValue) {
+		currentValue = predefinedValue;
+
+		previousPredefinedValue.current = predefinedValue;
+	}
+	else if (previousPredefinedValue.current) {
+		currentValue = '';
+	}
+
+	return currentValue;
+};
+
 const RichText = ({
 	editingLanguageId,
 	editorConfig,
@@ -46,7 +61,13 @@ const RichText = ({
 		}
 	}, [editingLanguageId, editorRef]);
 
-	const currentValue = value ?? predefinedValue;
+	const previousPredefinedValue = useRef(predefinedValue);
+
+	const currentValue = getCurrentValue({
+		predefinedValue,
+		previousPredefinedValue,
+		value,
+	});
 
 	return (
 		<FieldBase


### PR DESCRIPTION
Related Issue: https://issues.liferay.com/browse/LPS-135713

Fixes: https://issues.liferay.com/browse/LPS-135713, as a part of https://issues.liferay.com/browse/PTR-2589

@diogosantos @natocesarrego 

This PR fixes one of the `RichText` bugs, the most severe one, where changing predefined value stops updating field (see [attached movie in JIRA](https://issues.liferay.com/secure/attachment/415564/richTextNotWorking.mp4))

The root cause is [this line](https://github.com/liferay/liferay-portal/blob/master/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/RichText/RichText.es.js#L49) in RichText:
```js
const currentValue = value ?? predefinedValue;
```
After `value` is set for the first time, we ignore `predefinedValue` from then on.

In this PR we are fixing the value setting, `predefinedValue` now always overrides `value`. `previousPredefinedValue` is needed for the case when we delete predefined value. Without it, we would set content to the last `value`, which is incorrect. Content should be deleted.

After PR, there are still glitching bugs, but value updating no longer stops:
![after](https://user-images.githubusercontent.com/5435511/131535731-6cf7c838-861e-45b7-868f-cd3b92048fb1.gif)

