### PR TITLE
LPS-145181 Unit tests

### DIFF
--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/custom/form-report/components/card/CardList.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/custom/form-report/components/card/CardList.js
@@ -39,6 +39,7 @@ const chartFactory = ({
 		case 'color':
 		case 'country':
 		case 'date':
+		case 'date_time':
 		case 'place':
 		case 'postal-code':
 		case 'state':

--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/custom/form-report/components/list/List.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/custom/form-report/components/list/List.js
@@ -23,10 +23,17 @@ import {SidebarContext} from '../sidebar/SidebarContext';
 export default function List({data, field, summary, totalEntries, type}) {
 	const {portletNamespace, toggleSidebar} = useContext(SidebarContext);
 
-	const formatDate = (field) => {
+	const formatDate = (field, isDateTime) => {
 		const locale = themeDisplay.getLanguageId().split('_', 1).join('');
+		const date = moment(field).locale(locale).format('L');
 
-		return moment(field).locale(locale).format('L');
+		if (!isDateTime) {
+			return date;
+		}
+
+		const time = moment(field).locale(locale).format('LT');
+
+		return `${date} ${time}`;
 	};
 
 	const checkType = (field, type) => {
@@ -35,6 +42,8 @@ export default function List({data, field, summary, totalEntries, type}) {
 				return <Color hexColor={field} />;
 			case 'date':
 				return formatDate(field);
+			case 'date_time':
+				return formatDate(field, true);
 			default:
 				return field;
 		}

--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/custom/form-report/utils/fieldTypes.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/custom/form-report/utils/fieldTypes.js
@@ -42,6 +42,10 @@ export default {
 		icon: 'calendar',
 		title: Liferay.Language.get('date-field-type-label'),
 	},
+	date_time: {
+		icon: 'date-time',
+		title: Liferay.Language.get('date-and-time'),
+	},
 	grid: {
 		icon: 'table2',
 		title: Liferay.Language.get('grid-field-type-label'),

--- a/modules/apps/data-engine/data-engine-js-components-web/test/js/custom/form-report/components/list/List.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/test/js/custom/form-report/components/list/List.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {cleanup, render} from '@testing-library/react';
+import {render} from '@testing-library/react';
 import React from 'react';
 
 import List from '../../../../../../src/main/resources/META-INF/resources/js/custom/form-report/components/list/List';
@@ -25,8 +25,6 @@ const props = {
 };
 
 describe('List', () => {
-	afterEach(cleanup);
-
 	it('renders', () => {
 		const {asFragment, container} = render(<List {...props} />);
 
@@ -85,6 +83,32 @@ describe('List', () => {
 		);
 
 		expect(getByText('20/12/2020')).toBeTruthy();
+
+		themeDisplay = originalThemeDisplay;
+	});
+
+	it('renders dates and time in the english US format', () => {
+		const originalThemeDisplay = themeDisplay;
+		themeDisplay = {getLanguageId: () => 'en_US'};
+
+		const {getByText} = render(
+			<List {...props} data={['2020-12-20 14:48']} type="date_time" />
+		);
+
+		expect(getByText('12/20/2020 2:48 PM')).toBeTruthy();
+
+		themeDisplay = originalThemeDisplay;
+	});
+
+	it('renders dates and time in the japanese format', () => {
+		const originalThemeDisplay = themeDisplay;
+		themeDisplay = {getLanguageId: () => 'ja_JP'};
+
+		const {getByText} = render(
+			<List {...props} data={['2020-12-20 14:48']} type="date_time" />
+		);
+
+		expect(getByText('2020/12/20 14:48')).toBeTruthy();
 
 		themeDisplay = originalThemeDisplay;
 	});

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/package.json
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/package.json
@@ -3,6 +3,7 @@
 		"@clayui/autocomplete": "3.43.0",
 		"@clayui/button": "3.40.0",
 		"@clayui/data-provider": "3.40.0",
+		"@clayui/date-picker": "3.43.0",
 		"@clayui/drop-down": "3.43.0",
 		"@clayui/form": "3.42.0",
 		"@clayui/icon": "3.40.0",

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/date/time/DateTimeDDMFormFieldType.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/date/time/DateTimeDDMFormFieldType.java
@@ -29,7 +29,7 @@ import org.osgi.service.component.annotations.Component;
 	property = {
 		"ddm.form.field.type.description=date-time-field-type-description",
 		"ddm.form.field.type.display.order:Double=6.1",
-		"ddm.form.field.type.group=basic", "ddm.form.field.type.icon=time",
+		"ddm.form.field.type.group=basic", "ddm.form.field.type.icon=date-time",
 		"ddm.form.field.type.label=date-and-time",
 		"ddm.form.field.type.name=" + DDMFormFieldTypeConstants.DATE_TIME,
 		"ddm.form.field.type.scope=forms"

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/DatePicker/createAutoCorrectedDatePipe.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/DatePicker/createAutoCorrectedDatePipe.js
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+/**
+ * This code is from https://github.com/text-mask/text-mask
+ * https://github.com/text-mask/text-mask/blob/master/addons/src/createAutoCorrectedDatePipe.js
+ */
+
+const maxValueMonth = [31, 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+const formatOrder = ['yyyy', 'yy', 'mm', 'dd', 'HH', 'MM', 'SS', 'hh'];
+export function createAutoCorrectedDatePipe(
+	dateFormat = 'mm dd yyyy',
+	{maxYear = 9999, minYear = 1} = {}
+) {
+	const dateFormatArray = dateFormat
+		.split(/[^dhmyHMS]+/)
+		.sort((a, b) => formatOrder.indexOf(a) - formatOrder.indexOf(b));
+
+	return function (conformedValue) {
+		const indexesOfPipedChars = [];
+		const maxValue = {
+			HH: 23,
+			MM: 59,
+			SS: 59,
+			dd: 31,
+			hh: 12,
+			mm: 12,
+			yy: 99,
+			yyyy: maxYear,
+		};
+		const minValue = {
+			HH: 0,
+			MM: 0,
+			SS: 0,
+			dd: 1,
+			hh: 1,
+			mm: 1,
+			yy: 0,
+			yyyy: minYear,
+		};
+		const conformedValueArr = conformedValue.split('');
+
+		// Check first digit
+
+		dateFormatArray.forEach((format) => {
+			const position = dateFormat.indexOf(format);
+			const maxFirstDigit = parseInt(
+				maxValue[format].toString().substr(0, 1),
+				10
+			);
+
+			if (parseInt(conformedValueArr[position], 10) > maxFirstDigit) {
+				conformedValueArr[position + 1] = conformedValueArr[position];
+				conformedValueArr[position] = 0;
+				indexesOfPipedChars.push(position);
+			}
+		});
+
+		// Check for invalid date
+
+		let month = 0;
+		const isInvalid = dateFormatArray.some((format) => {
+			const position = dateFormat.indexOf(format);
+			const length = format.length;
+			const textValue = conformedValue
+				.substr(position, length)
+				.replace(/\D/g, '');
+			const value = parseInt(textValue, 10);
+			if (format === 'mm') {
+				month = value || 0;
+			}
+			const maxValueForFormat =
+				format === 'dd' ? maxValueMonth[month] : maxValue[format];
+			if (format === 'yyyy' && (minYear !== 1 || maxYear !== 9999)) {
+				const scopedMaxValue = parseInt(
+					maxValue[format].toString().substring(0, textValue.length),
+					10
+				);
+				const scopedMinValue = parseInt(
+					minValue[format].toString().substring(0, textValue.length),
+					10
+				);
+
+				return value < scopedMinValue || value > scopedMaxValue;
+			}
+
+			return (
+				value > maxValueForFormat ||
+				(textValue.length === length && value < minValue[format])
+			);
+		});
+
+		if (isInvalid) {
+			return false;
+		}
+
+		return {
+			indexesOfPipedChars,
+			value: conformedValueArr.join(''),
+		};
+	};
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/DatePicker/DatePicker.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/DatePicker/DatePicker.es.js
@@ -13,7 +13,7 @@
  */
 
 import '@testing-library/jest-dom/extend-expect';
-import {render, screen} from '@testing-library/react';
+import {fireEvent, render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import moment from 'moment';
 import React from 'react';
@@ -125,5 +125,52 @@ describe('DatePicker', () => {
 		userEvent.type(input, '٠١/٠١/٢٠٢١');
 
 		expect(onChange).toHaveBeenLastCalledWith('');
+	});
+
+	it('fills the input date and time according to the locale', () => {
+		const {container} = render(
+			<DatePicker locale="pt_BR" onChange={() => {}} type="date_time" />
+		);
+
+		userEvent.click(screen.getByLabelText('Choose date'));
+
+		const hours = screen.getByLabelText('Enter the hour in 00:00 format');
+		const minutes = screen.getByLabelText(
+			'Enter the minutes in 00:00 format'
+		);
+		userEvent.type(hours, '23');
+		userEvent.type(minutes, '30');
+
+		userEvent.click(screen.getByLabelText('Select current date'));
+
+		expect(container.querySelector('[type=text]')).toHaveValue(
+			moment().format('DD/MM/YYYY [23:30]')
+		);
+	});
+
+	it('calls the onChange callback with a valid date and time', () => {
+		const onChange = jest.fn();
+
+		render(<DatePicker onChange={onChange} type="date_time" />);
+
+		userEvent.click(screen.getByLabelText('Choose date'));
+
+		const hours = screen.getByLabelText('Enter the hour in 00:00 format');
+		const minutes = screen.getByLabelText(
+			'Enter the minutes in 00:00 format'
+		);
+		const sufix = screen.getByLabelText(
+			'Select time of day (AM/PM) using up (PM) and down (AM) arrow keys'
+		);
+
+		userEvent.type(hours, '11');
+		userEvent.type(minutes, '30');
+		fireEvent.keyDown(sufix, {code: 'ArrowUp', key: 'ArrowUp'}); // PM
+		userEvent.click(screen.getByLabelText('Select current date'));
+
+		expect(onChange).toHaveBeenCalledWith(
+			{},
+			moment().format('YYYY-MM-DD [23:30]')
+		);
 	});
 });


### PR DESCRIPTION
Related Issues:
- https://issues.liferay.com/browse/LPS-144708
- https://issues.liferay.com/browse/LPS-144709
- https://issues.liferay.com/browse/LPS-144710
- https://issues.liferay.com/browse/LPS-144711
- https://issues.liferay.com/browse/LPS-145181

Hello Reviewer! 🌸

This PR has new features and tests related to the story:
**As a form admin, I want to be able to request datetime from my users** ([LPS-143050](https://issues.liferay.com/browse/LPS-143050))

Summary: Updates the date picker dependency, adjusts the DatePicker logic to support `date_time` field type, allows the display of `date_time` fields in the entries section and add unit tests.
More details can be found [here](https://liferay.atlassian.net/wiki/spaces/ENGFORMS/pages/1958839342/LPS-143050+As+a+form+admin+I+want+to+be+able+to+request+datetime+from+my+users) on our Confluence page.

If you have any questions feel free to ask, thank you for your time!