### PR TITLE
LRQA-69879

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/test/DDMStructureServiceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/test/DDMStructureServiceTest.java
@@ -23,18 +23,12 @@ import com.liferay.dynamic.data.mapping.storage.StorageType;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.model.ResourceConstants;
-import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
-import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
-import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
-import com.liferay.portal.kernel.service.ResourcePermissionServiceUtil;
-import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
@@ -121,23 +115,9 @@ public class DDMStructureServiceTest extends BaseDDMServiceTestCase {
 			_classNameId, StringUtil.randomString());
 		DDMStructure structure2 = addStructure(
 			_classNameId, StringUtil.randomString());
-		String modelName = ResourceActionsUtil.getCompositeModelName(
-			PortalUtil.getClassName(_classNameId),
-			DDMStructure.class.getName());
 
 		_ddmStructures.add(structure1);
 		_ddmStructures.add(structure2);
-
-		List<Role> roles = RoleLocalServiceUtil.getRoles(
-			TestPropsValues.getCompanyId());
-
-		for (Role role : roles) {
-			ResourcePermissionServiceUtil.removeResourcePermission(
-				structure2.getGroupId(), structure2.getCompanyId(), modelName,
-				ResourceConstants.SCOPE_INDIVIDUAL,
-				String.valueOf(structure2.getPrimaryKey()), role.getRoleId(),
-				ActionKeys.VIEW);
-		}
 
 		long[] groupIds = {group.getGroupId(), _group.getGroupId()};
 
@@ -328,21 +308,6 @@ public class DDMStructureServiceTest extends BaseDDMServiceTestCase {
 
 		_ddmStructures.add(structure);
 
-		String modelName = ResourceActionsUtil.getCompositeModelName(
-			PortalUtil.getClassName(_classNameId),
-			DDMStructure.class.getName());
-
-		List<Role> roles = RoleLocalServiceUtil.getRoles(
-			TestPropsValues.getCompanyId());
-
-		for (Role role : roles) {
-			ResourcePermissionServiceUtil.removeResourcePermission(
-				structure.getGroupId(), structure.getCompanyId(), modelName,
-				ResourceConstants.SCOPE_INDIVIDUAL,
-				String.valueOf(structure.getPrimaryKey()), role.getRoleId(),
-				ActionKeys.VIEW);
-		}
-
 		List<DDMStructure> structures = DDMStructureServiceUtil.search(
 			TestPropsValues.getCompanyId(),
 			new long[] {group.getGroupId(), group.getGroupId()}, _classNameId,
@@ -361,21 +326,6 @@ public class DDMStructureServiceTest extends BaseDDMServiceTestCase {
 			_classNameId, StringUtil.randomString());
 
 		_ddmStructures.add(structure);
-
-		String modelName = ResourceActionsUtil.getCompositeModelName(
-			PortalUtil.getClassName(_classNameId),
-			DDMStructure.class.getName());
-
-		List<Role> roles = RoleLocalServiceUtil.getRoles(
-			TestPropsValues.getCompanyId());
-
-		for (Role role : roles) {
-			ResourcePermissionServiceUtil.removeResourcePermission(
-				structure.getGroupId(), structure.getCompanyId(), modelName,
-				ResourceConstants.SCOPE_INDIVIDUAL,
-				String.valueOf(structure.getPrimaryKey()), role.getRoleId(),
-				ActionKeys.VIEW);
-		}
 
 		long[] groupIds = {group.getGroupId(), group.getGroupId()};
 


### PR DESCRIPTION
Related Issue: https://issues.liferay.com/browse/LRQA-69879

The [LPS-30938](https://issues.liferay.com/browse/LPS-30938) has removed the default VIEW permission of the roles **Site Member** and **Guest**. Therefore, remove the VIEW permission from all roles in the following tests is no more necessary:

- com.liferay.dynamic.data.mapping.service.test.DDMStructureServiceTest.testSearchWithSiteMemberPermission
- com.liferay.dynamic.data.mapping.service.test.DDMStructureServiceTest.testSearchWithSiteAdminPermission
- com.liferay.dynamic.data.mapping.service.test.DDMStructureServiceTest.testGetStructuresWithSiteAdminPermission