### PR TITLE
LPS-145983 Set time default value as 12AM for english language

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/DatePicker/DatePicker.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/DatePicker/DatePicker.es.js
@@ -209,13 +209,20 @@ export default function DatePicker({
 			inputRef.current.focus();
 		}
 
+		/**
+		 * TO DO: When Clay change their implementation of the default time
+		 * value to '--:--' remember to change the code bellow of formattedTime
+		 */
+
 		let formattedDate = value;
 		if (isDateTime) {
 			const firstSpace = value.indexOf(' ');
 			formattedDate = value.substring(0, firstSpace);
-			const formattedTime = value
-				.substring(firstSpace)
-				.replaceAll('-', '_');
+			let formattedTime = value.substring(firstSpace);
+			formattedTime =
+				use12Hours && formattedTime === ' 00:00'
+					? ' 12:00 AM'
+					: formattedTime.replaceAll('-', '_');
 			formattedDate = `${formattedDate}${formattedTime}`;
 		}
 		const nextState = {
@@ -223,7 +230,7 @@ export default function DatePicker({
 			rawDate: '',
 		};
 
-		const date = moment(value, momentFormat, true);
+		const date = moment(formattedDate, momentFormat, true);
 		if (date.isValid()) {
 			nextState.rawDate = date.locale('en').format(serverFormat);
 			nextState.years = {end: date.year() + 5, start: date.year() - 5};


### PR DESCRIPTION
Related Issue: https://issues.liferay.com/browse/LPS-145983

Hello Reviewer!

This PR has a fix of the impedibug above. I had to force the code to put 12 AM as the default value for english language when the date picker modal sends their default value as `'00:00'`. The ideal fix for this issue has yet to be discussed with the Clay Team and thats why a `TO DO` comment is present.
If you have any questions feel free to ask, thank you for your time!