### PR TITLE
LPS-136124 Make sure AUI module is loaded before calling Liferay.Form

### DIFF
--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/custom/form/FormView.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/custom/form/FormView.es.js
@@ -63,34 +63,36 @@ const useFormSubmit = ({apiRef, containerRef}) => {
 				.validate()
 				.then((validForm) => {
 					if (validForm) {
-						const liferayForm =
-							event.target.id &&
-							Liferay.Form.get(event.target.id);
+						AUI().use('liferay-form', () => {
+							const liferayForm =
+								event.target.id &&
+								Liferay.Form.get(event.target.id);
 
-						const validLiferayForm = !Object.keys(
-							liferayForm?.formValidator?.errors ?? {}
-						).length;
+							const validLiferayForm = !Object.keys(
+								liferayForm?.formValidator?.errors ?? {}
+							).length;
 
-						if (!validLiferayForm) {
-							Liferay.fire('ddmFormError', {
+							if (!validLiferayForm) {
+								Liferay.fire('ddmFormError', {
+									formWrapperId: event.target.id,
+								});
+
+								return;
+							}
+
+							if (submittable) {
+								Liferay.Util.submitForm(event.target);
+							}
+
+							Liferay.fire('ddmFormValid', {
 								formWrapperId: event.target.id,
 							});
 
-							return;
-						}
-
-						if (submittable) {
-							Liferay.Util.submitForm(event.target);
-						}
-
-						Liferay.fire('ddmFormValid', {
-							formWrapperId: event.target.id,
-						});
-
-						Liferay.fire('ddmFormSubmit', {
-							formId: getFormId(
-								getFormNode(containerRef.current)
-							),
+							Liferay.fire('ddmFormSubmit', {
+								formId: getFormId(
+									getFormNode(containerRef.current)
+								),
+							});
 						});
 					}
 					else {


### PR DESCRIPTION
This is follow up from https://github.com/liferay-echo/liferay-portal/pull/7392 

I believe this is a better solution since this way we make sure that Liferay.Form is always accessible before trying to call it :)

Let me know what do you think