### PR TITLE
LRQA-66927,LRQA-66928

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-evaluator-impl/src/main/java/com/liferay/dynamic/data/mapping/form/evaluator/internal/helper/DDMFormEvaluatorHelper.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-evaluator-impl/src/main/java/com/liferay/dynamic/data/mapping/form/evaluator/internal/helper/DDMFormEvaluatorHelper.java
@@ -52,7 +52,6 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MapUtil;
-import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -221,43 +220,14 @@ public class DDMFormEvaluatorHelper {
 
 			return false;
 		}
-		catch (NullPointerException nullPointerException) {
-
-			// LRQA-66927
-
-			throw new NullPointerException(
-				StringBundler.concat(
-					nullPointerException.getMessage(), "; Condition: \"",
-					condition));
-		}
 	}
 
 	protected <T> T evaluateExpression(String expression)
 		throws DDMExpressionException {
 
-		DDMExpression<T> ddmExpression = null;
+		DDMExpression<T> ddmExpression = createExpression(expression);
 
-		try {
-			ddmExpression = createExpression(expression);
-
-			return (T)ddmExpression.evaluate();
-		}
-		catch (NullPointerException nullPointerException) {
-
-			// LRQA-66927
-
-			String ddmExpressionString = StringPool.NULL;
-
-			if (ddmExpression != null) {
-				ddmExpressionString = ddmExpression.toString();
-			}
-
-			throw new NullPointerException(
-				StringBundler.concat(
-					nullPointerException.getMessage(), "; DDMExpression: \"",
-					ddmExpressionString, "\"; Expression: \"", expression,
-					"\""));
-		}
+		return (T)ddmExpression.evaluate();
 	}
 
 	protected void evaluateVisibilityExpression(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-evaluator-impl/src/main/java/com/liferay/dynamic/data/mapping/form/evaluator/internal/helper/DDMFormEvaluatorHelper.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-evaluator-impl/src/main/java/com/liferay/dynamic/data/mapping/form/evaluator/internal/helper/DDMFormEvaluatorHelper.java
@@ -582,7 +582,7 @@ public class DDMFormEvaluatorHelper {
 		String fieldInstanceId =
 			ddmFormEvaluatorFieldContextKey.getInstanceId();
 
-		boolean valid = false;
+		Boolean valid = Boolean.FALSE;
 
 		try {
 			String localizedValueString = null;
@@ -634,7 +634,7 @@ public class DDMFormEvaluatorHelper {
 
 		builder.withInstanceId(fieldInstanceId);
 
-		if (!valid) {
+		if (!Objects.equals(Boolean.TRUE, valid)) {
 			String errorMessage = null;
 
 			LocalizedValue errorMessageLocalizedValue =

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test-util/src/main/java/com/liferay/dynamic/data/mapping/test/util/DDMDataProviderTestUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test-util/src/main/java/com/liferay/dynamic/data/mapping/test/util/DDMDataProviderTestUtil.java
@@ -83,7 +83,7 @@ public class DDMDataProviderTestUtil {
 				"username", "test@liferay.com"));
 		ddmFormValues.addDDMFormFieldValue(
 			DDMFormValuesTestUtil.createUnlocalizedDDMFormFieldValue(
-				"timeout", "1000"));
+				"timeout", "30000"));
 
 		if (inputParameterSettings != null) {
 			for (DDMDataProviderInputParametersSettings inputParameterSetting :

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-validator/src/main/java/com/liferay/dynamic/data/mapping/validator/internal/DDMFormValuesValidatorImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-validator/src/main/java/com/liferay/dynamic/data/mapping/validator/internal/DDMFormValuesValidatorImpl.java
@@ -44,13 +44,11 @@ import com.liferay.dynamic.data.mapping.validator.DDMFormValuesValidator;
 import com.liferay.dynamic.data.mapping.validator.internal.expression.DDMFormFieldValueExpressionParameterAccessor;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.SetUtil;
-import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.Collections;
@@ -198,28 +196,6 @@ public class DDMFormValuesValidatorImpl implements DDMFormValuesValidator {
 		}
 		catch (DDMExpressionException ddmExpressionException) {
 			throw new DDMFormValuesValidationException(ddmExpressionException);
-		}
-		catch (NullPointerException nullPointerException) {
-
-			// LRQA-66928
-
-			String ddmExpressionString = StringPool.NULL;
-
-			if (ddmExpression != null) {
-				ddmExpressionString = ddmExpression.toString();
-			}
-
-			String ddmExpressionFactoryString = StringPool.NULL;
-
-			if (_ddmExpressionFactory != null) {
-				ddmExpressionFactoryString = _ddmExpressionFactory.toString();
-			}
-
-			throw new NullPointerException(
-				StringBundler.concat(
-					nullPointerException.getMessage(), ", DDM expression: ",
-					ddmExpressionString, ", DDM expression factory: ",
-					ddmExpressionFactoryString));
 		}
 	}
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-validator/src/main/java/com/liferay/dynamic/data/mapping/validator/internal/DDMFormValuesValidatorImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-validator/src/main/java/com/liferay/dynamic/data/mapping/validator/internal/DDMFormValuesValidatorImpl.java
@@ -55,6 +55,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -112,7 +113,7 @@ public class DDMFormValuesValidatorImpl implements DDMFormValuesValidator {
 		_serviceTrackerMap.close();
 	}
 
-	protected boolean evaluateValidationExpression(
+	protected Boolean evaluateValidationExpression(
 			String dataType, String ddmFormFieldName,
 			DDMFormFieldValidation ddmFormFieldValidation,
 			DDMFormFieldValue ddmFormFieldValue)
@@ -345,11 +346,11 @@ public class DDMFormValuesValidatorImpl implements DDMFormValuesValidator {
 			return;
 		}
 
-		boolean valid = evaluateValidationExpression(
+		Boolean valid = evaluateValidationExpression(
 			ddmFormField.getDataType(), ddmFormField.getName(),
 			ddmFormFieldValidation, ddmFormFieldValue);
 
-		if (!valid) {
+		if (!Objects.equals(Boolean.TRUE, valid)) {
 			throw new MustSetValidValue(
 				ddmFormField.getLabel(), ddmFormField.getName());
 		}


### PR DESCRIPTION
This change was made necessary, because CI runs integration/unit tests with Jacoco.
The old implementation used to get the first "apply" method of a class using reflection. For that to work, all class loaders would need to populate the list of methods of a class in the same order. That wasn't the case with Jacoco.

Related tickets:
https://issues.liferay.com/browse/LRQA-66927
https://issues.liferay.com/browse/LRQA-66928