### PR TITLE
LPS-149185 Fix false positives in tests due to orphan ResourcePermission - Bravo team - LPS-145396 Subtask

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test-util/bnd.bnd
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test-util/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Dynamic Data Mapping Test Utilities
 Bundle-SymbolicName: com.liferay.dynamic.data.mapping.test.util
-Bundle-Version: 10.0.1
+Bundle-Version: 11.0.0
 Export-Package:\
 	com.liferay.dynamic.data.mapping.test.util,\
 	com.liferay.dynamic.data.mapping.test.util.search,\

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test-util/src/main/java/com/liferay/dynamic/data/mapping/test/util/DDMFormInstanceTestUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test-util/src/main/java/com/liferay/dynamic/data/mapping/test/util/DDMFormInstanceTestUtil.java
@@ -40,9 +40,18 @@ public class DDMFormInstanceTestUtil {
 		throws Exception {
 
 		return addDDMFormInstance(
+			ddmForm, group, settingsDDMFormValues,
+			DDMFormInstance.class.getName(), userId);
+	}
+
+	public static DDMFormInstance addDDMFormInstance(
+			DDMForm ddmForm, Group group, DDMFormValues settingsDDMFormValues,
+			String className, long userId)
+		throws Exception {
+
+		return addDDMFormInstance(
 			DDMStructureTestUtil.addStructure(
-				group.getGroupId(), DDMFormInstance.class.getName(), ddmForm,
-				LocaleUtil.US),
+				group.getGroupId(), className, ddmForm, LocaleUtil.US),
 			group, settingsDDMFormValues, userId);
 	}
 
