### PR TITLE
LRQA-70178

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/FormFields.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/FormFields.macro
@@ -1972,7 +1972,9 @@ definition {
 	}
 
 	macro viewSwitchChecked {
-		FormFields.viewCheckboxChecked(fieldName = "${fieldName}");
+		AssertChecked.assertCheckedNotVisible(
+			key_fieldName = "${fieldName}",
+			locator1 = "FormFields#SWITCH");
 	}
 
 	macro viewSwitchLabel {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/fields/FormsMultipleSelectionField.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/fields/FormsMultipleSelectionField.testcase
@@ -690,7 +690,7 @@ definition {
 
 		FormFields.enableSwitch(fieldName = "Inline");
 
-		FormViewBuilder.validateInlineOptionIsSetOn();
+		FormFields.viewSwitchChecked(fieldName = "Inline");
 
 		Form.save();
 


### PR DESCRIPTION
Related Issue: https://issues.liferay.com/browse/LRQA-70178
This PR fixes:
FormsMultipleSelectionField#OptionsCanBeDisplayedInlineAndAsList
FormsFieldsets#PreserveTheAutoCompleteProperty
FormsFieldsets#PreserveTheMultipleSelectionsProperty