### PR TITLE
LPS-145897 Calculate formattedDate correctly for all translations

### DIFF
--- a/modules/apps/calendar/calendar-web-test/src/testFunctional/macros/CalendarScheduler.macro
+++ b/modules/apps/calendar/calendar-web-test/src/testFunctional/macros/CalendarScheduler.macro
@@ -121,9 +121,6 @@ definition {
 
 	macro gotoAddViaDayView {
 		Click(locator1 = "CalendarDayView#SCHEDULER_VIEW_DAY");
-
-
-		
 	}
 
 	macro gotoDetailsViaDialogBox {

--- a/modules/apps/calendar/calendar-web-test/src/testFunctional/macros/CalendarScheduler.macro
+++ b/modules/apps/calendar/calendar-web-test/src/testFunctional/macros/CalendarScheduler.macro
@@ -120,7 +120,10 @@ definition {
 	}
 
 	macro gotoAddViaDayView {
-		SikuliClick(locator1 = "Calendar#SCHEDULER_DAY_VIEW_PNG");
+		Click(locator1 = "CalendarDayView#SCHEDULER_VIEW_DAY");
+
+
+		
 	}
 
 	macro gotoDetailsViaDialogBox {

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/impl/CTCollectionLocalServiceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/impl/CTCollectionLocalServiceImpl.java
@@ -60,7 +60,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.petra.string.StringUtil;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
-import com.liferay.portal.kernel.dao.jdbc.CurrentConnectionUtil;
+import com.liferay.portal.kernel.dao.jdbc.CurrentConnection;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.log.Log;
@@ -385,7 +385,7 @@ public class CTCollectionLocalServiceImpl
 
 			ctService.updateWithUnsafeFunction(
 				ctPersistence -> {
-					Connection connection = CurrentConnectionUtil.getConnection(
+					Connection connection = _currentConnection.getConnection(
 						ctPersistence.getDataSource());
 
 					try (PreparedStatement preparedStatement =
@@ -913,6 +913,9 @@ public class CTCollectionLocalServiceImpl
 
 	@Reference
 	private CTServiceRegistry _ctServiceRegistry;
+
+	@Reference
+	private CurrentConnection _currentConnection;
 
 	@Reference
 	private GroupLocalService _groupLocalService;

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/impl/CTCollectionServiceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/impl/CTCollectionServiceImpl.java
@@ -37,7 +37,7 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.dao.orm.custom.sql.CustomSQL;
 import com.liferay.portal.kernel.change.tracking.CTColumnResolutionType;
-import com.liferay.portal.kernel.dao.jdbc.CurrentConnectionUtil;
+import com.liferay.portal.kernel.dao.jdbc.CurrentConnection;
 import com.liferay.portal.kernel.dao.orm.WildcardMode;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
@@ -357,7 +357,7 @@ public class CTCollectionServiceImpl extends CTCollectionServiceBaseImpl {
 
 				sb.setStringAt(")", sb.index() - 1);
 
-				Connection connection = CurrentConnectionUtil.getConnection(
+				Connection connection = _currentConnection.getConnection(
 					ctPersistence.getDataSource());
 
 				try (PreparedStatement preparedStatement =
@@ -524,6 +524,9 @@ public class CTCollectionServiceImpl extends CTCollectionServiceBaseImpl {
 
 	@Reference
 	private CTServiceRegistry _ctServiceRegistry;
+
+	@Reference
+	private CurrentConnection _currentConnection;
 
 	@Reference
 	private CustomSQL _customSQL;

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/DataDefinitionResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/DataDefinitionResourceImpl.java
@@ -83,7 +83,7 @@ import com.liferay.frontend.js.loader.modules.extender.npm.NPMResolver;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.change.tracking.CTAware;
 import com.liferay.portal.kernel.editor.configuration.EditorConfiguration;
-import com.liferay.portal.kernel.editor.configuration.EditorConfigurationFactoryUtil;
+import com.liferay.portal.kernel.editor.configuration.EditorConfigurationFactory;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
@@ -930,7 +930,7 @@ public class DataDefinitionResourceImpl
 			StringUtil.equals(ddmFormFieldType.getName(), "rich_text")) {
 
 			EditorConfiguration editorConfiguration =
-				EditorConfigurationFactoryUtil.getEditorConfiguration(
+				_editorConfigurationFactory.getEditorConfiguration(
 					StringPool.BLANK, ddmFormFieldType.getName(),
 					"ckeditor_classic", new HashMap<String, Object>(),
 					themeDisplay,
@@ -1587,6 +1587,9 @@ public class DataDefinitionResourceImpl
 
 	@Reference
 	private DEDataListViewLocalService _deDataListViewLocalService;
+
+	@Reference
+	private EditorConfigurationFactory _editorConfigurationFactory;
 
 	@Reference
 	private JSONFactory _jsonFactory;

--- a/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/display/context/DepotAdminViewDepotDashboardDisplayContext.java
+++ b/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/display/context/DepotAdminViewDepotDashboardDisplayContext.java
@@ -20,6 +20,7 @@ import com.liferay.application.list.PanelCategory;
 import com.liferay.application.list.PanelCategoryRegistry;
 import com.liferay.application.list.constants.PanelCategoryKeys;
 import com.liferay.asset.categories.admin.web.constants.AssetCategoriesAdminPortletKeys;
+import com.liferay.asset.list.constants.AssetListPortletKeys;
 import com.liferay.asset.tags.constants.AssetTagsAdminPortletKeys;
 import com.liferay.depot.web.internal.constants.DepotPortletKeys;
 import com.liferay.depot.web.internal.servlet.taglib.clay.DepotDashboardApplicationNavigationCard;
@@ -142,6 +143,8 @@ public class DepotAdminViewDepotDashboardDisplayContext {
 	private static final Map<String, String> _panelAppIcons =
 		HashMapBuilder.put(
 			AssetCategoriesAdminPortletKeys.ASSET_CATEGORIES_ADMIN, "categories"
+		).put(
+			AssetListPortletKeys.ASSET_LIST, "closed-book"
 		).put(
 			AssetTagsAdminPortletKeys.ASSET_TAGS_ADMIN, "tag"
 		).put(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/rich/text/RichTextDDMFormFieldTemplateContextContributor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/rich/text/RichTextDDMFormFieldTemplateContextContributor.java
@@ -20,7 +20,7 @@ import com.liferay.dynamic.data.mapping.form.field.type.internal.util.DDMFormFie
 import com.liferay.dynamic.data.mapping.model.DDMFormField;
 import com.liferay.dynamic.data.mapping.render.DDMFormFieldRenderingContext;
 import com.liferay.portal.kernel.editor.configuration.EditorConfiguration;
-import com.liferay.portal.kernel.editor.configuration.EditorConfigurationFactoryUtil;
+import com.liferay.portal.kernel.editor.configuration.EditorConfigurationFactory;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -31,6 +31,7 @@ import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Carlos Lancha
@@ -78,7 +79,7 @@ public class RichTextDDMFormFieldTemplateContextContributor
 				WebKeys.THEME_DISPLAY);
 
 		EditorConfiguration editorConfiguration =
-			EditorConfigurationFactoryUtil.getEditorConfiguration(
+			_editorConfigurationFactory.getEditorConfiguration(
 				themeDisplay.getPpid(), ddmFormFieldType, "ckeditor_classic",
 				HashMapBuilder.<String, Object>put(
 					"liferay-ui:input-editor:allowBrowseDocuments", true
@@ -92,5 +93,8 @@ public class RichTextDDMFormFieldTemplateContextContributor
 
 		return editorConfiguration.getData();
 	}
+
+	@Reference
+	private EditorConfigurationFactory _editorConfigurationFactory;
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/DatePicker/DatePicker.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/DatePicker/DatePicker.es.js
@@ -208,11 +208,18 @@ export default function DatePicker({
 			setExpand(false);
 			inputRef.current.focus();
 		}
-		const firstSpace = value.indexOf(' ');
-		const formattedDate = value.substring(0, firstSpace);
-		const formattedTime = value.substring(firstSpace).replaceAll('-', '_');
+
+		let formattedDate = value;
+		if (isDateTime) {
+			const firstSpace = value.indexOf(' ');
+			formattedDate = value.substring(0, firstSpace);
+			const formattedTime = value
+				.substring(firstSpace)
+				.replaceAll('-', '_');
+			formattedDate = `${formattedDate}${formattedTime}`;
+		}
 		const nextState = {
-			formattedDate: `${formattedDate}${formattedTime}`,
+			formattedDate,
 			rawDate: '',
 		};
 

--- a/modules/apps/frontend-js/frontend-js-aui-web/build.gradle
+++ b/modules/apps/frontend-js/frontend-js-aui-web/build.gradle
@@ -7,7 +7,7 @@ configurations {
 
 task buildAlloyUI(type: Copy)
 
-String alloyUIVersion = "3.1.0-deprecated.86"
+String alloyUIVersion = "3.1.0-deprecated.90"
 
 File jsDestinationDir = file("tmp/META-INF/resources")
 

--- a/modules/apps/frontend-theme/frontend-theme-unstyled/build.gradle
+++ b/modules/apps/frontend-theme/frontend-theme-unstyled/build.gradle
@@ -15,7 +15,7 @@ task buildLexiconIcons(type: Copy)
 task buildTheme
 task publishNodeModule(type: PublishNodeModuleTask)
 
-String alloyUIVersion = "3.1.0-deprecated.86"
+String alloyUIVersion = "3.1.0-deprecated.90"
 
 String fontAwesomeVersion = "3.2.1"
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -51,7 +51,7 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.dao.jdbc.postgresql.PostgreSQLJDBCUtil;
-import com.liferay.portal.kernel.dao.jdbc.CurrentConnectionUtil;
+import com.liferay.portal.kernel.dao.jdbc.CurrentConnection;
 import com.liferay.portal.kernel.dao.orm.Session;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
@@ -1114,7 +1114,7 @@ public class ObjectEntryLocalServiceImpl
 			_log.debug("SQL: " + sql);
 		}
 
-		Connection connection = CurrentConnectionUtil.getConnection(
+		Connection connection = _currentConnection.getConnection(
 			objectEntryPersistence.getDataSource());
 
 		try (PreparedStatement preparedStatement = connection.prepareStatement(
@@ -1499,7 +1499,7 @@ public class ObjectEntryLocalServiceImpl
 			_log.debug("SQL: " + sql);
 		}
 
-		Connection connection = CurrentConnectionUtil.getConnection(
+		Connection connection = _currentConnection.getConnection(
 			objectEntryPersistence.getDataSource());
 
 		try (PreparedStatement preparedStatement = connection.prepareStatement(
@@ -1592,7 +1592,7 @@ public class ObjectEntryLocalServiceImpl
 
 		int count = 0;
 
-		Connection connection = CurrentConnectionUtil.getConnection(
+		Connection connection = _currentConnection.getConnection(
 			objectEntryPersistence.getDataSource());
 
 		try (PreparedStatement preparedStatement = connection.prepareStatement(
@@ -1631,7 +1631,7 @@ public class ObjectEntryLocalServiceImpl
 
 		int count = 0;
 
-		Connection connection = CurrentConnectionUtil.getConnection(
+		Connection connection = _currentConnection.getConnection(
 			objectEntryPersistence.getDataSource());
 
 		try (PreparedStatement preparedStatement = connection.prepareStatement(
@@ -1698,6 +1698,9 @@ public class ObjectEntryLocalServiceImpl
 
 	@Reference
 	private AssetLinkLocalService _assetLinkLocalService;
+
+	@Reference
+	private CurrentConnection _currentConnection;
 
 	@Reference
 	private GroupLocalService _groupLocalService;

--- a/modules/apps/object/object-test/src/testFunctional/macros/Picklist.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/Picklist.macro
@@ -56,6 +56,16 @@ definition {
 			value1 = "No items were found.");
 	}
 
+	macro assertEntryRelationshipFieldPicklist {
+		Click(
+			key_selectField = "${selectField}",
+			locator1 = "Picklist#SELECT_FIELD_RELATIONSHIP_OBJECT");
+
+		AssertElementPresent(
+			key_entry = "${newEntry}",
+			locator1 = "CreateObject#ENTRY_RELATIONSHIP_FIELD_OPTION");
+	}
+
 	macro assertPicklist {
 		var key_picklistName = "${picklistName}";
 
@@ -128,6 +138,20 @@ definition {
 
 	macro cancelUpdatePicklist {
 		Click.javaScriptClick(locator1 = "Picklist#CANCEL_UPDATE_PICKLIST");
+	}
+
+	macro chooseLanguagePicklistItem {
+		SelectFrameTop();
+
+		IFrame.selectModalFrame();
+
+		PortletEntry.changeLocale(locale = "${newlanguage}");
+
+		Type(
+			locator1 = "Picklist#EDIT_ITEM_NAME",
+			value1 = "${itemName}");
+
+		WaitForSPARefresh();
 	}
 
 	macro clickSaveButton {

--- a/modules/apps/object/object-test/src/testFunctional/paths/Picklist.path
+++ b/modules/apps/object/object-test/src/testFunctional/paths/Picklist.path
@@ -130,6 +130,16 @@
 		<td>//input[@class='field disabled form-control lfr-input-text']</td>
 		<td></td>
 	</tr>
+	<tr>
+		<td>EDIT_ITEM_NAME</td>
+		<td>//input[@class='form-control language-value field form-control lfr-input-text']</td>
+		<td></td>
+	</tr>
+	<tr>
+		<td>SELECT_FIELD_RELATIONSHIP_OBJECT</td>
+		<td>//div[(@class='form-builder-select-field input-group-container')and contains(.,'${key_selectField}')]/div[@class='form-control results-chosen select-field-trigger']</td>
+		<td></td>
+	</tr>
 </tbody>
 </table>
 </body>

--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectsPopulating.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectsPopulating.testcase
@@ -550,12 +550,59 @@ definition {
 	}
 
 	@description = "LPS-139902 - Verify that entries Object entries added through forms are not deleted when form is deleted"
-	@ignore = "Test Stub"
 	@priority = "4"
 	test EntriesAreNotDeletedWhenFormIsDeleted {
+		ObjectAdmin.addObjectViaAPI(
+			labelName = "Custom Object",
+			objectName = "CustomObject",
+			pluralLabelName = "Custom Objects");
 
-		// TODO LPS-141822 EntriesAreNotDeletedWhenFormIsDeleted pending implementation
+		ObjectAdmin.addObjectFieldViaAPI(
+			fieldLabelName = "Custom Field",
+			fieldName = "customObjectField",
+			fieldType = "String",
+			isRequired = "false",
+			objectName = "CustomObject");
 
+		ObjectAdmin.publishObjectViaAPI(objectName = "CustomObject");
+
+		PopulateObjectFormsConfiguration.openForm();
+
+		FormsAdminNavigator.gotoAddForm();
+
+		Form.editName(formName = "Form 1");
+
+		PopulateObjectFormsConfiguration.openFormSettings();
+
+		PopulateObjectFormsConfiguration.selectObject(label = "Object");
+
+		PopulateObjectFormsConfiguration.selectCustomObject(label = "Custom Object");
+
+		Form.gotoAddField(fieldType = "Text");
+
+		PopulateObjectFormsConfiguration.mapFormField(fieldLabelName = "Custom Field");
+
+		Form.save();
+
+		Form.publishForm();
+
+		FormsAdminNavigator.gotoPublishedForm();
+
+		FormViewBuilder.editText(
+			fieldName = "Text",
+			fieldValue = "Test text");
+
+		FormPortlet.submitSuccessfully();
+
+		Navigator.openURL();
+
+		PopulateObjectFormsConfiguration.openForm();
+
+		FormsAdmin.deleteForm(formName = "Form 1");
+
+		ObjectAdmin.goToCustomObject(objectName = "CustomObject");
+
+		ObjectPortlet.viewEntry(entry = "Test text");
 	}
 
 	@description = "LPS-136451 - Verify if it's possible to see the entries of a field with capitalized letters in the name"

--- a/modules/apps/object/object-test/src/testFunctional/tests/Picklist.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/Picklist.testcase
@@ -390,12 +390,72 @@ definition {
 	}
 
 	@description = "LPS-136595 - Verify that the translated Picklist item's name will be displayed on the Object layout"
-	@ignore = "Test Stub"
 	@priority = "3"
 	test ViewTranslatedPicklistItemNameOnObjectLayout {
+		Picklist.addPicklistViaAPI(picklistName = "Picklist Test");
 
-		// TODO LPS-139770 ViewTranslatedPicklistItemNameOnObjectLayout pending implementation
+		Picklist.addPicklistItemViaAPI(
+			itemKey = "entryTest",
+			itemName = "Entry Test",
+			picklistName = "Picklist Test");
 
+		Picklist.gotoPicklists();
+
+		Picklist.gotoPicklistView(picklistName = "Picklist Test");
+
+		Picklist.assertPicklistDetails(title = "Items");
+
+		ObjectAdmin.selectKebabMenuOption(kebabOption = "View");
+
+		Picklist.chooseLanguagePicklistItem(
+			itemName = "Teste de entrada",
+			newlanguage = "pt-BR");
+
+		Button.clickSave();
+
+		Navigator.openURL();
+
+		ObjectAdmin.addObjectViaAPI(
+			labelName = "Custom Object",
+			objectName = "CustomObject",
+			pluralLabelName = "Custom Objects");
+
+		ObjectAdmin.openObjectAdmin();
+
+		ObjectPortlet.selectCustomObject(label = "Custom Object");
+
+		ObjectAdmin.goToFieldsTab();
+
+		ObjectAdmin.addObjectFieldViaUI(
+			fieldLabel = "Field Picklist",
+			fieldPicklist = "Picklist Test",
+			fieldType = "Picklist");
+
+		Navigator.openURL();
+
+		ObjectAdmin.publishObjectViaAPI(objectName = "CustomObject");
+
+		ObjectAdmin.goToCustomObject(objectName = "CustomObject");
+
+		ObjectAdmin.addObjectPicklistFieldEntryViaUI(picklistOption = "Entry Test");
+
+		User.openUsersAdmin();
+
+		User.editDisplaySettingsCP(
+			languageName = "português (Brasil)",
+			userScreenName = "test");
+
+		Navigator.openURL();
+
+		ObjectAdmin.goToCustomObject(objectName = "CustomObject");
+
+		ObjectPortlet.viewEntry(entry = "Teste de entrada");
+
+		LexiconEntry.gotoAdd();
+
+		Picklist.assertEntryRelationshipFieldPicklist(
+			newEntry = "Teste de entrada",
+			selectField = "Escolha");
 	}
 
 	@description = "LPS-136595 - Verify that the updating or deleting a picklist item warn message is displayed"

--- a/modules/apps/server/server-admin-web/src/main/java/com/liferay/server/admin/web/internal/portlet/action/EditServerMVCActionCommand.java
+++ b/modules/apps/server/server-admin-web/src/main/java/com/liferay/server/admin/web/internal/portlet/action/EditServerMVCActionCommand.java
@@ -31,7 +31,7 @@ import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.dao.orm.ProjectionFactoryUtil;
 import com.liferay.portal.kernel.dao.orm.Property;
 import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
-import com.liferay.portal.kernel.image.GhostscriptUtil;
+import com.liferay.portal.kernel.image.Ghostscript;
 import com.liferay.portal.kernel.image.ImageMagickUtil;
 import com.liferay.portal.kernel.io.unsync.UnsyncByteArrayOutputStream;
 import com.liferay.portal.kernel.io.unsync.UnsyncPrintWriter;
@@ -626,7 +626,7 @@ public class EditServerMVCActionCommand extends BaseMVCActionCommand {
 
 		portletPreferences.store();
 
-		GhostscriptUtil.reset();
+		_ghostscript.reset();
 		ImageMagickUtil.reset();
 	}
 
@@ -755,6 +755,9 @@ public class EditServerMVCActionCommand extends BaseMVCActionCommand {
 
 	@Reference
 	private DirectServletRegistry _directServletRegistry;
+
+	@Reference
+	private Ghostscript _ghostscript;
 
 	@Reference
 	private GroupLocalService _groupLocalService;

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/search/SXPIndexerPostProcessor.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/search/SXPIndexerPostProcessor.java
@@ -38,7 +38,6 @@ import org.osgi.service.component.annotations.Reference;
 @Component(
 	enabled = false, immediate = true,
 	property = {
-		"indexer.class.name=com.liferay.blogs.model.BlogsEntry",
 		"indexer.class.name=com.liferay.document.library.kernel.model.DLFileEntry",
 		"indexer.class.name=com.liferay.journal.model.JournalArticle",
 		"indexer.class.name=com.liferay.knowledge.base.model.KBArticle",

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/resources/portlet.properties
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/resources/portlet.properties
@@ -4,4 +4,4 @@ include-and-override=portlet-ext.properties
 # Input a list of comma delimited resource action configurations that will be
 # read from the class path.
 #
-resource.actions.configs=/resource-actions/default.xml
+resource.actions.configs=resource-actions/default.xml

--- a/modules/util/source-formatter/src/main/resources/sourcechecks.xml
+++ b/modules/util/source-formatter/src/main/resources/sourcechecks.xml
@@ -879,6 +879,7 @@
 			<property name="serviceReferenceUtilClassNames" value="com.liferay.portal.kernel.bean.BeanPropertiesUtil" />
 			<property name="serviceReferenceUtilClassNames" value="com.liferay.portal.kernel.comment.CommentManagerUtil" />
 			<property name="serviceReferenceUtilClassNames" value="com.liferay.portal.kernel.dao.jdbc.CurrentConnectionUtil" />
+			<property name="serviceReferenceUtilClassNames" value="com.liferay.portal.kernel.editor.configuration.EditorConfigurationFactoryUtil" />
 			<property name="serviceReferenceUtilClassNames" value="com.liferay.portal.kernel.util.HttpUtil" />
 			<property name="serviceReferenceUtilClassNames" value="com.liferay.portal.kernel.util.PortalUtil" />
 		</check>

--- a/modules/util/source-formatter/src/main/resources/sourcechecks.xml
+++ b/modules/util/source-formatter/src/main/resources/sourcechecks.xml
@@ -878,6 +878,7 @@
 			<property name="serviceReferenceUtilClassNames" value="com.liferay.portal.kernel.backgroundtask.display.BackgroundTaskDisplayFactoryUtil" />
 			<property name="serviceReferenceUtilClassNames" value="com.liferay.portal.kernel.bean.BeanPropertiesUtil" />
 			<property name="serviceReferenceUtilClassNames" value="com.liferay.portal.kernel.comment.CommentManagerUtil" />
+			<property name="serviceReferenceUtilClassNames" value="com.liferay.portal.kernel.dao.jdbc.CurrentConnectionUtil" />
 			<property name="serviceReferenceUtilClassNames" value="com.liferay.portal.kernel.util.HttpUtil" />
 			<property name="serviceReferenceUtilClassNames" value="com.liferay.portal.kernel.util.PortalUtil" />
 		</check>

--- a/modules/util/source-formatter/src/main/resources/sourcechecks.xml
+++ b/modules/util/source-formatter/src/main/resources/sourcechecks.xml
@@ -880,6 +880,7 @@
 			<property name="serviceReferenceUtilClassNames" value="com.liferay.portal.kernel.comment.CommentManagerUtil" />
 			<property name="serviceReferenceUtilClassNames" value="com.liferay.portal.kernel.dao.jdbc.CurrentConnectionUtil" />
 			<property name="serviceReferenceUtilClassNames" value="com.liferay.portal.kernel.editor.configuration.EditorConfigurationFactoryUtil" />
+			<property name="serviceReferenceUtilClassNames" value="com.liferay.portal.kernel.image.GhostscriptUtil" />
 			<property name="serviceReferenceUtilClassNames" value="com.liferay.portal.kernel.util.HttpUtil" />
 			<property name="serviceReferenceUtilClassNames" value="com.liferay.portal.kernel.util.PortalUtil" />
 		</check>

--- a/portal-impl/src/META-INF/util-spring.xml
+++ b/portal-impl/src/META-INF/util-spring.xml
@@ -18,6 +18,7 @@
 	<bean class="com.liferay.portal.bean.BeanPropertiesImpl" id="com.liferay.portal.bean.BeanPropertiesImpl" />
 	<bean class="com.liferay.portal.convert.documentlibrary.DocumentLibraryConvertProcess" />
 	<bean class="com.liferay.portal.convert.documentlibrary.DocumentLibraryExtraSettingsConvertProcess" />
+	<bean class="com.liferay.portal.dao.jdbc.CurrentConnectionImpl" id="com.liferay.portal.dao.jdbc.CurrentConnectionImpl" />
 	<bean class="com.liferay.portal.format.IdenticalPhoneNumberFormatImpl" id="com.liferay.portal.format.IdenticalPhoneNumberFormatImpl" />
 	<bean class="com.liferay.portal.internal.increment.BufferedIncrementProcessorUtil" />
 	<bean factory-bean="com.liferay.portal.kernel.json.JSONFactory" factory-method="getLiferayJSONDeserializationWhitelist" id="com.liferay.portal.json.jabsorb.serializer.LiferayJSONDeserializationWhitelist" />
@@ -47,9 +48,7 @@
 		</property>
 	</bean>
 	<bean class="com.liferay.portal.kernel.dao.jdbc.CurrentConnectionUtil">
-		<property name="currentConnection">
-			<bean class="com.liferay.portal.dao.jdbc.CurrentConnectionImpl" />
-		</property>
+		<property name="currentConnection" ref="com.liferay.portal.dao.jdbc.CurrentConnectionImpl" />
 	</bean>
 	<bean class="com.liferay.portal.kernel.dao.jdbc.MappingSqlQueryFactoryUtil" id="com.liferay.portal.kernel.dao.jdbc.MappingSqlQueryFactoryUtil">
 		<property name="mappingSqlQueryFactory">

--- a/portal-impl/src/META-INF/util-spring.xml
+++ b/portal-impl/src/META-INF/util-spring.xml
@@ -20,6 +20,7 @@
 	<bean class="com.liferay.portal.convert.documentlibrary.DocumentLibraryExtraSettingsConvertProcess" />
 	<bean class="com.liferay.portal.dao.jdbc.CurrentConnectionImpl" id="com.liferay.portal.dao.jdbc.CurrentConnectionImpl" />
 	<bean class="com.liferay.portal.format.IdenticalPhoneNumberFormatImpl" id="com.liferay.portal.format.IdenticalPhoneNumberFormatImpl" />
+	<bean class="com.liferay.portal.image.GhostscriptImpl" id="com.liferay.portal.image.GhostscriptImpl" />
 	<bean class="com.liferay.portal.internal.increment.BufferedIncrementProcessorUtil" />
 	<bean factory-bean="com.liferay.portal.kernel.json.JSONFactory" factory-method="getLiferayJSONDeserializationWhitelist" id="com.liferay.portal.json.jabsorb.serializer.LiferayJSONDeserializationWhitelist" />
 	<bean class="com.liferay.portal.kernel.bean.BeanPropertiesUtil" id="com.liferay.portal.kernel.bean.BeanPropertiesUtil">
@@ -82,9 +83,7 @@
 		</property>
 	</bean>
 	<bean class="com.liferay.portal.kernel.image.GhostscriptUtil" id="com.liferay.portal.kernel.image.GhostscriptUtil">
-		<property name="ghostscript">
-			<bean class="com.liferay.portal.image.GhostscriptImpl" />
-		</property>
+		<property name="ghostscript" ref="com.liferay.portal.image.GhostscriptImpl" />
 	</bean>
 	<bean class="com.liferay.portal.kernel.image.ImageToolUtil" id="com.liferay.portal.kernel.image.ImageToolUtil">
 		<property name="imageTool">

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/AnalyticsCloudConnectionTest.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/AnalyticsCloudConnectionTest.testcase
@@ -657,13 +657,10 @@ definition {
 	}
 
 	@description = "Automation ID: LRAC-8128 | Test Summary: View asset added by DXP data source"
-	@ignore = "true"
 	@priority = "5"
 	test ViewAssetAddedByDXPDataSource {
 		property portal.release = "true";
 		property portal.upstream = "quarantine";
-
-		// AC Bug Ticket: LRAC-10060
 
 		task ("Create site, page and add a blog to the page") {
 			ACUtils.addSiteAndPage();

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/AnalyticsCloudConnectionTest.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/AnalyticsCloudConnectionTest.testcase
@@ -660,7 +660,6 @@ definition {
 	@priority = "5"
 	test ViewAssetAddedByDXPDataSource {
 		property portal.release = "true";
-		property portal.upstream = "quarantine";
 
 		task ("Create site, page and add a blog to the page") {
 			ACUtils.addSiteAndPage();

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/AssetsBlogs.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/AssetsBlogs.testcase
@@ -38,12 +38,10 @@ definition {
 	}
 
 	@description = "Feature ID: Legacy | Automation ID: LRAC-8387 | Test Summary: Blogs asset appears on list shows pages that the blog exists on"
-	@ignore = "true"
 	@priority = "5"
 	test AssertAppearsOnListShowsPagesBlogExists {
 		property portal.upstream = "quarantine";
 
-		// AC Bug Ticket: LRAC-10060
 		// AC Refactor: It is not possible to perform the assert because this test presents timing problems.
 		// AC Refactor ticket: LRAC-9341
 
@@ -152,12 +150,9 @@ definition {
 	}
 
 	@description = "Feature ID: Legacy | Automation ID: LRAC-8374 | Test Summary: Blogs audience card shows expected amount of know and anonymous individuals"
-	@ignore = "true"
 	@priority = "5"
 	test AudienceCardShowsExpectedAmountKnowAndAnonymousIndividualsInBlogs {
 		property portal.upstream = "quarantine";
-
-		// AC Bug Ticket: LRAC-10060
 
 		var usernameList = "ac,liferay";
 		var emailList = "ac@liferay.com,liferay@liferay.com";
@@ -213,12 +208,9 @@ definition {
 	}
 
 	@description = "Feature ID: Legacy | Automation ID: LRAC-8375 | Test Summary: Blogs audience card shows expected amount of segmented and unsegmented individuals"
-	@ignore = "true"
 	@priority = "5"
 	test AudienceCardShowsExpectedAmountSegmentedAndUnsegmentedInBlogs {
 		property portal.upstream = "quarantine";
-
-		// AC Bug Ticket: LRAC-10060
 
 		var usernameList = "ac,liferay";
 		var emailList = "ac@liferay.com,liferay@liferay.com";
@@ -362,12 +354,9 @@ definition {
 	}
 
 	@description = "Feature ID: Legacy | Automation ID: LRAC-8386 | Test Summary: Blogs views by technology card shows views by the expected browser"
-	@ignore = "true"
 	@priority = "5"
 	test BlogsTechnologyCardShowsViewsByExpectedBrowser {
 		property portal.upstream = "quarantine";
-
-		// AC Bug Ticket: LRAC-10060
 
 		var propertyName = ACDXPSettings.connectDXPtoAnalyticsCloud(siteName = "Site Name");
 
@@ -417,12 +406,9 @@ definition {
 	}
 
 	@description = "Feature ID: Legacy | Automation ID: LRAC-8385 | Test Summary: Blogs views by technology card shows views by the expected device"
-	@ignore = "true"
 	@priority = "5"
 	test BlogsTechnologyCardShowsViewsByExpectedDevice {
 		property portal.upstream = "quarantine";
-
-		// AC Bug Ticket: LRAC-10060
 
 		var propertyName = ACDXPSettings.connectDXPtoAnalyticsCloud(siteName = "Site Name");
 
@@ -466,12 +452,9 @@ definition {
 	}
 
 	@description = "Feature ID: Legacy | Automation ID: LRAC-8382 | Test Summary: The blogs list is searchable"
-	@ignore = "true"
 	@priority = "5"
 	test CanBlogsListSearchable {
 		property portal.upstream = "quarantine";
-
-		// AC Bug Ticket: LRAC-10060
 
 		var propertyName = ACDXPSettings.connectDXPtoAnalyticsCloud(siteName = "Site Name");
 
@@ -511,12 +494,9 @@ definition {
 	}
 
 	@description = "Feature ID: Legacy | Automation ID: LRAC-8113 | Test Summary: Assert clicking a blog in the blogs list navigates to the blogs overview page"
-	@ignore = "true"
 	@priority = "5"
 	test CanNavigatesToBlogsOverviewPage {
 		property portal.upstream = "quarantine";
-
-		// AC Bug Ticket: LRAC-10060
 
 		var propertyName = ACDXPSettings.connectDXPtoAnalyticsCloud(siteName = "Site Name");
 
@@ -629,12 +609,9 @@ definition {
 	}
 
 	@description = "Feature ID: Legacy | Automation ID: LRAC-8114 | Test Summary: Blogs known individuals list shows individuals who have viewed the blog"
-	@ignore = "true"
 	@priority = "5"
 	test KnownIndividualsListShowsIndividualsWhoHaveViewedBlog {
 		property portal.upstream = "quarantine";
-
-		// AC Bug Ticket: LRAC-10060
 
 		var usernameList = "ac,dxp,liferay";
 		var emailList = "ac@liferay.com,dxp@liferay.com,liferay@liferay.com";
@@ -704,12 +681,9 @@ definition {
 	}
 
 	@description = "View all blogs in the property in assets"
-	@ignore = "true"
 	@priority = "5"
 	test ViewAllBlogsShownInAssetList {
 		property portal.upstream = "quarantine";
-
-		// AC Bug Ticket: LRAC-10060
 
 		ACUtils.createBlogsAndAddToPage(entryTitle = "Test 2");
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/AssetsBlogs.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/AssetsBlogs.testcase
@@ -152,8 +152,6 @@ definition {
 	@description = "Feature ID: Legacy | Automation ID: LRAC-8374 | Test Summary: Blogs audience card shows expected amount of know and anonymous individuals"
 	@priority = "5"
 	test AudienceCardShowsExpectedAmountKnowAndAnonymousIndividualsInBlogs {
-		property portal.upstream = "quarantine";
-
 		var usernameList = "ac,liferay";
 		var emailList = "ac@liferay.com,liferay@liferay.com";
 
@@ -210,8 +208,6 @@ definition {
 	@description = "Feature ID: Legacy | Automation ID: LRAC-8375 | Test Summary: Blogs audience card shows expected amount of segmented and unsegmented individuals"
 	@priority = "5"
 	test AudienceCardShowsExpectedAmountSegmentedAndUnsegmentedInBlogs {
-		property portal.upstream = "quarantine";
-
 		var usernameList = "ac,liferay";
 		var emailList = "ac@liferay.com,liferay@liferay.com";
 
@@ -356,8 +352,6 @@ definition {
 	@description = "Feature ID: Legacy | Automation ID: LRAC-8386 | Test Summary: Blogs views by technology card shows views by the expected browser"
 	@priority = "5"
 	test BlogsTechnologyCardShowsViewsByExpectedBrowser {
-		property portal.upstream = "quarantine";
-
 		var propertyName = ACDXPSettings.connectDXPtoAnalyticsCloud(siteName = "Site Name");
 
 		task ("View the blog") {
@@ -408,8 +402,6 @@ definition {
 	@description = "Feature ID: Legacy | Automation ID: LRAC-8385 | Test Summary: Blogs views by technology card shows views by the expected device"
 	@priority = "5"
 	test BlogsTechnologyCardShowsViewsByExpectedDevice {
-		property portal.upstream = "quarantine";
-
 		var propertyName = ACDXPSettings.connectDXPtoAnalyticsCloud(siteName = "Site Name");
 
 		task ("View the blog") {
@@ -454,8 +446,6 @@ definition {
 	@description = "Feature ID: Legacy | Automation ID: LRAC-8382 | Test Summary: The blogs list is searchable"
 	@priority = "5"
 	test CanBlogsListSearchable {
-		property portal.upstream = "quarantine";
-
 		var propertyName = ACDXPSettings.connectDXPtoAnalyticsCloud(siteName = "Site Name");
 
 		ACUtils.createBlogsAndAddToPage(entryTitle = "Test 2");
@@ -496,8 +486,6 @@ definition {
 	@description = "Feature ID: Legacy | Automation ID: LRAC-8113 | Test Summary: Assert clicking a blog in the blogs list navigates to the blogs overview page"
 	@priority = "5"
 	test CanNavigatesToBlogsOverviewPage {
-		property portal.upstream = "quarantine";
-
 		var propertyName = ACDXPSettings.connectDXPtoAnalyticsCloud(siteName = "Site Name");
 
 		JSONUser.addUser(
@@ -611,8 +599,6 @@ definition {
 	@description = "Feature ID: Legacy | Automation ID: LRAC-8114 | Test Summary: Blogs known individuals list shows individuals who have viewed the blog"
 	@priority = "5"
 	test KnownIndividualsListShowsIndividualsWhoHaveViewedBlog {
-		property portal.upstream = "quarantine";
-
 		var usernameList = "ac,dxp,liferay";
 		var emailList = "ac@liferay.com,dxp@liferay.com,liferay@liferay.com";
 		var nameList = "ac ac,liferay liferay,dxp dxp";
@@ -683,8 +669,6 @@ definition {
 	@description = "View all blogs in the property in assets"
 	@priority = "5"
 	test ViewAllBlogsShownInAssetList {
-		property portal.upstream = "quarantine";
-
 		ACUtils.createBlogsAndAddToPage(entryTitle = "Test 2");
 
 		var propertyName = ACDXPSettings.connectDXPtoAnalyticsCloud(siteName = "Site Name");

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/DeleteSegments.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/DeleteSegments.testcase
@@ -106,8 +106,6 @@ definition {
 	@description = "Delete a dynamic segment"
 	@priority = "5"
 	test CanDeleteDynamicSegment {
-		property portal.upstream = "quarantine";
-
 		ACUtils.createBlogsAndAddToPage();
 
 		var propertyName = ACDXPSettings.connectDXPtoAnalyticsCloud(siteName = "Site Name");

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/DeleteSegments.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/DeleteSegments.testcase
@@ -104,12 +104,9 @@ definition {
 	}
 
 	@description = "Delete a dynamic segment"
-	@ignore = "true"
 	@priority = "5"
 	test CanDeleteDynamicSegment {
 		property portal.upstream = "quarantine";
-
-		// AC Bug Ticket: LRAC-10060
 
 		ACUtils.createBlogsAndAddToPage();
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/EditSegments.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/EditSegments.testcase
@@ -36,12 +36,9 @@ definition {
 	}
 
 	@description = "Feature ID: Legacy | Automation ID: LRAC-8588 | Test Summary: Assert segment overview shows criteria"
-	@ignore = "true"
 	@priority = "3"
 	test AssertSegmentOverviewShowsCriteria {
 		property portal.upstream = "quarantine";
-
-		// AC Bug Ticket: LRAC-10060
 
 		task ("Create Blog and Add to Page") {
 			ACUtils.createBlogsAndAddToPage();
@@ -106,13 +103,10 @@ definition {
 	}
 
 	@description = "Edit a dynamic segment and check the edits are saved"
-	@ignore = "true"
 	@priority = "5"
 	test CanEditDynamicSegmentCheckEditSaved {
 		property portal.acceptance = "false";
 		property portal.upstream = "quarantine";
-
-		// AC Bug Ticket: LRAC-10060
 
 		ACUtils.createBlogsAndAddToPage();
 
@@ -216,12 +210,9 @@ definition {
 	}
 
 	@description = "Feature ID: Legacy | Automation ID: LRAC-8135 | Test Summary: Edit a static segment and check the edits are saved"
-	@ignore = "true"
 	@priority = "5"
 	test CanEditStaticSegmentCheckEditSaved {
 		property portal.upstream = "quarantine";
-
-		// AC Bug Ticket: LRAC-10060
 
 		var usernameList = "ac,liferay";
 		var emailList = "ac@liferay.com,liferay@liferay.com";
@@ -290,12 +281,9 @@ definition {
 	}
 
 	@description = "Feature ID: Legacy | Automation ID: LRAC-8136 | Test Summary: Rename Individuals Segment"
-	@ignore = "true"
 	@priority = "5"
 	test CanRenameIndividualsSegment {
 		property portal.upstream = "quarantine";
-
-		// AC Bug Ticket: LRAC-10060
 
 		ACUtils.createBlogsAndAddToPage();
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/EditSegments.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/EditSegments.testcase
@@ -38,8 +38,6 @@ definition {
 	@description = "Feature ID: Legacy | Automation ID: LRAC-8588 | Test Summary: Assert segment overview shows criteria"
 	@priority = "3"
 	test AssertSegmentOverviewShowsCriteria {
-		property portal.upstream = "quarantine";
-
 		task ("Create Blog and Add to Page") {
 			ACUtils.createBlogsAndAddToPage();
 		}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/SegmentsCreationWebBehavior.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/SegmentsCreationWebBehavior.testcase
@@ -737,12 +737,8 @@ definition {
 	}
 
 	@description = "Create a Web Behavior using 'has not' segment"
-	@ignore = "true"
 	@priority = "5"
 	test CanCreateWebBehaviorSegmentUsingHasNot {
-
-		// AC Bug Ticket: LRAC-10060
-
 		ACUtils.createBlogsAndAddToPage();
 
 		var propertyName = ACDXPSettings.connectDXPtoAnalyticsCloud(siteName = "Site Name");
@@ -895,13 +891,10 @@ definition {
 	}
 
 	@description = "Add segment using a web behavior 'since' some time"
-	@ignore = "true"
 	@priority = "5"
 	test CanCreateWebBehaviorSegmentUsingSince {
 		property portal.upstream = "quarantine";
 		property test.name.skip.portal.instance = "SegmentsCreationWebBehavior#CanCreateWebBehaviorSegmentUsingSince";
-
-		// AC Bug Ticket: LRAC-10060
 
 		ACUtils.createBlogsAndAddToPage();
 
@@ -980,12 +973,8 @@ definition {
 	}
 
 	@description = "Feature ID: Legacy | Automation ID: LRAC-9223 | Test Summary: Create a Web Behavior Segment of Viewing a Blog"
-	@ignore = "true"
 	@priority = "4"
 	test CanCreateWebBehaviorSegmentViewingBlog {
-
-		// AC Bug Ticket: LRAC-10060
-
 		ACUtils.createBlogsAndAddToPage();
 
 		var propertyName = ACDXPSettings.connectDXPtoAnalyticsCloud(siteName = "Site Name");

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/SegmentsCreationWebBehavior.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/SegmentsCreationWebBehavior.testcase
@@ -893,7 +893,6 @@ definition {
 	@description = "Add segment using a web behavior 'since' some time"
 	@priority = "5"
 	test CanCreateWebBehaviorSegmentUsingSince {
-		property portal.upstream = "quarantine";
 		property test.name.skip.portal.instance = "SegmentsCreationWebBehavior#CanCreateWebBehaviorSegmentUsingSince";
 
 		ACUtils.createBlogsAndAddToPage();

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/SegmentsMembership.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/SegmentsMembership.testcase
@@ -246,12 +246,9 @@ definition {
 	}
 
 	@description = "Feature ID: Legacy | Automation ID: LRAC-8513 | Test Summary: Order the Segment Profile Membership List"
-	@ignore = "true"
 	@priority = "3"
 	test OrderSegmentProfileMembershipList {
 		property portal.upstream = "quarantine";
-
-		// AC Bug Ticket: LRAC-10060
 
 		var emailList = "user1@liferay.com,user2@liferay.com,user3@liferay.com";
 		var nameList = "user1 user1,user2 user2,user3 user3";
@@ -331,12 +328,9 @@ definition {
 	}
 
 	@description = "Feature ID: Legacy | Automation ID: LRAC-8519 | Test Summary: Search a Dynamic Segment's Membership Preview Modal"
-	@ignore = "true"
 	@priority = "3"
 	test SearchDynamicSegmentsMembershipPreviewModal {
 		property portal.upstream = "quarantine";
-
-		// AC Bug Ticket: LRAC-10060
 
 		var emailList = "user1@liferay.com,user2@liferay.com,user3@liferay.com";
 		var nameList = "user1 user1,user2 user2,user3 user3";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/SegmentsMembership.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/SegmentsMembership.testcase
@@ -248,8 +248,6 @@ definition {
 	@description = "Feature ID: Legacy | Automation ID: LRAC-8513 | Test Summary: Order the Segment Profile Membership List"
 	@priority = "3"
 	test OrderSegmentProfileMembershipList {
-		property portal.upstream = "quarantine";
-
 		var emailList = "user1@liferay.com,user2@liferay.com,user3@liferay.com";
 		var nameList = "user1 user1,user2 user2,user3 user3";
 


### PR DESCRIPTION
Related Issue: https://issues.liferay.com/browse/LPS-145897

Hello Reviewer!

This PR has a fix of the bug above. The `formattedDate` was being wrongly calculated when the date field didn't have time; now it has an `isDateTime` verification before the operations to avoid that. 
If you have any questions feel free to ask, thank you for your time!