### PR TITLE
LPS-147973

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/css/_portlet-forms.scss
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/css/_portlet-forms.scss
@@ -121,6 +121,8 @@
 	}
 
 	.liferay-ddm-form-field-paragraph {
+		overflow-x: auto;
+
 		blockquote {
 			margin: 1em 40px;
 		}


### PR DESCRIPTION
Related Issue: https://issues.liferay.com/browse/LPS-147973

Hi! 

This PR is intended to improve the Paragraph field view when there's a table with a large number of columns.
By adding the attribute `overflow-x: auto` on the `liferay-ddm-form-field-paragraph` class an horizontal scrollbar will appear and the table will not overlap others div tags anymore.

Before:
![image](https://user-images.githubusercontent.com/77082869/156608796-7e7fd89b-ea3c-4ff7-bbba-bea5d41bb6dd.png)

Now:
![image](https://user-images.githubusercontent.com/77082869/156608821-7b4fe839-c1c9-4439-86c7-d9afa8004a8a.png)


Feel free to ask if you have any questions.

Thanks. 