### PR TITLE
LPS-146617 Improve code of DDMIndexerImpl.createFieldValueQueryFilter and DDMIndexerImpl._addFieldValueRequiredTerm methods

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMIndexerImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMIndexerImpl.java
@@ -548,6 +548,10 @@ public class DDMIndexerImpl implements DDMIndexer {
 					fieldReference, "localizable"));
 		}
 
+		if (!localizable) {
+			locale = null;
+		}
+
 		if (ddmStructureFieldValue instanceof String[]) {
 			String[] ddmStructureFieldValueArray =
 				(String[])ddmStructureFieldValue;
@@ -557,15 +561,13 @@ public class DDMIndexerImpl implements DDMIndexer {
 
 				_addFieldValueRequiredTerm(
 					booleanQuery, ddmStructureFieldName,
-					ddmStructureFieldValueString, indexType, locale,
-					localizable);
+					ddmStructureFieldValueString, indexType, locale);
 			}
 		}
 		else {
 			_addFieldValueRequiredTerm(
 				booleanQuery, ddmStructureFieldName,
-				String.valueOf(ddmStructureFieldValue), indexType, locale,
-				localizable);
+				String.valueOf(ddmStructureFieldValue), indexType, locale);
 		}
 
 		if (isLegacyDDMIndexFieldsEnabled()) {
@@ -630,8 +632,7 @@ public class DDMIndexerImpl implements DDMIndexer {
 
 	private void _addFieldValueRequiredTerm(
 		BooleanQuery booleanQuery, String ddmStructureFieldName,
-		String ddmStructureFieldValue, String indexType, Locale locale,
-		boolean localizable) {
+		String ddmStructureFieldValue, String indexType, Locale locale) {
 
 		if (isLegacyDDMIndexFieldsEnabled()) {
 			booleanQuery.addRequiredTerm(
@@ -645,10 +646,6 @@ public class DDMIndexerImpl implements DDMIndexer {
 			StringBundler.concat(
 				DDM_FIELD_ARRAY, StringPool.PERIOD, DDM_FIELD_NAME),
 			ddmStructureFieldName);
-
-		if (!localizable) {
-			locale = null;
-		}
 
 		booleanQuery.addRequiredTerm(
 			StringBundler.concat(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMIndexerImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMIndexerImpl.java
@@ -533,8 +533,6 @@ public class DDMIndexerImpl implements DDMIndexer {
 			String indexType, Locale locale)
 		throws Exception {
 
-		BooleanQuery booleanQuery = new BooleanQueryImpl();
-
 		boolean localizable = false;
 
 		if (ddmStructure.hasFieldByFieldReference(fieldReference)) {
@@ -552,6 +550,8 @@ public class DDMIndexerImpl implements DDMIndexer {
 			locale = null;
 		}
 
+		BooleanQuery booleanQuery = new BooleanQueryImpl();
+
 		if (!isLegacyDDMIndexFieldsEnabled()) {
 			booleanQuery.addRequiredTerm(
 				StringBundler.concat(
@@ -563,25 +563,8 @@ public class DDMIndexerImpl implements DDMIndexer {
 				getValueFieldName(indexType, locale));
 		}
 
-		if (ddmStructureFieldValue instanceof String[]) {
-			String[] ddmStructureFieldValueArray =
-				(String[])ddmStructureFieldValue;
-
-			for (String ddmStructureFieldValueString :
-					ddmStructureFieldValueArray) {
-
-				booleanQuery.addRequiredTerm(
-					ddmStructureFieldName,
-					StringPool.QUOTE + ddmStructureFieldValueString +
-						StringPool.QUOTE);
-			}
-		}
-		else {
-			booleanQuery.addRequiredTerm(
-				ddmStructureFieldName,
-				StringPool.QUOTE + String.valueOf(ddmStructureFieldValue) +
-					StringPool.QUOTE);
-		}
+		_addFieldValueRequiredTerm(
+			booleanQuery, ddmStructureFieldName, ddmStructureFieldValue);
 
 		if (isLegacyDDMIndexFieldsEnabled()) {
 			return new QueryFilter(booleanQuery);
@@ -642,6 +625,26 @@ public class DDMIndexerImpl implements DDMIndexer {
 
 	@Reference
 	protected Sorts sorts;
+
+	private void _addFieldValueRequiredTerm(
+		BooleanQuery booleanQuery, String fieldName, Serializable fieldValue) {
+
+		if (fieldValue instanceof String[]) {
+			String[] fieldValueArray = (String[])fieldValue;
+
+			for (String fieldValueString : fieldValueArray) {
+				booleanQuery.addRequiredTerm(
+					fieldName,
+					StringPool.QUOTE + fieldValueString + StringPool.QUOTE);
+			}
+		}
+		else {
+			booleanQuery.addRequiredTerm(
+				fieldName,
+				StringPool.QUOTE + String.valueOf(fieldValue) +
+					StringPool.QUOTE);
+		}
+	}
 
 	private void _addToDocument(
 			Document document, Field field, String indexType, String name,

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMIndexerImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMIndexerImpl.java
@@ -552,6 +552,17 @@ public class DDMIndexerImpl implements DDMIndexer {
 			locale = null;
 		}
 
+		if (!isLegacyDDMIndexFieldsEnabled()) {
+			booleanQuery.addRequiredTerm(
+				StringBundler.concat(
+					DDM_FIELD_ARRAY, StringPool.PERIOD, DDM_FIELD_NAME),
+				ddmStructureFieldName);
+
+			ddmStructureFieldName = StringBundler.concat(
+				DDM_FIELD_ARRAY, StringPool.PERIOD,
+				getValueFieldName(indexType, locale));
+		}
+
 		if (ddmStructureFieldValue instanceof String[]) {
 			String[] ddmStructureFieldValueArray =
 				(String[])ddmStructureFieldValue;
@@ -559,15 +570,17 @@ public class DDMIndexerImpl implements DDMIndexer {
 			for (String ddmStructureFieldValueString :
 					ddmStructureFieldValueArray) {
 
-				_addFieldValueRequiredTerm(
-					booleanQuery, ddmStructureFieldName,
-					ddmStructureFieldValueString, indexType, locale);
+				booleanQuery.addRequiredTerm(
+					ddmStructureFieldName,
+					StringPool.QUOTE + ddmStructureFieldValueString +
+						StringPool.QUOTE);
 			}
 		}
 		else {
-			_addFieldValueRequiredTerm(
-				booleanQuery, ddmStructureFieldName,
-				String.valueOf(ddmStructureFieldValue), indexType, locale);
+			booleanQuery.addRequiredTerm(
+				ddmStructureFieldName,
+				StringPool.QUOTE + String.valueOf(ddmStructureFieldValue) +
+					StringPool.QUOTE);
 		}
 
 		if (isLegacyDDMIndexFieldsEnabled()) {
@@ -629,30 +642,6 @@ public class DDMIndexerImpl implements DDMIndexer {
 
 	@Reference
 	protected Sorts sorts;
-
-	private void _addFieldValueRequiredTerm(
-		BooleanQuery booleanQuery, String ddmStructureFieldName,
-		String ddmStructureFieldValue, String indexType, Locale locale) {
-
-		if (isLegacyDDMIndexFieldsEnabled()) {
-			booleanQuery.addRequiredTerm(
-				ddmStructureFieldName,
-				StringPool.QUOTE + ddmStructureFieldValue + StringPool.QUOTE);
-
-			return;
-		}
-
-		booleanQuery.addRequiredTerm(
-			StringBundler.concat(
-				DDM_FIELD_ARRAY, StringPool.PERIOD, DDM_FIELD_NAME),
-			ddmStructureFieldName);
-
-		booleanQuery.addRequiredTerm(
-			StringBundler.concat(
-				DDM_FIELD_ARRAY, StringPool.PERIOD,
-				getValueFieldName(indexType, locale)),
-			StringPool.QUOTE + ddmStructureFieldValue + StringPool.QUOTE);
-	}
 
 	private void _addToDocument(
 			Document document, Field field, String indexType, String name,

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMIndexerImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMIndexerImpl.java
@@ -552,23 +552,24 @@ public class DDMIndexerImpl implements DDMIndexer {
 
 		BooleanQuery booleanQuery = new BooleanQueryImpl();
 
-		if (!isLegacyDDMIndexFieldsEnabled()) {
-			booleanQuery.addRequiredTerm(
-				StringBundler.concat(
-					DDM_FIELD_ARRAY, StringPool.PERIOD, DDM_FIELD_NAME),
-				ddmStructureFieldName);
-
-			ddmStructureFieldName = StringBundler.concat(
-				DDM_FIELD_ARRAY, StringPool.PERIOD,
-				getValueFieldName(indexType, locale));
-		}
-
-		_addFieldValueRequiredTerm(
-			booleanQuery, ddmStructureFieldName, ddmStructureFieldValue);
-
 		if (isLegacyDDMIndexFieldsEnabled()) {
+			_addFieldValueRequiredTerm(
+				booleanQuery, ddmStructureFieldName, ddmStructureFieldValue);
+
 			return new QueryFilter(booleanQuery);
 		}
+
+		booleanQuery.addRequiredTerm(
+			StringBundler.concat(
+				DDM_FIELD_ARRAY, StringPool.PERIOD, DDM_FIELD_NAME),
+			ddmStructureFieldName);
+
+		_addFieldValueRequiredTerm(
+			booleanQuery,
+			StringBundler.concat(
+				DDM_FIELD_ARRAY, StringPool.PERIOD,
+				getValueFieldName(indexType, locale)),
+			ddmStructureFieldValue);
 
 		return new QueryFilter(new NestedQuery(DDM_FIELD_ARRAY, booleanQuery));
 	}


### PR DESCRIPTION
In the LPS-103224, I added the protected method [DDMIndexerImpl.createFieldValueQueryFilter](https://github.com/liferay/liferay-portal/blob/b9b0dee253287fb23e10736f989d56872ef29f14/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMIndexerImpl.java#L530-L576) and the private method [DDMIndexerImpl._addFieldValueRequiredTerm](https://github.com/liferay/liferay-portal/blob/b9b0dee253287fb23e10736f989d56872ef29f14/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMIndexerImpl.java#L631-L658).

The code of both methods are a bit complex due to:
- The isLegacyDDMIndexFieldsEnabled method that is called in two places
- The Elasticsearch nested fields code
- The Serializable ddmStructureFieldValue variable that is handle in a special way if it is a String[].

My proposal is to rearrange this code in order to have only one isLegacyDDMIndexFieldsEnabled call and make the code cleaner.
