### PR TITLE
LPS-143678 Let the date format follow the user current language

### DIFF
--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/custom/form-report/components/list/List.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/custom/form-report/components/list/List.js
@@ -13,7 +13,7 @@
  */
 
 import ClayButton from '@clayui/button';
-import moment from 'moment';
+import moment from 'moment/min/moment-with-locales';
 import React, {useContext} from 'react';
 
 import {removeEmptyValues} from '../../utils/data';

--- a/modules/apps/data-engine/data-engine-js-components-web/test/js/custom/form-report/components/list/List.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/test/js/custom/form-report/components/list/List.js
@@ -63,13 +63,29 @@ describe('List', () => {
 		);
 	});
 
-	it('renders dates according to the language', () => {
-		const data = ['12-20-2020'];
+	it('renders dates in the english US format', () => {
+		const originalThemeDisplay = themeDisplay;
+		themeDisplay = {getLanguageId: () => 'en_US'};
 
-		const type = 'date';
-
-		const {getByText} = render(<List {...props} data={data} type={type} />);
+		const {getByText} = render(
+			<List {...props} data={['2020-12-20']} type="date" />
+		);
 
 		expect(getByText('12/20/2020')).toBeTruthy();
+
+		themeDisplay = originalThemeDisplay;
+	});
+
+	it('renders dates in the portuguese BR format', () => {
+		const originalThemeDisplay = themeDisplay;
+		themeDisplay = {getLanguageId: () => 'pt_BR'};
+
+		const {getByText} = render(
+			<List {...props} data={['2020-12-20']} type="date" />
+		);
+
+		expect(getByText('20/12/2020')).toBeTruthy();
+
+		themeDisplay = originalThemeDisplay;
 	});
 });


### PR DESCRIPTION
Related Issue: https://issues.liferay.com/browse/LPS-143678

Hello Reviewer!

This PR has a fix and tests of the bug above. To let the date format be shown according the user's current language, it was necessary to change the way we were importing the `moment` library.

If you have any questions feel free to ask, thank you for your time!