### PR TITLE
LPS-135604

### DIFF
--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/utils/evaluation.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/utils/evaluation.es.js
@@ -105,14 +105,6 @@ export function mergePages(
 			}
 
 			if (newField.localizable) {
-				if (
-					field.type === 'numeric' &&
-					field.valueChanged &&
-					field.value !== field.localizedValue[editingLanguageId]
-				) {
-					sourceField.localizedValue[editingLanguageId] = field.value;
-				}
-
 				newField = {
 					...newField,
 					localizedValue: {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-evaluator-impl/src/main/java/com/liferay/dynamic/data/mapping/form/evaluator/internal/helper/DDMFormEvaluatorRuleHelper.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-evaluator-impl/src/main/java/com/liferay/dynamic/data/mapping/form/evaluator/internal/helper/DDMFormEvaluatorRuleHelper.java
@@ -18,13 +18,11 @@ import com.liferay.dynamic.data.mapping.expression.UpdateFieldPropertyRequest;
 import com.liferay.dynamic.data.mapping.form.evaluator.internal.expression.DDMFormEvaluatorExpressionObserver;
 import com.liferay.dynamic.data.mapping.model.DDMFormField;
 import com.liferay.dynamic.data.mapping.model.DDMFormRule;
-import com.liferay.dynamic.data.mapping.model.LocalizedValue;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.GetterUtil;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
@@ -54,33 +52,32 @@ public class DDMFormEvaluatorRuleHelper {
 	protected void checkFieldAffectedByAction(
 		DDMFormRule ddmFormRule, DDMFormField ddmFormField) {
 
-		_checkFieldAffectedByCalculateAction(ddmFormRule, ddmFormField);
 		_checkFieldAffectedBySetReadOnlyAction(ddmFormRule, ddmFormField);
 		_checkFieldAffectedBySetRequiredAction(ddmFormRule, ddmFormField);
 		_checkFieldAffectedBySetVisibleAction(ddmFormRule, ddmFormField);
+		_checkFieldAffectedByCalculateAction(ddmFormRule, ddmFormField);
 	}
 
 	private void _checkFieldAffectedByCalculateAction(
 		DDMFormRule ddmFormRule, DDMFormField ddmFormField) {
 
+		Map<String, Object> properties = ddmFormField.getProperties();
+
 		if (_containsAction(
 				ddmFormRule, "calculate", ddmFormField.getName(),
-				GetterUtil.getString(ddmFormField.getProperty("value")))) {
+				GetterUtil.getString(properties.get("value")))) {
 
-			String newValue = StringPool.BLANK;
+			String value = StringPool.BLANK;
 
-			LocalizedValue predefinedValue = ddmFormField.getPredefinedValue();
+			if (GetterUtil.getString(properties.get("predefinedValue")) !=
+					null) {
 
-			if (predefinedValue != null) {
-				newValue = GetterUtil.getString(
-					predefinedValue.getString(
-						new Locale(
-							(String)ddmFormField.getProperty("locale"))));
+				value = GetterUtil.getString(properties.get("predefinedValue"));
 			}
 
 			UpdateFieldPropertyRequest.Builder builder =
 				UpdateFieldPropertyRequest.Builder.newBuilder(
-					ddmFormField.getName(), "value", newValue);
+					ddmFormField.getName(), "value", value);
 
 			_ddmFormEvaluatorExpressionObserver.updateFieldProperty(
 				builder.build());

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-evaluator-impl/src/main/java/com/liferay/dynamic/data/mapping/form/evaluator/internal/helper/DDMFormEvaluatorRuleHelper.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-evaluator-impl/src/main/java/com/liferay/dynamic/data/mapping/form/evaluator/internal/helper/DDMFormEvaluatorRuleHelper.java
@@ -18,8 +18,6 @@ import com.liferay.dynamic.data.mapping.expression.UpdateFieldPropertyRequest;
 import com.liferay.dynamic.data.mapping.form.evaluator.internal.expression.DDMFormEvaluatorExpressionObserver;
 import com.liferay.dynamic.data.mapping.model.DDMFormField;
 import com.liferay.dynamic.data.mapping.model.DDMFormRule;
-import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.util.GetterUtil;
 
 import java.util.Collection;
 import java.util.List;
@@ -55,33 +53,6 @@ public class DDMFormEvaluatorRuleHelper {
 		_checkFieldAffectedBySetReadOnlyAction(ddmFormRule, ddmFormField);
 		_checkFieldAffectedBySetRequiredAction(ddmFormRule, ddmFormField);
 		_checkFieldAffectedBySetVisibleAction(ddmFormRule, ddmFormField);
-		_checkFieldAffectedByCalculateAction(ddmFormRule, ddmFormField);
-	}
-
-	private void _checkFieldAffectedByCalculateAction(
-		DDMFormRule ddmFormRule, DDMFormField ddmFormField) {
-
-		Map<String, Object> properties = ddmFormField.getProperties();
-
-		if (_containsAction(
-				ddmFormRule, "calculate", ddmFormField.getName(),
-				GetterUtil.getString(properties.get("value")))) {
-
-			String value = StringPool.BLANK;
-
-			if (GetterUtil.getString(properties.get("predefinedValue")) !=
-					null) {
-
-				value = GetterUtil.getString(properties.get("predefinedValue"));
-			}
-
-			UpdateFieldPropertyRequest.Builder builder =
-				UpdateFieldPropertyRequest.Builder.newBuilder(
-					ddmFormField.getName(), "value", value);
-
-			_ddmFormEvaluatorExpressionObserver.updateFieldProperty(
-				builder.build());
-		}
 	}
 
 	private void _checkFieldAffectedBySetReadOnlyAction(
@@ -135,9 +106,9 @@ public class DDMFormEvaluatorRuleHelper {
 
 	private boolean _containsAction(
 		DDMFormRule ddmFormRule, String functionName, String ddmFormFieldName,
-		Object defaultValue) {
+		boolean defaultValue) {
 
-		String setPropertyAction = String.format(
+		String setBooleanPropertyAction = String.format(
 			"%s('%s', %s)", functionName, ddmFormFieldName, defaultValue);
 
 		List<String> actions = ddmFormRule.getActions();
@@ -145,7 +116,7 @@ public class DDMFormEvaluatorRuleHelper {
 		Stream<String> stream = actions.stream();
 
 		return stream.anyMatch(
-			action -> Objects.equals(setPropertyAction, action));
+			action -> Objects.equals(setBooleanPropertyAction, action));
 	}
 
 	private final DDMFormEvaluatorExpressionObserver

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Text/Text.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Text/Text.es.js
@@ -406,7 +406,7 @@ const Main = ({
 				placeholder={placeholder}
 				shouldUpdateValue={shouldUpdateValue}
 				syncDelay={syncDelay}
-				value={value ?? predefinedValue}
+				value={value ? value : predefinedValue}
 			/>
 		</FieldBase>
 	);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/test/java/com/liferay/dynamic/data/mapping/form/field/type/internal/numeric/NumericDDMFormFieldTemplateContextContributorTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/test/java/com/liferay/dynamic/data/mapping/form/field/type/internal/numeric/NumericDDMFormFieldTemplateContextContributorTest.java
@@ -235,22 +235,6 @@ public class NumericDDMFormFieldTemplateContextContributorTest
 	}
 
 	@Test
-	public void testGetPredefinedValue() {
-		DDMFormField ddmFormField = new DDMFormField("field", "numeric");
-
-		ddmFormField.setProperty(
-			"predefinedValue",
-			DDMFormValuesTestUtil.createLocalizedValue("42", _locale));
-
-		Map<String, Object> parameters =
-			_numericDDMFormFieldTemplateContextContributor.getParameters(
-				ddmFormField, _createDDMFormFieldRenderingContext());
-
-		Assert.assertEquals(
-			"42", String.valueOf(parameters.get("predefinedValue")));
-	}
-
-	@Test
 	public void testGetSymbols() {
 		DDMFormField ddmFormField = new DDMFormField("field", "numeric");
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/java/com/liferay/dynamic/data/mapping/form/renderer/internal/servlet/DDMFormTemplateContextProcessor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/java/com/liferay/dynamic/data/mapping/form/renderer/internal/servlet/DDMFormTemplateContextProcessor.java
@@ -33,7 +33,6 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.kernel.util.Validator;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -112,8 +111,6 @@ public class DDMFormTemplateContextProcessor {
 			jsonObject.getString("numericInputMask"), ddmFormField);
 		_setDDMFormFieldOptions(
 			jsonObject.getJSONArray("options"), ddmFormField);
-		_setDDMFormFieldPredefinedValue(
-			jsonObject.getString("predefinedValue"), ddmFormField);
 		_setDDMFormFieldPlaceholder(
 			jsonObject.getString("placeholder"), ddmFormField);
 		_setDDMFormFieldProperty(
@@ -398,19 +395,7 @@ public class DDMFormTemplateContextProcessor {
 			_getLocalizedValue(GetterUtil.getString(placeholder)));
 	}
 
-	private void _setDDMFormFieldPredefinedValue(
-		String predefinedValue, DDMFormField ddmFormField) {
-
-		if (Validator.isNull(predefinedValue)) {
-			return;
-		}
-
-		ddmFormField.setProperty(
-			"predefinedValue",
-			_getLocalizedValue(GetterUtil.getString(predefinedValue)));
-	}
-
-	private void _setDDMFormFieldProperty(
+	protected void _setDDMFormFieldProperty(
 		DDMFormField ddmFormField, String propertyName, String propertyValue) {
 
 		if (!Objects.equals(ddmFormField.getType(), "redirect_button")) {


### PR DESCRIPTION
Hi team,

As discussed with you I'm creating this pull request to remove some codes that the master branch have. 

As you can see, there is only [one commit](https://github.com/liferay/liferay-portal/commit/3e8863ffe29ac691652b3b6108e1df93cc7c821f) that I'm not reverting, since the changes made with this commit were already updated with two situations: [First one clicking here](https://github.com/liferay/liferay-portal/blame/03ebcdd0201433f203bca9033f5947834745949a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/components/PageRenderer/DefaultVariant.es.js#L97)

But, talking specifically about the second change in the commit, I didn't revert because [this](https://github.com/liferay/liferay-portal/blame/482ea656a5464a23a5cded2338ecbea231ce4836/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/util/DDMFormFieldTypeUtil.java#L31) method was deleted of the branch. And, as the difference between this method and the one I decided to keep is just a conditional, that is currently used only [in a part](https://github.com/liferay/liferay-portal/blob/03ebcdd0201433f203bca9033f5947834745949a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/util/NumericDDMFormFieldTypeUtil.java#L57) of the new class `NumericDDMFormFieldTypeUtil`  after the code move that this field suffered, I decided to continue using the `DDMFormFieldTypeUtil.getPropertyValue` that I first use in my commit.

Please, let me know if you have any questions or if I need to update this PR with changes.

Thank you,
Richard.