### PR TITLE
LPS-150153

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/java/com/liferay/dynamic/data/mapping/form/builder/internal/context/helper/DDMFormBuilderContextFactoryHelper.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/src/main/java/com/liferay/dynamic/data/mapping/form/builder/internal/context/helper/DDMFormBuilderContextFactoryHelper.java
@@ -48,7 +48,6 @@ import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -420,11 +419,7 @@ public class DDMFormBuilderContextFactoryHelper {
 			).put(
 				"isLink", false
 			).put(
-				"label",
-				LanguageUtil.get(
-					ResourceBundleUtil.getBundle(
-						"content.Language", _locale, getClass()),
-					"builder")
+				"label", LanguageUtil.get(_httpServletRequest, "builder")
 			).put(
 				"pluginEntryPoint",
 				_npmResolver.resolveModuleName(


### PR DESCRIPTION
Related Issue: https://issues.liferay.com/browse/LPS-150153

This fix uses the locale of the `_httpServletRequest` (which is the user's locale) rather than the locale of the `DDMFormBuilderContextFactoryHelper` (which is the Form's locale) to render the word "Builder".

/cc @SelenaAungst

https://issues.liferay.com/browse/LPS-150153