### PR TITLE
LPS-144911 Set fieldName column's type from VARCHAR(255) to TEXT in a new upgrade process

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/model/DDMFieldTable.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/model/DDMFieldTable.java
@@ -17,6 +17,7 @@ package com.liferay.dynamic.data.mapping.model;
 import com.liferay.petra.sql.dsl.Column;
 import com.liferay.petra.sql.dsl.base.BaseTable;
 
+import java.sql.Clob;
 import java.sql.Types;
 
 /**
@@ -44,8 +45,8 @@ public class DDMFieldTable extends BaseTable<DDMFieldTable> {
 		"storageId", Long.class, Types.BIGINT, Column.FLAG_DEFAULT);
 	public final Column<DDMFieldTable, Long> structureVersionId = createColumn(
 		"structureVersionId", Long.class, Types.BIGINT, Column.FLAG_DEFAULT);
-	public final Column<DDMFieldTable, String> fieldName = createColumn(
-		"fieldName", String.class, Types.VARCHAR, Column.FLAG_DEFAULT);
+	public final Column<DDMFieldTable, Clob> fieldName = createColumn(
+		"fieldName", Clob.class, Types.CLOB, Column.FLAG_DEFAULT);
 	public final Column<DDMFieldTable, String> fieldType = createColumn(
 		"fieldType", String.class, Types.VARCHAR, Column.FLAG_DEFAULT);
 	public final Column<DDMFieldTable, String> instanceId = createColumn(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/bnd.bnd
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/bnd.bnd
@@ -35,6 +35,6 @@ Import-Package:\
 	org.tukaani.*;resolution:=optional,\
 	\
 	*
-Liferay-Require-SchemaVersion: 5.1.2
+Liferay-Require-SchemaVersion: 5.1.3
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/DDMServiceUpgrade.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/DDMServiceUpgrade.java
@@ -479,6 +479,11 @@ public class DDMServiceUpgrade implements UpgradeStepRegistrator {
 			"5.1.1", "5.1.2",
 			new com.liferay.dynamic.data.mapping.internal.upgrade.v5_1_2.
 				DDMFormInstanceUpgradeProcess(_jsonFactory));
+
+		registry.register(
+			"5.1.2", "5.1.3",
+			new com.liferay.dynamic.data.mapping.internal.upgrade.v5_1_3.
+				FieldNameUpgradeProcess());
 	}
 
 	@Activate

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v4_1_0/DDMFieldUpgradeProcess.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v4_1_0/DDMFieldUpgradeProcess.java
@@ -81,9 +81,9 @@ public class DDMFieldUpgradeProcess extends UpgradeProcess {
 				"create table DDMField (mvccVersion LONG default 0 not null, ",
 				"ctCollectionId LONG default 0 not null, fieldId LONG not ",
 				"null, companyId LONG, parentFieldId LONG, storageId LONG, ",
-				"structureVersionId LONG, fieldName VARCHAR(255) null, ",
-				"fieldType VARCHAR(255) null, instanceId VARCHAR(75) null, ",
-				"localizable BOOLEAN, priority INTEGER, primary key (fieldId, ",
+				"structureVersionId LONG, fieldName TEXT null, fieldType ",
+				"VARCHAR(255) null, instanceId VARCHAR(75) null, localizable ",
+				"BOOLEAN, priority INTEGER, primary key (fieldId, ",
 				"ctCollectionId))"));
 
 		runSQL(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_1_3/FieldNameUpgradeProcess.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_1_3/FieldNameUpgradeProcess.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.dynamic.data.mapping.internal.upgrade.v5_1_3;
+
+import com.liferay.dynamic.data.mapping.internal.upgrade.v5_1_3.util.DDMFieldTable;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+
+/**
+ * @author István András Dézsi
+ */
+public class FieldNameUpgradeProcess extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		if (!hasColumnType("DDMField", "fieldName", "TEXT null")) {
+			alter(
+				DDMFieldTable.class,
+				new AlterColumnType("fieldName", "TEXT null"));
+		}
+	}
+
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_1_3/util/DDMFieldTable.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_1_3/util/DDMFieldTable.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.dynamic.data.mapping.internal.upgrade.v5_1_3.util;
+
+import java.sql.Types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author	  Brian Wing Shun Chan
+ * @generated
+ */
+public class DDMFieldTable {
+
+	public static final String TABLE_NAME = "DDMField";
+
+	public static final Object[][] TABLE_COLUMNS = {
+		{"mvccVersion", Types.BIGINT}, {"ctCollectionId", Types.BIGINT},
+		{"fieldId", Types.BIGINT}, {"companyId", Types.BIGINT},
+		{"parentFieldId", Types.BIGINT}, {"storageId", Types.BIGINT},
+		{"structureVersionId", Types.BIGINT}, {"fieldName", Types.CLOB},
+		{"fieldType", Types.VARCHAR}, {"instanceId", Types.VARCHAR},
+		{"localizable", Types.BOOLEAN}, {"priority", Types.INTEGER}
+	};
+
+	public static final Map<String, Integer> TABLE_COLUMNS_MAP =
+new HashMap<String, Integer>();
+
+static {
+TABLE_COLUMNS_MAP.put("mvccVersion", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("ctCollectionId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("fieldId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("parentFieldId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("storageId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("structureVersionId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("fieldName", Types.CLOB);
+
+TABLE_COLUMNS_MAP.put("fieldType", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("instanceId", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("localizable", Types.BOOLEAN);
+
+TABLE_COLUMNS_MAP.put("priority", Types.INTEGER);
+
+}
+	public static final String TABLE_SQL_CREATE =
+"create table DDMField (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,fieldId LONG not null,companyId LONG,parentFieldId LONG,storageId LONG,structureVersionId LONG,fieldName TEXT null,fieldType VARCHAR(255) null,instanceId VARCHAR(75) null,localizable BOOLEAN,priority INTEGER,primary key (fieldId, ctCollectionId))";
+
+	public static final String TABLE_SQL_DROP = "drop table DDMField";
+
+	public static final String[] TABLE_SQL_ADD_INDEXES = {
+		"create index IX_5378BAAD on DDMField (companyId, fieldType[$COLUMN_LENGTH:255$], ctCollectionId)",
+		"create index IX_582EBFF1 on DDMField (storageId, ctCollectionId)",
+		"create unique index IX_1BB20E75 on DDMField (storageId, instanceId[$COLUMN_LENGTH:75$], ctCollectionId)",
+		"create index IX_5C0B8AE5 on DDMField (structureVersionId, ctCollectionId)"
+	};
+
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/model/impl/DDMFieldCacheModel.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/model/impl/DDMFieldCacheModel.java
@@ -147,7 +147,9 @@ public class DDMFieldCacheModel
 	}
 
 	@Override
-	public void readExternal(ObjectInput objectInput) throws IOException {
+	public void readExternal(ObjectInput objectInput)
+		throws ClassNotFoundException, IOException {
+
 		mvccVersion = objectInput.readLong();
 
 		ctCollectionId = objectInput.readLong();
@@ -161,7 +163,7 @@ public class DDMFieldCacheModel
 		storageId = objectInput.readLong();
 
 		structureVersionId = objectInput.readLong();
-		fieldName = objectInput.readUTF();
+		fieldName = (String)objectInput.readObject();
 		fieldType = objectInput.readUTF();
 		instanceId = objectInput.readUTF();
 
@@ -187,10 +189,10 @@ public class DDMFieldCacheModel
 		objectOutput.writeLong(structureVersionId);
 
 		if (fieldName == null) {
-			objectOutput.writeUTF("");
+			objectOutput.writeObject("");
 		}
 		else {
-			objectOutput.writeUTF(fieldName);
+			objectOutput.writeObject(fieldName);
 		}
 
 		if (fieldType == null) {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/model/impl/DDMFieldModelImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/model/impl/DDMFieldModelImpl.java
@@ -70,7 +70,7 @@ public class DDMFieldModelImpl
 		{"mvccVersion", Types.BIGINT}, {"ctCollectionId", Types.BIGINT},
 		{"fieldId", Types.BIGINT}, {"companyId", Types.BIGINT},
 		{"parentFieldId", Types.BIGINT}, {"storageId", Types.BIGINT},
-		{"structureVersionId", Types.BIGINT}, {"fieldName", Types.VARCHAR},
+		{"structureVersionId", Types.BIGINT}, {"fieldName", Types.CLOB},
 		{"fieldType", Types.VARCHAR}, {"instanceId", Types.VARCHAR},
 		{"localizable", Types.BOOLEAN}, {"priority", Types.INTEGER}
 	};
@@ -86,7 +86,7 @@ public class DDMFieldModelImpl
 		TABLE_COLUMNS_MAP.put("parentFieldId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("storageId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("structureVersionId", Types.BIGINT);
-		TABLE_COLUMNS_MAP.put("fieldName", Types.VARCHAR);
+		TABLE_COLUMNS_MAP.put("fieldName", Types.CLOB);
 		TABLE_COLUMNS_MAP.put("fieldType", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("instanceId", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("localizable", Types.BOOLEAN);
@@ -94,7 +94,7 @@ public class DDMFieldModelImpl
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table DDMField (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,fieldId LONG not null,companyId LONG,parentFieldId LONG,storageId LONG,structureVersionId LONG,fieldName VARCHAR(255) null,fieldType VARCHAR(255) null,instanceId VARCHAR(75) null,localizable BOOLEAN,priority INTEGER,primary key (fieldId, ctCollectionId))";
+		"create table DDMField (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,fieldId LONG not null,companyId LONG,parentFieldId LONG,storageId LONG,structureVersionId LONG,fieldName TEXT null,fieldType VARCHAR(255) null,instanceId VARCHAR(75) null,localizable BOOLEAN,priority INTEGER,primary key (fieldId, ctCollectionId))";
 
 	public static final String TABLE_SQL_DROP = "drop table DDMField";
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/META-INF/module-hbm.xml
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/META-INF/module-hbm.xml
@@ -58,7 +58,7 @@
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="parentFieldId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="storageId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="structureVersionId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
-		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="fieldName" type="com.liferay.portal.dao.orm.hibernate.StringType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="fieldName" type="com.liferay.portal.dao.orm.hibernate.StringClobType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="fieldType" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="instanceId" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="localizable" type="com.liferay.portal.dao.orm.hibernate.BooleanType" />

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -62,7 +62,7 @@
 		<field name="storageId" type="long" />
 		<field name="structureVersionId" type="long" />
 		<field name="fieldName" type="String">
-			<hint name="max-length">255</hint>
+			<hint-collection name="CLOB" />
 		</field>
 		<field name="fieldType" type="String">
 			<hint name="max-length">255</hint>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/META-INF/sql/tables.sql
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/META-INF/sql/tables.sql
@@ -52,7 +52,7 @@ create table DDMField (
 	parentFieldId LONG,
 	storageId LONG,
 	structureVersionId LONG,
-	fieldName VARCHAR(255) null,
+	fieldName TEXT null,
 	fieldType VARCHAR(255) null,
 	instanceId VARCHAR(75) null,
 	localizable BOOLEAN,

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMFieldPersistenceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/persistence/test/DDMFieldPersistenceTest.java
@@ -239,8 +239,8 @@ public class DDMFieldPersistenceTest {
 		return OrderByComparatorFactoryUtil.create(
 			"DDMField", "mvccVersion", true, "ctCollectionId", true, "fieldId",
 			true, "companyId", true, "parentFieldId", true, "storageId", true,
-			"structureVersionId", true, "fieldName", true, "fieldType", true,
-			"instanceId", true, "localizable", true, "priority", true);
+			"structureVersionId", true, "fieldType", true, "instanceId", true,
+			"localizable", true, "priority", true);
 	}
 
 	@Test


### PR DESCRIPTION
Related Issue: https://issues.liferay.com/browse/LPS-144911

Dear Team,

I modified the solution so it addresses Brian's concerns in https://github.com/brianchandotcom/liferay-portal/pull/112555#issuecomment-1020521780

`FieldNameUpgradeProcess` sets the `fieldName` column's type explicitly to TEXT if it not already has that type.
 
Thank you and best regards,
István