### PR TITLE
LPS-145983 Remove time default value as 12AM for english language after clay 3.46.0 update fix

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/DatePicker/DatePicker.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/DatePicker/DatePicker.es.js
@@ -205,21 +205,13 @@ export default function DatePicker({
 	}, [momentFormat]);
 
 	const handleValueChange = (value) => {
-
-		/**
-		 * TODO When Clay change their implementation of the default time
-		 * value to '--:--' remember to change the code bellow of formattedTime
-		 */
-
 		let formattedDate = value;
 		if (isDateTime) {
 			const firstSpace = value.indexOf(' ');
 			formattedDate = value.substring(0, firstSpace);
-			let formattedTime = value.substring(firstSpace);
-			formattedTime =
-				use12Hours && formattedTime === ' 00:00'
-					? ' 12:00 AM'
-					: formattedTime.replaceAll('-', '_');
+			const formattedTime = value
+				.substring(firstSpace)
+				.replaceAll('-', '_');
 			formattedDate = `${formattedDate}${formattedTime}`;
 		}
 		const nextState = {


### PR DESCRIPTION
Related Issue: https://issues.liferay.com/browse/LPS-145983

Hello Reviewer!

This PR has the removal of some code related to the story:
**As a form admin, I want to be able to request datetime from my users** ([LPS-143050](https://issues.liferay.com/browse/LPS-143050))
This part of the code was initially introduced to fix the impedibug above as you can see [here](https://github.com/liferay-forms/liferay-portal/pull/1396), but is no more necessary because of the ideal fix made by clay team on their 3.46.0 version update.

If you have any questions feel free to ask, thank you for your time!