@@ -52,6 +61,14 @@ public class DDMFormInstanceTestUtil {
 
 		return addDDMFormInstance(
 			ddmForm, group, createSettingsDDMFormValues(), userId);
+	}
+
+	public static DDMFormInstance addDDMFormInstance(
+			DDMForm ddmForm, Group group, String className, long userId)
+		throws Exception {
+
+		return addDDMFormInstance(
+			ddmForm, group, createSettingsDDMFormValues(), className, userId);
 	}
 
 	public static DDMFormInstance addDDMFormInstance(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test-util/src/main/java/com/liferay/dynamic/data/mapping/test/util/DDMFormInstanceTestUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test-util/src/main/java/com/liferay/dynamic/data/mapping/test/util/DDMFormInstanceTestUtil.java
@@ -127,8 +127,10 @@ public class DDMFormInstanceTestUtil {
 		return ddmFormValues;
 	}
 
-	public static void deleteDDMFormInstance(DDMFormInstance ddmFormInstance) {
-		DDMFormInstanceLocalServiceUtil.deleteDDMFormInstance(ddmFormInstance);
+	public static void deleteDDMFormInstance(DDMFormInstance ddmFormInstance)
+		throws PortalException {
+
+		DDMFormInstanceLocalServiceUtil.deleteFormInstance(ddmFormInstance);
 	}
 
 	public static DDMFormInstance updateDDMFormInstance(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test-util/src/main/java/com/liferay/dynamic/data/mapping/test/util/DDMFormInstanceTestUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test-util/src/main/java/com/liferay/dynamic/data/mapping/test/util/DDMFormInstanceTestUtil.java
@@ -144,7 +144,7 @@ public class DDMFormInstanceTestUtil {
 		return ddmFormValues;
 	}
 
-	public static void deleteDDMFormInstance(DDMFormInstance ddmFormInstance)
+	public static void deleteFormInstance(DDMFormInstance ddmFormInstance)
 		throws PortalException {
 
 		DDMFormInstanceLocalServiceUtil.deleteFormInstance(ddmFormInstance);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test-util/src/main/resources/com/liferay/dynamic/data/mapping/test/util/packageinfo
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test-util/src/main/resources/com/liferay/dynamic/data/mapping/test/util/packageinfo
@@ -1,1 +1,1 @@
-version 5.0.0
+version 6.0.0

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/internal/exportimport/content/processor/test/DDMFormValuesExportImportContentProcessorTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/internal/exportimport/content/processor/test/DDMFormValuesExportImportContentProcessorTest.java
@@ -169,11 +169,11 @@ public class DDMFormValuesExportImportContentProcessorTest {
 		_journalArticleLocalService.deleteArticles(_liveGroup.getGroupId());
 
 		if (_ddmTemplate != null) {
-			_ddmTemplateLocalService.deleteDDMTemplate(_ddmTemplate);
+			_ddmTemplateLocalService.deleteTemplate(_ddmTemplate);
 		}
 
 		if (_ddmStructure != null) {
-			_ddmStructureLocalService.deleteDDMStructure(_ddmStructure);
+			_ddmStructureLocalService.deleteStructure(_ddmStructure);
 		}
 	}
 
@@ -229,7 +229,7 @@ public class DDMFormValuesExportImportContentProcessorTest {
 
 		newDLFileEntry.setUuid(_fileEntry.getUuid());
 
-		_dlFileEntryLocalService.deleteDLFileEntry(fileEntryId);
+		_dlFileEntryLocalService.deleteFileEntry(fileEntryId);
 
 		_dlFileEntryLocalService.updateDLFileEntry(newDLFileEntry);
 
@@ -250,7 +250,7 @@ public class DDMFormValuesExportImportContentProcessorTest {
 
 		long newDLFileEntryId = newDLFileEntry.getFileEntryId();
 
-		_dlFileEntryLocalService.deleteDLFileEntry(newDLFileEntry);
+		_dlFileEntryLocalService.deleteFileEntry(newDLFileEntry);
 
 		Assert.assertEquals(newDLFileEntryId, jsonObject2.getLong("classPK"));
 	}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/internal/exportimport/content/processor/test/DDMFormValuesExportImportContentProcessorTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/internal/exportimport/content/processor/test/DDMFormValuesExportImportContentProcessorTest.java
@@ -305,6 +305,17 @@ public class DDMFormValuesExportImportContentProcessorTest {
 
 		Assert.assertEquals(
 			newArticleResourcePrimKey, jsonObject.getLong("classPK"));
+
+		long fileEntryId = _fileEntry.getPrimaryKey();
+
+		DLFileEntry dlFileEntry = _dlFileEntryLocalService.getDLFileEntry(
+			fileEntryId);
+
+		DLFileEntryType dlFileEntryType = dlFileEntry.getDLFileEntryType();
+
+		_dlFileEntryLocalService.deleteFileEntry(dlFileEntry);
+
+		_dlFileEntryTypeLocalService.deleteFileEntryType(dlFileEntryType);
 	}
 
 	private DDMForm _createDDMFormWithJournalField(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/internal/exportimport/content/processor/test/DDMFormValuesExportImportContentProcessorTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/internal/exportimport/content/processor/test/DDMFormValuesExportImportContentProcessorTest.java
@@ -393,7 +393,8 @@ public class DDMFormValuesExportImportContentProcessorTest {
 		return journalDDMForm;
 	}
 
-	private DDMFormInstance _createFormInstanceWithDocLib(Group group)
+	private DDMFormInstance _createFormInstanceWithDocLib(
+			Group group, String className)
 		throws Exception {
 
 		DDMForm ddmForm = DDMFormTestUtil.createDDMForm();
@@ -402,7 +403,7 @@ public class DDMFormValuesExportImportContentProcessorTest {
 			ddmForm, "DocumentsAndMedia9t17");
 
 		return DDMFormInstanceTestUtil.addDDMFormInstance(
-			ddmForm, group, TestPropsValues.getUserId());
+			ddmForm, group, className, TestPropsValues.getUserId());
 	}
 
 	private void _initDLReferences() throws Exception {
@@ -422,7 +423,8 @@ public class DDMFormValuesExportImportContentProcessorTest {
 		_fileEntry = thumbnailCapability.setLargeImageId(
 			_fileEntry, _fileEntry.getFileEntryId());
 
-		_formInstance = _createFormInstanceWithDocLib(_stagingGroup);
+		_formInstance = _createFormInstanceWithDocLib(
+			_stagingGroup, JournalArticle.class.getName());
 
 		DDMStructure structure = _formInstance.getStructure();
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/search/test/DDMFormInstanceRecordSearchTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/search/test/DDMFormInstanceRecordSearchTest.java
@@ -179,7 +179,7 @@ public class DDMFormInstanceRecordSearchTest {
 		assertSearch("Liferay", 1);
 		assertSearch("Not indexable name", 0);
 
-		DDMFormInstanceTestUtil.deleteDDMFormInstance(ddmFormInstance);
+		DDMFormInstanceTestUtil.deleteFormInstance(ddmFormInstance);
 	}
 
 	@Test

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/test/DDMFormInstanceReportLocalServiceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/test/DDMFormInstanceReportLocalServiceTest.java
@@ -127,9 +127,7 @@ public class DDMFormInstanceReportLocalServiceTest
 
 		Assert.assertNotNull(ddmFormInstanceReport);
 
-		_ddmFormInstance =
-			DDMFormInstanceLocalServiceUtil.deleteDDMFormInstance(
-				_ddmFormInstance);
+		DDMFormInstanceTestUtil.deleteDDMFormInstance(_ddmFormInstance);
 
 		_ddmFormInstanceReportLocalService.
 			getFormInstanceReportByFormInstanceId(
@@ -168,7 +166,7 @@ public class DDMFormInstanceReportLocalServiceTest
 		DDMFormInstanceRecord ddmFormInstanceRecord =
 			createDDMFormInstanceRecord();
 
-		_ddmFormInstanceRecordLocalService.deleteDDMFormInstanceRecord(
+		_ddmFormInstanceRecordLocalService.deleteFormInstanceRecord(
 			ddmFormInstanceRecord);
 
 		DDMFormInstanceReport ddmFormInstanceReport =

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/test/DDMFormInstanceReportLocalServiceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/test/DDMFormInstanceReportLocalServiceTest.java
@@ -127,7 +127,7 @@ public class DDMFormInstanceReportLocalServiceTest
 
 		Assert.assertNotNull(ddmFormInstanceReport);
 
-		DDMFormInstanceTestUtil.deleteDDMFormInstance(_ddmFormInstance);
+		DDMFormInstanceTestUtil.deleteFormInstance(_ddmFormInstance);
 
 		_ddmFormInstanceReportLocalService.
 			getFormInstanceReportByFormInstanceId(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/test/DDMStructureLocalServiceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/test/DDMStructureLocalServiceTest.java
@@ -755,7 +755,7 @@ public class DDMStructureLocalServiceTest extends BaseDDMServiceTestCase {
 
 		PermissionThreadLocal.setPermissionChecker(originalPermissionChecker);
 
-		DDMStructureLocalServiceUtil.deleteDDMStructure(structure);
+		DDMStructureLocalServiceUtil.deleteStructure(structure);
 
 		UserLocalServiceUtil.deleteUser(user);
 	}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/staging/test/DDMFormInstanceStagingTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/staging/test/DDMFormInstanceStagingTest.java
@@ -80,7 +80,7 @@ public class DDMFormInstanceStagingTest {
 			DDMFormInstanceLocalServiceUtil.getFormInstancesCount(
 				_stagingGroup.getGroupId()));
 
-		DDMFormInstanceTestUtil.deleteDDMFormInstance(ddmFormInstance);
+		DDMFormInstanceTestUtil.deleteFormInstance(ddmFormInstance);
 	}
 
 	@Test
@@ -124,7 +124,7 @@ public class DDMFormInstanceStagingTest {
 			DDMFormInstanceLocalServiceUtil.getFormInstancesCount(
 				_remoteLiveGroup.getGroupId()));
 
-		DDMFormInstanceTestUtil.deleteDDMFormInstance(ddmFormInstance);
+		DDMFormInstanceTestUtil.deleteFormInstance(ddmFormInstance);
 	}
 
 	@Test(expected = PrincipalException.MustHavePermission.class)


### PR DESCRIPTION
Related Issue: https://issues.liferay.com/browse/LPS-149185

In parent LPS-145396 I am going to add some changes in DataGuardTestRule to detect orphan ResourcePermission records, avoiding the bug in the future.

In this LPS I am fixing some false positives in tests for DDM Bravo team code.

The false positives are caused because:
  - in some tests we call LocalServiceBaseImpl delete methods instead of calling the LocalServiceImpl ones and 
  - in a test we create a structure with a wrong className



