### PR TITLE
LPS-145982 Adjust pipe mask format logic to work with hungarian language

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/DatePicker/DatePicker.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/DatePicker/DatePicker.es.js
@@ -21,7 +21,7 @@ import {FieldBase} from '../FieldBase/ReactFieldBase.es';
 import {createAutoCorrectedDatePipe} from './createAutoCorrectedDatePipe';
 
 const DIGIT_REGEX = /\d/;
-const PIPE_FORBIDDEN_ENDING_CHAR_REGEX = /[^\w]|[a]$/i;
+const PIPE_FORBIDDEN_ENDING_CHAR_REGEX = /[^\w]/i;
 const LETTER_REGEX = /[a-z]/i;
 const SERVER_DATE_FORMAT = 'YYYY-MM-DD';
 const SERVER_DATE_TIME_FORMAT = 'YYYY-MM-DD HH:mm';
@@ -183,8 +183,11 @@ export default function DatePicker({
 						return `${format} dd`;
 					case 'mm':
 						return `${format} MM`;
-					case '':
+					case 'A':
+					case 'a':
 						return format;
+					case '':
+						return `${format} `;
 					default:
 						return `${format} ${item}`;
 				}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/DatePicker/DatePicker.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/DatePicker/DatePicker.es.js
@@ -50,8 +50,6 @@ export default function DatePicker({
 }) {
 	const inputRef = useRef(null);
 	const maskRef = useRef();
-	const [expanded, setExpand] = useState(false);
-
 	const {
 		clayFormat,
 		isDateTime,
@@ -203,11 +201,7 @@ export default function DatePicker({
 		});
 	}, [momentFormat]);
 
-	const handleValueChange = (value, eventType) => {
-		if (eventType === 'click') {
-			setExpand(false);
-			inputRef.current.focus();
-		}
+	const handleValueChange = (value) => {
 
 		/**
 		 * TODO When Clay change their implementation of the default time
@@ -254,10 +248,8 @@ export default function DatePicker({
 				dateFormat={clayFormat}
 				dir={dir}
 				disabled={readOnly}
-				expanded={expanded}
 				months={months}
 				onBlur={onBlur}
-				onExpandedChange={setExpand}
 				onFocus={onFocus}
 				onInput={({target: {value}}) => maskRef.current.update(value)}
 				onValueChange={handleValueChange}


### PR DESCRIPTION
Related Issues: 

- https://issues.liferay.com/browse/LPS-145986
- https://issues.liferay.com/browse/LPS-145982

Hello Reviewer!

This PR has a fix of the bugs above. The first commit is to avoid closing the Date Picker modal after selecting a date so the user can select an hour value without the need to open the modal again. 

The second one fixes an issue on the pipe mask that wasn't working for the Hungarian language. The correct format for this language is `'yyyy mm dd  HH:MM'` with two spaces between `dd` and `HH` but the mask was sending only one, so I changed the logic to cover this case as well.

If you have any questions feel free to ask, thank you for your time!