### PR TITLE
LPS-143865 Should return the object entry's title instead of the object definition's title

### DIFF
--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/layout/display/page/ObjectEntryLayoutDisplayPageObjectProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/layout/display/page/ObjectEntryLayoutDisplayPageObjectProvider.java
@@ -18,6 +18,9 @@ import com.liferay.layout.display.page.LayoutDisplayPageObjectProvider;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 
 import java.util.Locale;
@@ -72,13 +75,25 @@ public class ObjectEntryLayoutDisplayPageObjectProvider
 
 	@Override
 	public String getTitle(Locale locale) {
-		return _objectDefinition.getLabel(locale);
+		try {
+			return _objectEntry.getTitleValue();
+		}
+		catch (PortalException portalException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(portalException, portalException);
+			}
+		}
+
+		return StringPool.BLANK;
 	}
 
 	@Override
 	public String getURLTitle(Locale locale) {
 		return String.valueOf(_objectEntry.getObjectEntryId());
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		ObjectEntryLayoutDisplayPageObjectProvider.class);
 
 	private final ObjectDefinition _objectDefinition;
 	private final ObjectEntry _objectEntry;


### PR DESCRIPTION
Related issue: https://issues.liferay.com/browse/LPS-143865

Hi team!

During the validations of the site navigation menus items for display pages, we have found a couple of bugs related to the info-framework implementation of Objects.

Could you please review the fix?

Thanks!!!

Regards