### PR TITLE
LPS-140296 Add EVENT_TYPES.LANGUAGE.UPDATE to language reducer

### DIFF
--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/actions/eventTypes.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/actions/eventTypes.es.js
@@ -63,6 +63,7 @@ const LANGUAGE = {
 	ADD: 'language_add',
 	CHANGE: 'language_change',
 	DELETE: 'language_delete',
+	UPDATE: 'language_update',
 };
 
 export const EVENT_TYPES = {

--- a/modules/apps/data-engine/data-engine-js-components-web/test/js/core/reducers/languageReducer.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/test/js/core/reducers/languageReducer.js
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {EVENT_TYPES} from '../../../../src/main/resources/META-INF/resources/js/core/actions/eventTypes.es';
+import reducer from '../../../../src/main/resources/META-INF/resources/js/core/reducers/languageReducer.es';
+
+describe('core/reducers/languageReducer', () => {
+	describe('EVENT_TYPES.LANGUAGE.UPDATE', () => {
+		it('returns the same state when no language is added or deleted', () => {
+			const state = {availableLanguageIds: ['en_US']};
+
+			const action = {
+				payload: {activeLanguageIds: ['en_US']},
+				type: EVENT_TYPES.LANGUAGE.UPDATE,
+			};
+
+			const newState = reducer(state, action);
+
+			expect(newState).toBe(state);
+		});
+
+		it('adds a language to availableLanguageIds when a language is added', () => {
+			const state = {availableLanguageIds: ['en_US']};
+
+			const activeLanguageIds = ['en_US', 'pt_BR'];
+
+			const action = {
+				payload: {activeLanguageIds},
+				type: EVENT_TYPES.LANGUAGE.UPDATE,
+			};
+
+			const {availableLanguageIds} = reducer(state, action);
+
+			expect(availableLanguageIds).toEqual(['en_US', 'pt_BR']);
+
+			expect(availableLanguageIds).not.toBe(activeLanguageIds);
+		});
+
+		it('deletes a language to availableLanguageIds when a language is deleted', () => {
+			const focusedField = {
+				instanceId: '12345678',
+				localizedValue: {en_US: 'value', pt_BR: 'valor'},
+			};
+			const pages = [
+				{
+					localizedDescription: {
+						en_US: 'description',
+						pt_BR: 'descrição',
+					},
+					localizedTitle: {en_US: 'title', pt_BR: 'título'},
+					rows: [{columns: [{fields: [focusedField]}]}],
+				},
+			];
+			const state = {
+				availableLanguageIds: ['en_US', 'pt_BR'],
+				focusedField,
+				pages,
+			};
+
+			const activeLanguageIds = ['en_US'];
+
+			const action = {
+				payload: {activeLanguageIds},
+				type: EVENT_TYPES.LANGUAGE.UPDATE,
+			};
+
+			const {
+				availableLanguageIds,
+				focusedField: updatedFocusedField,
+				pages: updatedPages,
+			} = reducer(state, action);
+
+			const expectedField = {
+				instanceId: '12345678',
+				localizedValue: {en_US: 'value'},
+			};
+
+			expect(availableLanguageIds).toEqual(['en_US']);
+
+			expect(updatedFocusedField).toEqual(expectedField);
+
+			expect(updatedPages).toEqual([
+				{
+					localizedDescription: {en_US: 'description'},
+					localizedTitle: {en_US: 'title'},
+					rows: [{columns: [{fields: [expectedField]}]}],
+				},
+			]);
+		});
+	});
+});

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/DataEngineTaglibCompatibilityLayer.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/DataEngineTaglibCompatibilityLayer.js
@@ -12,7 +12,14 @@
  * details.
  */
 
-import {useConfig, useForm, useFormState} from 'data-engine-js-components-web';
+import {State} from '@liferay/frontend-js-state-web';
+import {
+	EVENT_TYPES,
+	useConfig,
+	useForm,
+	useFormState,
+} from 'data-engine-js-components-web';
+import {activeLanguageIdsAtom} from 'frontend-js-components-web';
 import {useEffect, useRef} from 'react';
 
 const SYMBOL_INTERNAL = Symbol('data.engine.internal');
@@ -74,6 +81,20 @@ export const DataEngineTaglibCompatibilityLayer = () => {
 			Liferay.destroyComponent(dataLayoutBuilderId);
 		};
 	}, [dataEngineCompatibilityLayerRef, dataLayoutBuilderId]);
+
+	useEffect(() => {
+		const {dispose} = State.subscribe(
+			activeLanguageIdsAtom,
+			(activeLanguageIds) => {
+				dispatch({
+					payload: {activeLanguageIds},
+					type: EVENT_TYPES.LANGUAGE.UPDATE,
+				});
+			}
+		);
+
+		return dispose;
+	}, [dispatch]);
 
 	return null;
 };


### PR DESCRIPTION
Related Issue: https://issues.liferay.com/browse/LPS-140296

Hello Reviewer! 🌸

This PR has a new feature and tests related to the story:
**As Web Content Admin, I want to delete an entire translation of a structure** ([LPS-127378](https://issues.liferay.com/browse/LPS-127378))

Summary: Added a subscribe event that triggers the new dispatch action `EVENT_TYPES.LANGUAGE.UPDATE` when Manage Translations Modal is closed, supporting the new behaviour of sending the array of `activeLanguageIds` instead of only one `languageId`.
More details can be found [here](https://liferay.atlassian.net/wiki/spaces/ENGFORMS/pages/1829208094/Aug+17th+and+Sep+21st) on our Confluence page.

If you have any questions feel free to ask, thank you for your time! :star2: