### PR TITLE
LPS-140715 Escape ddm field name to prevent xss

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/io/DDMFormValuesJSONDeserializer.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/io/DDMFormValuesJSONDeserializer.java
@@ -136,7 +136,13 @@ public class DDMFormValuesJSONDeserializer
 
 		ddmFormFieldValue.setFieldReference(
 			jsonObject.getString("fieldReference"));
-		ddmFormFieldValue.setInstanceId(jsonObject.getString("instanceId"));
+
+		String instanceId = jsonObject.getString("instanceId");
+
+		if (instanceId.matches("[a-zA-Z0-9]*")) {
+			ddmFormFieldValue.setInstanceId(instanceId);
+		}
+
 		ddmFormFieldValue.setName(jsonObject.getString("name"));
 
 		setDDMFormFieldValueValue(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/test/java/com/liferay/dynamic/data/mapping/internal/io/DDMFormValuesJSONDeserializerTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/test/java/com/liferay/dynamic/data/mapping/internal/io/DDMFormValuesJSONDeserializerTest.java
@@ -112,6 +112,56 @@ public class DDMFormValuesJSONDeserializerTest extends BaseDDMTestCase {
 	}
 
 	@Test
+	public void testDeserializationWithInvalidInstanceId() throws Exception {
+		String serializedDDMFormValues = read(
+			"ddm-form-values-json-deserializer-invalid-instance-id.json");
+
+		DDMFormValues ddmFormValues = deserialize(
+			serializedDDMFormValues, DDMFormTestUtil.createDDMForm());
+
+		Map<String, List<DDMFormFieldValue>> ddmFormFieldValuesMap =
+			ddmFormValues.getDDMFormFieldValuesMap();
+
+		Assert.assertEquals(
+			ddmFormFieldValuesMap.toString(), 4, ddmFormFieldValuesMap.size());
+
+		List<DDMFormFieldValue> ddmFormFieldValues = ddmFormFieldValuesMap.get(
+			"Text1");
+
+		DDMFormFieldValue ddmFormFieldValue = ddmFormFieldValues.get(0);
+
+		Assert.assertNotEquals(
+			ddmFormFieldValues.toString(),
+			"<script>alert(document.location)</script>",
+			ddmFormFieldValue.getInstanceId());
+
+		ddmFormFieldValues = ddmFormFieldValuesMap.get("Text2");
+
+		ddmFormFieldValue = ddmFormFieldValues.get(0);
+
+		Assert.assertNotEquals(
+			ddmFormFieldValues.toString(),
+			"^%&214214JDJ",
+			ddmFormFieldValue.getInstanceId());
+
+		ddmFormFieldValues = ddmFormFieldValuesMap.get("Select1");
+
+		ddmFormFieldValue = ddmFormFieldValues.get(0);
+
+		Assert.assertEquals(
+			ddmFormFieldValues.toString(), "yhar",
+			ddmFormFieldValue.getInstanceId());
+
+		ddmFormFieldValues = ddmFormFieldValuesMap.get("Select2");
+
+		ddmFormFieldValue = ddmFormFieldValues.get(0);
+
+		Assert.assertEquals(
+			ddmFormFieldValues.toString(), "yhKiArYe",
+			ddmFormFieldValue.getInstanceId());
+	}
+
+	@Test
 	public void testDeserializationWithParentRepeatableField()
 		throws Exception {
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/test/resources/com/liferay/dynamic/data/mapping/internal/io/dependencies/ddm-form-values-json-deserializer-invalid-instance-id.json
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/test/resources/com/liferay/dynamic/data/mapping/internal/io/dependencies/ddm-form-values-json-deserializer-invalid-instance-id.json
@@ -1,0 +1,32 @@
+{
+	"availableLanguageIds": [
+		"en_US"
+	],
+	"defaultLanguageId": "en_US",
+	"fieldValues": [
+		{
+			"instanceId": "<script>alert(document.location)</script>",
+			"name": "Text1",
+			"value": ""
+		},
+		{
+			"instanceId": "^%&214214JDJ",
+			"name": "Text2",
+			"value": ""
+		},
+		{
+			"instanceId": "yhar",
+			"name": "Select1",
+			"value": {
+				"en_US": "[]"
+			}
+		},
+		{
+			"instanceId": "yhKiArYe",
+			"name": "Select2",
+			"value": {
+				"en_US": "[]"
+			}
+		}
+	]
+}


### PR DESCRIPTION
Related Issue: https://issues.liferay.com/browse/LPS-140715

https://issues.liferay.com/browse/LPS-140715

/cc @binhtran92

Redirect here from https://github.com/liferay-echo/liferay-portal/pull/6198 and https://github.com/liferay-data-engine/liferay-portal/pull/584

### Problem overview

Legacy Liferay code in `dynamic-data-mapping-service` does not sanitize field namespaces for DDM fields. While the vulnerability requires that you hijack the session of a content administrator, this is true of many XSS vulnerabilities, so it's better to be safe than sorry.

### Steps to reproduce

**Note**: This issue is only reproducible in branch. While we could update the Javascript to submit instanceId information in master as well, as a side-effect of [LPS-129530](https://issues.liferay.com/browse/LPS-129530) which makes it so the problematic code is no longer called. However, this change cannot be brought back to maintenance branches.

1. Sign in as test@liferay.com
2. Go to Web Content > Basic Web Content
3. Submit a form where the instanceId is `<script>alert(document.location)</script>` by running the following script in the browser console:
``` javascript
document.getElementById('_com_liferay_journal_web_portlet_JournalPortlet_ddmFormValues').value = JSON.stringify({
  availableLanguageIds: ['en_US'],
  defaultLanguageId: 'en_US',
  fieldValues: [{
    instanceId: '<script>alert(document.location)</script>',
    name: 'content',
    value: {
      'en_US': 'testxss'
    }
  }]
});

document.forms[0].submit();
```
4. Navigate to the Web Content, access the latest Web Content you have just created.

**Expected Result:**
The edit screen shows up as normal

**Actual Result:**
The script is executed and the page stops loading

### Solution notes

Based on discussion with @samuelkong, it made more sense to validate the instanceId on the backend so that even if the problematic code is called in master, we don't experience any issues.

To introduce an invalid instanceId, you can use the following script in master on the screen where you create a new Basic Web Content:

```javascript
var prefix = '_com_liferay_journal_web_portlet_JournalPortlet_ddm$$content$';
var instanceId = '<script>alert(document.location)</script>';
document.querySelectorAll('input[name^="' + prefix + '"]').forEach(function(input) {
  var newName = prefix + instanceId + input.name.substring(input.name.indexOf('$', prefix.length));

  input.setAttribute('name', newName);
});

document.forms[0].submit();
```