### PR TITLE
Lps-145204

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -1291,8 +1291,6 @@ AUI.add(
 					var value = instance.getValue();
 
 					if (instance.get('localizable')) {
-						var defaultLocale = instance.getDefaultLocale();
-
 						if (
 							!(locale in localizationMap) ||
 							(localizationMap[locale] !== undefined &&

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -1294,7 +1294,7 @@ AUI.add(
 						var defaultLocale = instance.getDefaultLocale();
 
 						if (
-							locale === defaultLocale ||
+							!(locale in localizationMap) ||
 							(localizationMap[defaultLocale] !== undefined &&
 								value !== localizationMap[defaultLocale]) ||
 							localizationMap[locale]

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -1295,9 +1295,8 @@ AUI.add(
 
 						if (
 							!(locale in localizationMap) ||
-							(localizationMap[defaultLocale] !== undefined &&
-								value !== localizationMap[defaultLocale]) ||
-							localizationMap[locale]
+							(localizationMap[locale] !== undefined &&
+								value !== localizationMap[locale])
 						) {
 							localizationMap[locale] = value;
 						}


### PR DESCRIPTION
Related Issue: https://issues.liferay.com/browse/LPS-145204

When you try to apply a field filter to an Asset Publisher, if the page is on a language different from the default locale the validation fails.