### PR TITLE
LPS-144405

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormDisplayContext.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormDisplayContext.java
@@ -797,7 +797,8 @@ public class DDMFormDisplayContext {
 
 	public boolean isShowSuccessPage() throws PortalException {
 		if (!SessionErrors.isEmpty(_renderRequest) ||
-			SessionMessages.isEmpty(_renderRequest) ||
+			!SessionMessages.contains(
+				_renderRequest, "formInstanceRecordAdded") ||
 			Validator.isNotNull(getRedirectURL())) {
 
 			return false;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/AddFormInstanceRecordMVCActionCommand.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/AddFormInstanceRecordMVCActionCommand.java
@@ -132,6 +132,14 @@ public class AddFormInstanceRecordMVCActionCommand
 			return;
 		}
 
+		if (SessionMessages.contains(
+				actionRequest,
+				_portal.getPortletId(actionRequest) +
+					SessionMessages.KEY_SUFFIX_HIDE_DEFAULT_SUCCESS_MESSAGE)) {
+
+			SessionMessages.clear(actionRequest);
+		}
+
 		SessionMessages.add(actionRequest, "formInstanceRecordAdded");
 
 		DDMFormInstanceSettings ddmFormInstanceSettings =
@@ -153,13 +161,7 @@ public class AddFormInstanceRecordMVCActionCommand
 				ddmForm.getDDMFormSuccessPageSettings();
 
 			if (ddmFormSuccessPageSettings.isEnabled()) {
-				String portletId = _portal.getPortletId(actionRequest);
-
-				SessionMessages.add(
-					actionRequest,
-					portletId.concat(
-						SessionMessages.
-							KEY_SUFFIX_HIDE_DEFAULT_SUCCESS_MESSAGE));
+				hideDefaultSuccessMessage(actionRequest);
 			}
 		}
 	}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/AddFormInstanceRecordMVCActionCommand.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/AddFormInstanceRecordMVCActionCommand.java
@@ -132,11 +132,13 @@ public class AddFormInstanceRecordMVCActionCommand
 			return;
 		}
 
-		DDMFormInstanceSettings formInstanceSettings =
+		SessionMessages.add(actionRequest, "formInstanceRecordAdded");
+
+		DDMFormInstanceSettings ddmFormInstanceSettings =
 			ddmFormInstance.getSettingsModel();
 
 		String redirectURL = ParamUtil.getString(
-			actionRequest, "redirect", formInstanceSettings.redirectURL());
+			actionRequest, "redirect", ddmFormInstanceSettings.redirectURL());
 
 		if (Validator.isNotNull(redirectURL)) {
 			portletSession.setAttribute(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/UploadFileEntryMVCActionCommand.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/UploadFileEntryMVCActionCommand.java
@@ -49,6 +49,8 @@ public class UploadFileEntryMVCActionCommand extends BaseMVCActionCommand {
 		_uploadHandler.upload(
 			_ddmFormUploadFileEntryHandler, _ddmFormUploadResponseHandler,
 			actionRequest, actionResponse);
+
+		hideDefaultSuccessMessage(actionRequest);
 	}
 
 	@Reference

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/test/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormDisplayContextTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/test/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormDisplayContextTest.java
@@ -566,9 +566,7 @@ public class DDMFormDisplayContextTest extends PowerMockito {
 
 		MockRenderRequest mockRenderRequest = _mockRenderRequest();
 
-		SessionMessages.add(
-			mockRenderRequest,
-			SessionMessages.KEY_SUFFIX_HIDE_DEFAULT_SUCCESS_MESSAGE);
+		SessionMessages.add(mockRenderRequest, "formInstanceRecordAdded");
 
 		DDMFormDisplayContext ddmFormDisplayContext =
 			_createDDMFormDisplayContext(mockRenderRequest);
@@ -591,9 +589,7 @@ public class DDMFormDisplayContextTest extends PowerMockito {
 
 		MockRenderRequest mockRenderRequest = _mockRenderRequest();
 
-		SessionMessages.add(
-			mockRenderRequest,
-			SessionMessages.KEY_SUFFIX_HIDE_DEFAULT_SUCCESS_MESSAGE);
+		SessionMessages.add(mockRenderRequest, "formInstanceRecordAdded");
 
 		DDMFormDisplayContext ddmFormDisplayContext =
 			_createDDMFormDisplayContext(mockRenderRequest);


### PR DESCRIPTION
Related Issue: https://issues.liferay.com/browse/LPS-144405

I only need to concatenate with the `portletId` [here](https://github.com/carolmariaabb/liferay-portal/blob/e5b6ac4a1dabc3a6bc2f9e8014a81ff91be187ce/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/portlet/action/AddFormInstanceRecordMVCActionCommand.java#L135-L138) because the existing `hideDefaultSuccessMessage` method also concatenates [here](https://github.com/liferay/liferay-portal/blob/8d2e15d135ea6f96abb6a76380e71e1145f1ea52/portal-kernel/src/com/liferay/portal/kernel/portlet/bridges/mvc/BaseMVCActionCommand.java#L111-L115).
