### PR TITLE
LPS-146015 Disable the prop yearsCheck on Date Picker to allow dynamic year range

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/DatePicker/DatePicker.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/DatePicker/DatePicker.es.js
@@ -255,6 +255,7 @@ export default function DatePicker({
 				value={formattedDate}
 				weekdaysShort={weekdaysShort}
 				years={years}
+				yearsCheck={false}
 			/>
 
 			<input name={name} type="hidden" value={rawDate} />


### PR DESCRIPTION
Related Issue: https://issues.liferay.com/browse/LPS-146015

Hello Reviewer!

This PR has a fix of the bug above. The years range from the date picker wasn't behaving correctly with the dynamic value, so [we talked to clay](https://github.com/liferay/clay/issues/4624) about this issue and the solution was the API to disable the check if the year is in the value range; that's why I'm setting the prop `yearsCheck` to `false` to allow the dynamic year range logic we have.

If you have any questions feel free to ask, thank you for your time!