### PR TITLE
LPS-146591 Fix multiple page forms navigation index

### DIFF
--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/custom/form/components/MultiStep.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/custom/form/components/MultiStep.es.js
@@ -52,6 +52,7 @@ export function MultiStep({activePage, editable, pages}) {
 												containerElement.current
 											)
 										),
+										nextIndex: index + 1,
 									})
 								);
 							}
@@ -64,6 +65,7 @@ export function MultiStep({activePage, editable, pages}) {
 												containerElement.current
 											)
 										),
+										previousIndex: index - 1,
 									})
 								);
 							}

--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/custom/form/thunks/nextPage.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/custom/form/thunks/nextPage.es.js
@@ -24,6 +24,7 @@ export default function nextPage({
 	groupId,
 	pages,
 	portletNamespace,
+	previousIndex = activePage,
 	rules,
 	viewMode,
 }) {
@@ -37,6 +38,7 @@ export default function nextPage({
 			nextPage: activePage + 1,
 			pages,
 			portletNamespace,
+			previousIndex,
 			previousPage: activePage,
 			rules,
 			viewMode,
@@ -56,7 +58,7 @@ export default function nextPage({
 
 			if (validPage) {
 				const nextActivePageIndex = evaluatedPages.findIndex(
-					({enabled}, index) => enabled && index > activePage
+					({enabled}, index) => enabled && index > previousIndex
 				);
 
 				const activePageUpdated = Math.min(

--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/custom/form/thunks/previousPage.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/custom/form/thunks/previousPage.es.js
@@ -21,6 +21,7 @@ export default function previousPage({
 	editingLanguageId,
 	formId,
 	groupId,
+	nextIndex = activePage,
 	pages,
 	portletNamespace,
 	rules,
@@ -33,6 +34,7 @@ export default function previousPage({
 			editingLanguageId,
 			formId,
 			groupId,
+			nextIndex,
 			nextPage: activePage - 1,
 			pages,
 			portletNamespace,
@@ -42,7 +44,7 @@ export default function previousPage({
 		}).then((evaluatedPages) => {
 			let previousActivePageIndex = activePage;
 
-			for (let i = activePage - 1; i > -1; i--) {
+			for (let i = nextIndex - 1; i > -1; i--) {
 				if (evaluatedPages[i].enabled) {
 					previousActivePageIndex = i;
 


### PR DESCRIPTION
Related Issue: https://issues.liferay.com/browse/LPS-146591

Hello Reviewer!

This PR has a fix of the bug above. The multiple page forms navigation index wasn't working properly when we were using the top navigation bar; I've changed the logic to send the right `nextIndex` and `previousIndex` when using it. Notice that I left the `activePage` as the default value for both props, because this is the correct value when you do the same navigation through the `next` and `previous` buttons instead of the navigation bar.

If you have any questions feel free to ask, thank you for your time!