### PR TITLE
LPS-143863 If the item doesn't exist should return null instead of throwing an exception

### DIFF
--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/layout/display/page/ObjectEntryLayoutDisplayPageProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/layout/display/page/ObjectEntryLayoutDisplayPageProvider.java
@@ -50,7 +50,7 @@ public class ObjectEntryLayoutDisplayPageProvider
 			InfoItemReference infoItemReference) {
 
 		try {
-			ObjectEntry objectEntry = _objectEntryLocalService.getObjectEntry(
+			ObjectEntry objectEntry = _objectEntryLocalService.fetchObjectEntry(
 				infoItemReference.getClassPK());
 
 			if ((objectEntry == null) || objectEntry.isDraft()) {


### PR DESCRIPTION
Related issue: https://issues.liferay.com/browse/LPS-143863

Hi team!

During the validations of the site navigation menus items for display pages, we have found a couple of bugs related to the info-framework implementation of Objects.

Could you please review the fix?

Thanks!!!

Regards