### PR TITLE
LPS-148805 Unpublished form still appears and usable on site page in the Form widget

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/bnd.bnd
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Dynamic Data Mapping API
 Bundle-SymbolicName: com.liferay.dynamic.data.mapping.api
-Bundle-Version: 11.2.2
+Bundle-Version: 11.3.0
 Export-Package:\
 	com.liferay.dynamic.data.mapping.annotations,\
 	com.liferay.dynamic.data.mapping.configuration,\

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/DDMFormInstanceLocalService.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/DDMFormInstanceLocalService.java
@@ -406,7 +406,19 @@ public interface DDMFormInstanceLocalService
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<DDMFormInstance> search(
+		long companyId, long groupId, String keywords, Boolean publish,
+		int start, int end,
+		OrderByComparator<DDMFormInstance> orderByComparator);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<DDMFormInstance> search(
 		long companyId, long groupId, String keywords, int start, int end,
+		OrderByComparator<DDMFormInstance> orderByComparator);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<DDMFormInstance> search(
+		long companyId, long groupId, String[] names, String[] descriptions,
+		boolean publish, boolean andOperator, int start, int end,
 		OrderByComparator<DDMFormInstance> orderByComparator);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
@@ -420,8 +432,17 @@ public interface DDMFormInstanceLocalService
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int searchCount(
+		long companyId, long groupId, String keywords, boolean publish);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public int searchCount(
 		long companyId, long groupId, String[] names, String[] descriptions,
 		boolean andOperator);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public int searchCount(
+		long companyId, long groupId, String[] names, String[] descriptions,
+		boolean publish, boolean andOperator);
 
 	public void sendEmail(
 			long userId, String message, String subject,

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/DDMFormInstanceLocalServiceUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/DDMFormInstanceLocalServiceUtil.java
@@ -490,11 +490,31 @@ public class DDMFormInstanceLocalServiceUtil {
 	}
 
 	public static List<DDMFormInstance> search(
+		long companyId, long groupId, String keywords, Boolean publish,
+		int start, int end,
+		OrderByComparator<DDMFormInstance> orderByComparator) {
+
+		return getService().search(
+			companyId, groupId, keywords, publish, start, end,
+			orderByComparator);
+	}
+
+	public static List<DDMFormInstance> search(
 		long companyId, long groupId, String keywords, int start, int end,
 		OrderByComparator<DDMFormInstance> orderByComparator) {
 
 		return getService().search(
 			companyId, groupId, keywords, start, end, orderByComparator);
+	}
+
+	public static List<DDMFormInstance> search(
+		long companyId, long groupId, String[] names, String[] descriptions,
+		boolean publish, boolean andOperator, int start, int end,
+		OrderByComparator<DDMFormInstance> orderByComparator) {
+
+		return getService().search(
+			companyId, groupId, names, descriptions, publish, andOperator,
+			start, end, orderByComparator);
 	}
 
 	public static List<DDMFormInstance> search(
@@ -514,11 +534,25 @@ public class DDMFormInstanceLocalServiceUtil {
 	}
 
 	public static int searchCount(
+		long companyId, long groupId, String keywords, boolean publish) {
+
+		return getService().searchCount(companyId, groupId, keywords, publish);
+	}
+
+	public static int searchCount(
 		long companyId, long groupId, String[] names, String[] descriptions,
 		boolean andOperator) {
 
 		return getService().searchCount(
 			companyId, groupId, names, descriptions, andOperator);
+	}
+
+	public static int searchCount(
+		long companyId, long groupId, String[] names, String[] descriptions,
+		boolean publish, boolean andOperator) {
+
+		return getService().searchCount(
+			companyId, groupId, names, descriptions, publish, andOperator);
 	}
 
 	public static void sendEmail(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/DDMFormInstanceLocalServiceWrapper.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/DDMFormInstanceLocalServiceWrapper.java
@@ -554,12 +554,36 @@ public class DDMFormInstanceLocalServiceWrapper
 
 	@Override
 	public java.util.List<DDMFormInstance> search(
+		long companyId, long groupId, String keywords, Boolean publish,
+		int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<DDMFormInstance>
+			orderByComparator) {
+
+		return _ddmFormInstanceLocalService.search(
+			companyId, groupId, keywords, publish, start, end,
+			orderByComparator);
+	}
+
+	@Override
+	public java.util.List<DDMFormInstance> search(
 		long companyId, long groupId, String keywords, int start, int end,
 		com.liferay.portal.kernel.util.OrderByComparator<DDMFormInstance>
 			orderByComparator) {
 
 		return _ddmFormInstanceLocalService.search(
 			companyId, groupId, keywords, start, end, orderByComparator);
+	}
+
+	@Override
+	public java.util.List<DDMFormInstance> search(
+		long companyId, long groupId, String[] names, String[] descriptions,
+		boolean publish, boolean andOperator, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<DDMFormInstance>
+			orderByComparator) {
+
+		return _ddmFormInstanceLocalService.search(
+			companyId, groupId, names, descriptions, publish, andOperator,
+			start, end, orderByComparator);
 	}
 
 	@Override
@@ -582,11 +606,28 @@ public class DDMFormInstanceLocalServiceWrapper
 
 	@Override
 	public int searchCount(
+		long companyId, long groupId, String keywords, boolean publish) {
+
+		return _ddmFormInstanceLocalService.searchCount(
+			companyId, groupId, keywords, publish);
+	}
+
+	@Override
+	public int searchCount(
 		long companyId, long groupId, String[] names, String[] descriptions,
 		boolean andOperator) {
 
 		return _ddmFormInstanceLocalService.searchCount(
 			companyId, groupId, names, descriptions, andOperator);
+	}
+
+	@Override
+	public int searchCount(
+		long companyId, long groupId, String[] names, String[] descriptions,
+		boolean publish, boolean andOperator) {
+
+		return _ddmFormInstanceLocalService.searchCount(
+			companyId, groupId, names, descriptions, publish, andOperator);
 	}
 
 	@Override

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/DDMFormInstanceService.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/DDMFormInstanceService.java
@@ -109,12 +109,30 @@ public interface DDMFormInstanceService extends BaseService {
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<DDMFormInstance> search(
+		long companyId, long groupId, String keywords, boolean publish,
+		int status, int start, int end,
+		OrderByComparator<DDMFormInstance> orderByComparator);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<DDMFormInstance> search(
+		long companyId, long groupId, String keywords, boolean publish,
+		int start, int end,
+		OrderByComparator<DDMFormInstance> orderByComparator);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<DDMFormInstance> search(
 		long companyId, long groupId, String keywords, int status, int start,
 		int end, OrderByComparator<DDMFormInstance> orderByComparator);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<DDMFormInstance> search(
 		long companyId, long groupId, String keywords, int start, int end,
+		OrderByComparator<DDMFormInstance> orderByComparator);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<DDMFormInstance> search(
+		long companyId, long groupId, String[] names, String[] descriptions,
+		boolean publish, boolean andOperator, int start, int end,
 		OrderByComparator<DDMFormInstance> orderByComparator);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
@@ -128,12 +146,26 @@ public interface DDMFormInstanceService extends BaseService {
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int searchCount(
+		long companyId, long groupId, String keywords, boolean publish);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public int searchCount(
+		long companyId, long groupId, String keywords, boolean publish,
+		int status);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public int searchCount(
 		long companyId, long groupId, String keywords, int status);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int searchCount(
 		long companyId, long groupId, String[] names, String[] descriptions,
 		boolean andOperator);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public int searchCount(
+		long companyId, long groupId, String[] names, String[] descriptions,
+		boolean publish, boolean andOperator);
 
 	public void sendEmail(
 			long formInstanceId, String message, String subject,

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/DDMFormInstanceServiceUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/DDMFormInstanceServiceUtil.java
@@ -126,6 +126,26 @@ public class DDMFormInstanceServiceUtil {
 	}
 
 	public static List<DDMFormInstance> search(
+		long companyId, long groupId, String keywords, boolean publish,
+		int status, int start, int end,
+		OrderByComparator<DDMFormInstance> orderByComparator) {
+
+		return getService().search(
+			companyId, groupId, keywords, publish, status, start, end,
+			orderByComparator);
+	}
+
+	public static List<DDMFormInstance> search(
+		long companyId, long groupId, String keywords, boolean publish,
+		int start, int end,
+		OrderByComparator<DDMFormInstance> orderByComparator) {
+
+		return getService().search(
+			companyId, groupId, keywords, publish, start, end,
+			orderByComparator);
+	}
+
+	public static List<DDMFormInstance> search(
 		long companyId, long groupId, String keywords, int status, int start,
 		int end, OrderByComparator<DDMFormInstance> orderByComparator) {
 
@@ -140,6 +160,16 @@ public class DDMFormInstanceServiceUtil {
 
 		return getService().search(
 			companyId, groupId, keywords, start, end, orderByComparator);
+	}
+
+	public static List<DDMFormInstance> search(
+		long companyId, long groupId, String[] names, String[] descriptions,
+		boolean publish, boolean andOperator, int start, int end,
+		OrderByComparator<DDMFormInstance> orderByComparator) {
+
+		return getService().search(
+			companyId, groupId, names, descriptions, publish, andOperator,
+			start, end, orderByComparator);
 	}
 
 	public static List<DDMFormInstance> search(
@@ -159,6 +189,20 @@ public class DDMFormInstanceServiceUtil {
 	}
 
 	public static int searchCount(
+		long companyId, long groupId, String keywords, boolean publish) {
+
+		return getService().searchCount(companyId, groupId, keywords, publish);
+	}
+
+	public static int searchCount(
+		long companyId, long groupId, String keywords, boolean publish,
+		int status) {
+
+		return getService().searchCount(
+			companyId, groupId, keywords, publish, status);
+	}
+
+	public static int searchCount(
 		long companyId, long groupId, String keywords, int status) {
 
 		return getService().searchCount(companyId, groupId, keywords, status);
@@ -170,6 +214,14 @@ public class DDMFormInstanceServiceUtil {
 
 		return getService().searchCount(
 			companyId, groupId, names, descriptions, andOperator);
+	}
+
+	public static int searchCount(
+		long companyId, long groupId, String[] names, String[] descriptions,
+		boolean publish, boolean andOperator) {
+
+		return getService().searchCount(
+			companyId, groupId, names, descriptions, publish, andOperator);
 	}
 
 	public static void sendEmail(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/DDMFormInstanceServiceWrapper.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/DDMFormInstanceServiceWrapper.java
@@ -136,6 +136,30 @@ public class DDMFormInstanceServiceWrapper
 
 	@Override
 	public java.util.List<DDMFormInstance> search(
+		long companyId, long groupId, String keywords, boolean publish,
+		int status, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<DDMFormInstance>
+			orderByComparator) {
+
+		return _ddmFormInstanceService.search(
+			companyId, groupId, keywords, publish, status, start, end,
+			orderByComparator);
+	}
+
+	@Override
+	public java.util.List<DDMFormInstance> search(
+		long companyId, long groupId, String keywords, boolean publish,
+		int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<DDMFormInstance>
+			orderByComparator) {
+
+		return _ddmFormInstanceService.search(
+			companyId, groupId, keywords, publish, start, end,
+			orderByComparator);
+	}
+
+	@Override
+	public java.util.List<DDMFormInstance> search(
 		long companyId, long groupId, String keywords, int status, int start,
 		int end,
 		com.liferay.portal.kernel.util.OrderByComparator<DDMFormInstance>
@@ -159,6 +183,18 @@ public class DDMFormInstanceServiceWrapper
 	@Override
 	public java.util.List<DDMFormInstance> search(
 		long companyId, long groupId, String[] names, String[] descriptions,
+		boolean publish, boolean andOperator, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<DDMFormInstance>
+			orderByComparator) {
+
+		return _ddmFormInstanceService.search(
+			companyId, groupId, names, descriptions, publish, andOperator,
+			start, end, orderByComparator);
+	}
+
+	@Override
+	public java.util.List<DDMFormInstance> search(
+		long companyId, long groupId, String[] names, String[] descriptions,
 		boolean andOperator, int start, int end,
 		com.liferay.portal.kernel.util.OrderByComparator<DDMFormInstance>
 			orderByComparator) {
@@ -176,6 +212,23 @@ public class DDMFormInstanceServiceWrapper
 
 	@Override
 	public int searchCount(
+		long companyId, long groupId, String keywords, boolean publish) {
+
+		return _ddmFormInstanceService.searchCount(
+			companyId, groupId, keywords, publish);
+	}
+
+	@Override
+	public int searchCount(
+		long companyId, long groupId, String keywords, boolean publish,
+		int status) {
+
+		return _ddmFormInstanceService.searchCount(
+			companyId, groupId, keywords, publish, status);
+	}
+
+	@Override
+	public int searchCount(
 		long companyId, long groupId, String keywords, int status) {
 
 		return _ddmFormInstanceService.searchCount(
@@ -189,6 +242,15 @@ public class DDMFormInstanceServiceWrapper
 
 		return _ddmFormInstanceService.searchCount(
 			companyId, groupId, names, descriptions, andOperator);
+	}
+
+	@Override
+	public int searchCount(
+		long companyId, long groupId, String[] names, String[] descriptions,
+		boolean publish, boolean andOperator) {
+
+		return _ddmFormInstanceService.searchCount(
+			companyId, groupId, names, descriptions, publish, andOperator);
 	}
 
 	@Override

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/DDMFormInstanceFinder.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/DDMFormInstanceFinder.java
@@ -25,12 +25,26 @@ public interface DDMFormInstanceFinder {
 
 	public int countByKeywords(long companyId, long groupId, String keywords);
 
+	public int countByKeywords(
+		long companyId, long groupId, String keywords, Boolean publish);
+
 	public int countByC_G_N_D(
 		long companyId, long groupId, String[] names, String[] descriptions,
 		boolean andOperator);
 
+	public int countByC_G_N_D_P(
+		long companyId, long groupId, String[] names, String[] descriptions,
+		Boolean publish, boolean andOperator);
+
 	public int filterCountByKeywords(
 		long companyId, long groupId, String keywords);
+
+	public int filterCountByKeywords(
+		long companyId, long groupId, String keywords, Boolean publish);
+
+	public int filterCountByKeywords(
+		long companyId, long groupId, String keywords, Boolean publish,
+		int status);
 
 	public int filterCountByKeywords(
 		long companyId, long groupId, String keywords, int status);
@@ -40,6 +54,28 @@ public interface DDMFormInstanceFinder {
 	public int filterCountByC_G_N_D(
 		long companyId, long groupId, String[] names, String[] descriptions,
 		boolean andOperator);
+
+	public int filterCountByC_G_N_D_P(
+		long companyId, long groupId, String[] names, String[] descriptions,
+		Boolean publish, boolean andOperator);
+
+	public java.util.List
+		<com.liferay.dynamic.data.mapping.model.DDMFormInstance>
+			filterFindByKeywords(
+				long companyId, long groupId, String keywords, Boolean publish,
+				int status, int start, int end,
+				com.liferay.portal.kernel.util.OrderByComparator
+					<com.liferay.dynamic.data.mapping.model.DDMFormInstance>
+						orderByComparator);
+
+	public java.util.List
+		<com.liferay.dynamic.data.mapping.model.DDMFormInstance>
+			filterFindByKeywords(
+				long companyId, long groupId, String keywords, Boolean publish,
+				int start, int end,
+				com.liferay.portal.kernel.util.OrderByComparator
+					<com.liferay.dynamic.data.mapping.model.DDMFormInstance>
+						orderByComparator);
 
 	public java.util.List
 		<com.liferay.dynamic.data.mapping.model.DDMFormInstance>
@@ -74,6 +110,16 @@ public interface DDMFormInstanceFinder {
 
 	public java.util.List
 		<com.liferay.dynamic.data.mapping.model.DDMFormInstance>
+			filterFindByC_G_N_D_P(
+				long companyId, long groupId, String[] names,
+				String[] descriptions, Boolean publish, boolean andOperator,
+				int start, int end,
+				com.liferay.portal.kernel.util.OrderByComparator
+					<com.liferay.dynamic.data.mapping.model.DDMFormInstance>
+						orderByComparator);
+
+	public java.util.List
+		<com.liferay.dynamic.data.mapping.model.DDMFormInstance>
 			filterFindByC_G_N_D_S(
 				long companyId, long groupId, String[] names,
 				String[] descriptions, int status, boolean andOperator,
@@ -81,6 +127,24 @@ public interface DDMFormInstanceFinder {
 				com.liferay.portal.kernel.util.OrderByComparator
 					<com.liferay.dynamic.data.mapping.model.DDMFormInstance>
 						orderByComparator);
+
+	public java.util.List
+		<com.liferay.dynamic.data.mapping.model.DDMFormInstance>
+			filterFindByC_G_N_D_P_S(
+				long companyId, long groupId, String[] names,
+				String[] descriptions, Boolean publish, int status,
+				boolean andOperator, int start, int end,
+				com.liferay.portal.kernel.util.OrderByComparator
+					<com.liferay.dynamic.data.mapping.model.DDMFormInstance>
+						orderByComparator);
+
+	public java.util.List
+		<com.liferay.dynamic.data.mapping.model.DDMFormInstance> findByKeywords(
+			long companyId, long groupId, String keywords, Boolean publish,
+			int start, int end,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<com.liferay.dynamic.data.mapping.model.DDMFormInstance>
+					orderByComparator);
 
 	public java.util.List
 		<com.liferay.dynamic.data.mapping.model.DDMFormInstance> findByKeywords(
@@ -96,5 +160,15 @@ public interface DDMFormInstanceFinder {
 			com.liferay.portal.kernel.util.OrderByComparator
 				<com.liferay.dynamic.data.mapping.model.DDMFormInstance>
 					orderByComparator);
+
+	public java.util.List
+		<com.liferay.dynamic.data.mapping.model.DDMFormInstance>
+			findByC_G_N_D_P(
+				long companyId, long groupId, String[] names,
+				String[] descriptions, Boolean publish, boolean andOperator,
+				int start, int end,
+				com.liferay.portal.kernel.util.OrderByComparator
+					<com.liferay.dynamic.data.mapping.model.DDMFormInstance>
+						orderByComparator);
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/resources/com/liferay/dynamic/data/mapping/service/packageinfo
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/resources/com/liferay/dynamic/data/mapping/service/packageinfo
@@ -1,1 +1,1 @@
-version 3.12.0
+version 3.13.0

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/resources/com/liferay/dynamic/data/mapping/service/persistence/packageinfo
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/resources/com/liferay/dynamic/data/mapping/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 3.3.0
+version 3.4.0

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormDisplayContext.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormDisplayContext.java
@@ -563,56 +563,43 @@ public class DDMFormDisplayContext {
 	}
 
 	public boolean isFormAvailable() throws PortalException {
-		if (isPreview()) {
-			return true;
-		}
-
 		DDMFormInstance formInstance = getFormInstance();
 
-		if (formInstance != null) {
-			Group group = _groupLocalService.getGroup(
-				formInstance.getGroupId());
-
-			Group scopeGroup = _groupLocalService.getGroup(
-				_portal.getScopeGroupId(_renderRequest));
-
-			if ((group != null) && (scopeGroup != null) &&
-				group.isStagingGroup() && !scopeGroup.isStagingGroup()) {
-
-				return false;
-			}
-
-			if ((group != null) && group.isStagedRemotely()) {
-				ThemeDisplay themeDisplay = getThemeDisplay();
-
-				Role role = _roleLocalService.getRole(
-					themeDisplay.getCompanyId(), RoleConstants.ADMINISTRATOR);
-
-				List<User> users = _userLocalService.getRoleUsers(
-					role.getRoleId());
-
-				if (!DDMFormInstanceStagingUtil.
-						isFormInstancePublishedToRemoteLive(
-							group, users.get(0), formInstance.getUuid())) {
-
-					return false;
-				}
-			}
+		if (formInstance == null) {
+			return false;
 		}
 
-		if (isSharedURL()) {
-			if (isFormPublished() && isFormShared()) {
-				return true;
-			}
+		if (!isFormPublished() && (!isFormShared() || !isSharedURL())) {
+			return false;
+		}
+
+		Group group = _groupLocalService.getGroup(formInstance.getGroupId());
+
+		Group scopeGroup = _groupLocalService.getGroup(
+			_portal.getScopeGroupId(_renderRequest));
+
+		if ((group != null) && (scopeGroup != null) && group.isStagingGroup() &&
+			!scopeGroup.isStagingGroup()) {
 
 			return false;
 		}
 
-		if (formInstance != null) {
-			return true;
+		if ((group != null) && group.isStagedRemotely()) {
+			ThemeDisplay themeDisplay = getThemeDisplay();
+
+			Role role = _roleLocalService.getRole(
+				themeDisplay.getCompanyId(), RoleConstants.ADMINISTRATOR);
+
+			List<User> users = _userLocalService.getRoleUsers(role.getRoleId());
+
+			if (!DDMFormInstanceStagingUtil.isFormInstancePublishedToRemoteLive(
+					group, users.get(0), formInstance.getUuid())) {
+
+				return false;
+			}
 		}
 
-		return false;
+		return true;
 	}
 
 	public boolean isFormShared() {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/display/configuration.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/display/configuration.jsp
@@ -56,7 +56,7 @@ DDMFormInstance selFormInstance = DDMFormInstanceServiceUtil.fetchFormInstance(f
 						<liferay-ui:search-container
 							emptyResultsMessage="no-forms-were-found"
 							iteratorURL="<%= configurationRenderURL %>"
-							total="<%= DDMFormInstanceServiceUtil.searchCount(company.getCompanyId(), scopeGroupId, keywords, WorkflowConstants.STATUS_APPROVED) %>"
+							total="<%= DDMFormInstanceServiceUtil.searchCount(company.getCompanyId(), scopeGroupId, keywords, true, WorkflowConstants.STATUS_APPROVED) %>"
 						>
 							<div class="form-search input-append">
 								<liferay-ui:input-search
@@ -66,7 +66,7 @@ DDMFormInstance selFormInstance = DDMFormInstanceServiceUtil.fetchFormInstance(f
 							</div>
 
 							<liferay-ui:search-container-results
-								results="<%= DDMFormInstanceServiceUtil.search(company.getCompanyId(), scopeGroupId, keywords, WorkflowConstants.STATUS_APPROVED, searchContainer.getStart(), searchContainer.getEnd(), searchContainer.getOrderByComparator()) %>"
+								results="<%= DDMFormInstanceServiceUtil.search(company.getCompanyId(), scopeGroupId, keywords, true, WorkflowConstants.STATUS_APPROVED, searchContainer.getStart(), searchContainer.getEnd(), searchContainer.getOrderByComparator()) %>"
 							/>
 
 							<liferay-ui:search-container-row

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/display/view.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/display/view.jsp
@@ -121,7 +121,7 @@ boolean limitToOneSubmissionPerUser = DDMFormInstanceSubmissionLimitStatusUtil.i
 					%>'
 				/>
 			</c:when>
-			<c:when test="<%= ddmFormDisplayContext.isFormAvailable() %>">
+			<c:when test="<%= ddmFormDisplayContext.isFormAvailable() || preview %>">
 				<portlet:actionURL name="/dynamic_data_mapping_form/add_form_instance_record" var="addFormInstanceRecordActionURL" />
 
 				<div class="portlet-forms">

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/bnd.bnd
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Dynamic Data Mapping Service
 Bundle-SymbolicName: com.liferay.dynamic.data.mapping.service
-Bundle-Version: 7.0.12
+Bundle-Version: 7.1.0
 Export-Package: com.liferay.dynamic.data.mapping.service.http
 Import-Package:\
 	!com.fasterxml.jackson.*,\

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/http/DDMFormInstanceServiceHttp.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/http/DDMFormInstanceServiceHttp.java
@@ -428,7 +428,7 @@ public class DDMFormInstanceServiceHttp {
 	public static java.util.List
 		<com.liferay.dynamic.data.mapping.model.DDMFormInstance> search(
 			HttpPrincipal httpPrincipal, long companyId, long groupId,
-			String keywords, int status, int start, int end,
+			String keywords, boolean publish, int status, int start, int end,
 			com.liferay.portal.kernel.util.OrderByComparator
 				<com.liferay.dynamic.data.mapping.model.DDMFormInstance>
 					orderByComparator) {
@@ -437,6 +437,86 @@ public class DDMFormInstanceServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				DDMFormInstanceServiceUtil.class, "search",
 				_searchParameterTypes9);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, companyId, groupId, keywords, publish, status, start,
+				end, orderByComparator);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (java.util.List
+				<com.liferay.dynamic.data.mapping.model.DDMFormInstance>)
+					returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static java.util.List
+		<com.liferay.dynamic.data.mapping.model.DDMFormInstance> search(
+			HttpPrincipal httpPrincipal, long companyId, long groupId,
+			String keywords, boolean publish, int start, int end,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<com.liferay.dynamic.data.mapping.model.DDMFormInstance>
+					orderByComparator) {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				DDMFormInstanceServiceUtil.class, "search",
+				_searchParameterTypes10);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, companyId, groupId, keywords, publish, start, end,
+				orderByComparator);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (java.util.List
+				<com.liferay.dynamic.data.mapping.model.DDMFormInstance>)
+					returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static java.util.List
+		<com.liferay.dynamic.data.mapping.model.DDMFormInstance> search(
+			HttpPrincipal httpPrincipal, long companyId, long groupId,
+			String keywords, int status, int start, int end,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<com.liferay.dynamic.data.mapping.model.DDMFormInstance>
+					orderByComparator) {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				DDMFormInstanceServiceUtil.class, "search",
+				_searchParameterTypes11);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, groupId, keywords, status, start, end,
@@ -476,11 +556,52 @@ public class DDMFormInstanceServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DDMFormInstanceServiceUtil.class, "search",
-				_searchParameterTypes10);
+				_searchParameterTypes12);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, groupId, keywords, start, end,
 				orderByComparator);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (java.util.List
+				<com.liferay.dynamic.data.mapping.model.DDMFormInstance>)
+					returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static java.util.List
+		<com.liferay.dynamic.data.mapping.model.DDMFormInstance> search(
+			HttpPrincipal httpPrincipal, long companyId, long groupId,
+			String[] names, String[] descriptions, boolean publish,
+			boolean andOperator, int start, int end,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<com.liferay.dynamic.data.mapping.model.DDMFormInstance>
+					orderByComparator) {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				DDMFormInstanceServiceUtil.class, "search",
+				_searchParameterTypes13);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, companyId, groupId, names, descriptions, publish,
+				andOperator, start, end, orderByComparator);
 
 			Object returnObj = null;
 
@@ -517,7 +638,7 @@ public class DDMFormInstanceServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DDMFormInstanceServiceUtil.class, "search",
-				_searchParameterTypes11);
+				_searchParameterTypes14);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, groupId, names, descriptions, andOperator,
@@ -553,10 +674,76 @@ public class DDMFormInstanceServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DDMFormInstanceServiceUtil.class, "searchCount",
-				_searchCountParameterTypes12);
+				_searchCountParameterTypes15);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, groupId, keywords);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return ((Integer)returnObj).intValue();
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static int searchCount(
+		HttpPrincipal httpPrincipal, long companyId, long groupId,
+		String keywords, boolean publish) {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				DDMFormInstanceServiceUtil.class, "searchCount",
+				_searchCountParameterTypes16);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, companyId, groupId, keywords, publish);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return ((Integer)returnObj).intValue();
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static int searchCount(
+		HttpPrincipal httpPrincipal, long companyId, long groupId,
+		String keywords, boolean publish, int status) {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				DDMFormInstanceServiceUtil.class, "searchCount",
+				_searchCountParameterTypes17);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, companyId, groupId, keywords, publish, status);
 
 			Object returnObj = null;
 
@@ -586,7 +773,7 @@ public class DDMFormInstanceServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DDMFormInstanceServiceUtil.class, "searchCount",
-				_searchCountParameterTypes13);
+				_searchCountParameterTypes18);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, groupId, keywords, status);
@@ -619,10 +806,45 @@ public class DDMFormInstanceServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DDMFormInstanceServiceUtil.class, "searchCount",
-				_searchCountParameterTypes14);
+				_searchCountParameterTypes19);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, groupId, names, descriptions,
+				andOperator);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return ((Integer)returnObj).intValue();
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static int searchCount(
+		HttpPrincipal httpPrincipal, long companyId, long groupId,
+		String[] names, String[] descriptions, boolean publish,
+		boolean andOperator) {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				DDMFormInstanceServiceUtil.class, "searchCount",
+				_searchCountParameterTypes20);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, companyId, groupId, names, descriptions, publish,
 				andOperator);
 
 			Object returnObj = null;
@@ -654,7 +876,7 @@ public class DDMFormInstanceServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DDMFormInstanceServiceUtil.class, "sendEmail",
-				_sendEmailParameterTypes15);
+				_sendEmailParameterTypes21);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, formInstanceId, message, subject, toEmailAddresses);
@@ -690,7 +912,7 @@ public class DDMFormInstanceServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DDMFormInstanceServiceUtil.class, "updateFormInstance",
-				_updateFormInstanceParameterTypes16);
+				_updateFormInstanceParameterTypes22);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, formInstanceId, settingsDDMFormValues);
@@ -740,7 +962,7 @@ public class DDMFormInstanceServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				DDMFormInstanceServiceUtil.class, "updateFormInstance",
-				_updateFormInstanceParameterTypes17);
+				_updateFormInstanceParameterTypes23);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, ddmFormInstanceId, nameMap, descriptionMap, ddmForm,
@@ -812,36 +1034,60 @@ public class DDMFormInstanceServiceHttp {
 	private static final Class<?>[] _getFormInstancesCountParameterTypes8 =
 		new Class[] {String.class};
 	private static final Class<?>[] _searchParameterTypes9 = new Class[] {
-		long.class, long.class, String.class, int.class, int.class, int.class,
+		long.class, long.class, String.class, boolean.class, int.class,
+		int.class, int.class,
 		com.liferay.portal.kernel.util.OrderByComparator.class
 	};
 	private static final Class<?>[] _searchParameterTypes10 = new Class[] {
+		long.class, long.class, String.class, boolean.class, int.class,
+		int.class, com.liferay.portal.kernel.util.OrderByComparator.class
+	};
+	private static final Class<?>[] _searchParameterTypes11 = new Class[] {
+		long.class, long.class, String.class, int.class, int.class, int.class,
+		com.liferay.portal.kernel.util.OrderByComparator.class
+	};
+	private static final Class<?>[] _searchParameterTypes12 = new Class[] {
 		long.class, long.class, String.class, int.class, int.class,
 		com.liferay.portal.kernel.util.OrderByComparator.class
 	};
-	private static final Class<?>[] _searchParameterTypes11 = new Class[] {
+	private static final Class<?>[] _searchParameterTypes13 = new Class[] {
+		long.class, long.class, String[].class, String[].class, boolean.class,
+		boolean.class, int.class, int.class,
+		com.liferay.portal.kernel.util.OrderByComparator.class
+	};
+	private static final Class<?>[] _searchParameterTypes14 = new Class[] {
 		long.class, long.class, String[].class, String[].class, boolean.class,
 		int.class, int.class,
 		com.liferay.portal.kernel.util.OrderByComparator.class
 	};
-	private static final Class<?>[] _searchCountParameterTypes12 = new Class[] {
+	private static final Class<?>[] _searchCountParameterTypes15 = new Class[] {
 		long.class, long.class, String.class
 	};
-	private static final Class<?>[] _searchCountParameterTypes13 = new Class[] {
+	private static final Class<?>[] _searchCountParameterTypes16 = new Class[] {
+		long.class, long.class, String.class, boolean.class
+	};
+	private static final Class<?>[] _searchCountParameterTypes17 = new Class[] {
+		long.class, long.class, String.class, boolean.class, int.class
+	};
+	private static final Class<?>[] _searchCountParameterTypes18 = new Class[] {
 		long.class, long.class, String.class, int.class
 	};
-	private static final Class<?>[] _searchCountParameterTypes14 = new Class[] {
+	private static final Class<?>[] _searchCountParameterTypes19 = new Class[] {
 		long.class, long.class, String[].class, String[].class, boolean.class
 	};
-	private static final Class<?>[] _sendEmailParameterTypes15 = new Class[] {
+	private static final Class<?>[] _searchCountParameterTypes20 = new Class[] {
+		long.class, long.class, String[].class, String[].class, boolean.class,
+		boolean.class
+	};
+	private static final Class<?>[] _sendEmailParameterTypes21 = new Class[] {
 		long.class, String.class, String.class, String[].class
 	};
-	private static final Class<?>[] _updateFormInstanceParameterTypes16 =
+	private static final Class<?>[] _updateFormInstanceParameterTypes22 =
 		new Class[] {
 			long.class,
 			com.liferay.dynamic.data.mapping.storage.DDMFormValues.class
 		};
-	private static final Class<?>[] _updateFormInstanceParameterTypes17 =
+	private static final Class<?>[] _updateFormInstanceParameterTypes23 =
 		new Class[] {
 			long.class, java.util.Map.class, java.util.Map.class,
 			com.liferay.dynamic.data.mapping.model.DDMForm.class,

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMFormInstanceLocalServiceImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMFormInstanceLocalServiceImpl.java
@@ -87,9 +87,9 @@ public class DDMFormInstanceLocalServiceImpl
 
 	@Override
 	public DDMFormInstance addFormInstance(
-			long userId, long groupId, long ddmStructureId,
-			Map<Locale, String> nameMap, Map<Locale, String> descriptionMap,
-			DDMFormValues settingsDDMFormValues, ServiceContext serviceContext)
+		long userId, long groupId, long ddmStructureId,
+		Map<Locale, String> nameMap, Map<Locale, String> descriptionMap,
+		DDMFormValues settingsDDMFormValues, ServiceContext serviceContext)
 		throws PortalException {
 
 		Locale defaultLocale = getDDMFormDefaultLocale(ddmStructureId);
@@ -123,7 +123,7 @@ public class DDMFormInstanceLocalServiceImpl
 			ddmFormInstance, settingsDDMFormValues, serviceContext);
 
 		if (GetterUtil.getBoolean(
-				serviceContext.getAttribute("addResources"), true)) {
+			serviceContext.getAttribute("addResources"), true)) {
 
 			if (serviceContext.isAddGroupPermissions() ||
 				serviceContext.isAddGuestPermissions()) {
@@ -147,10 +147,10 @@ public class DDMFormInstanceLocalServiceImpl
 
 	@Override
 	public DDMFormInstance addFormInstance(
-			long userId, long groupId, long ddmStructureId,
-			Map<Locale, String> nameMap, Map<Locale, String> descriptionMap,
-			String serializedSettingsDDMFormValues,
-			ServiceContext serviceContext)
+		long userId, long groupId, long ddmStructureId,
+		Map<Locale, String> nameMap, Map<Locale, String> descriptionMap,
+		String serializedSettingsDDMFormValues,
+		ServiceContext serviceContext)
 		throws PortalException {
 
 		DDMFormValues settingsDDMFormValues = getFormInstanceSettingsFormValues(
@@ -163,10 +163,10 @@ public class DDMFormInstanceLocalServiceImpl
 
 	@Override
 	public DDMFormInstance addFormInstance(
-			long userId, long groupId, Map<Locale, String> nameMap,
-			Map<Locale, String> descriptionMap, DDMForm ddmForm,
-			DDMFormLayout ddmFormLayout, DDMFormValues settingsDDMFormValues,
-			ServiceContext serviceContext)
+		long userId, long groupId, Map<Locale, String> nameMap,
+		Map<Locale, String> descriptionMap, DDMForm ddmForm,
+		DDMFormLayout ddmFormLayout, DDMFormValues settingsDDMFormValues,
+		ServiceContext serviceContext)
 		throws PortalException {
 
 		DDMStructure ddmStructure = _ddmStructureLocalService.addStructure(
@@ -183,8 +183,8 @@ public class DDMFormInstanceLocalServiceImpl
 
 	@Override
 	public void addFormInstanceResources(
-			DDMFormInstance ddmFormInstance, boolean addGroupPermissions,
-			boolean addGuestPermissions)
+		DDMFormInstance ddmFormInstance, boolean addGroupPermissions,
+		boolean addGuestPermissions)
 		throws PortalException {
 
 		_resourceLocalService.addResources(
@@ -196,7 +196,7 @@ public class DDMFormInstanceLocalServiceImpl
 
 	@Override
 	public void addFormInstanceResources(
-			DDMFormInstance ddmFormInstance, ModelPermissions modelPermissions)
+		DDMFormInstance ddmFormInstance, ModelPermissions modelPermissions)
 		throws PortalException {
 
 		_resourceLocalService.addModelResources(
@@ -207,9 +207,9 @@ public class DDMFormInstanceLocalServiceImpl
 
 	@Override
 	public DDMFormInstance copyFormInstance(
-			long userId, long groupId, Map<Locale, String> nameMap,
-			DDMFormInstance ddmFormInstance,
-			DDMFormValues settingsDDMFormValues, ServiceContext serviceContext)
+		long userId, long groupId, Map<Locale, String> nameMap,
+		DDMFormInstance ddmFormInstance,
+		DDMFormValues settingsDDMFormValues, ServiceContext serviceContext)
 		throws PortalException {
 
 		DDMStructure ddmStructure = ddmFormInstance.getStructure();
@@ -321,7 +321,7 @@ public class DDMFormInstanceLocalServiceImpl
 
 	@Override
 	public DDMFormValues getFormInstanceSettingsFormValues(
-			DDMFormInstance formInstance)
+		DDMFormInstance formInstance)
 		throws PortalException {
 
 		return getFormInstanceSettingsFormValues(formInstance.getSettings());
@@ -329,7 +329,7 @@ public class DDMFormInstanceLocalServiceImpl
 
 	@Override
 	public DDMFormInstanceSettings getFormInstanceSettingsModel(
-			DDMFormInstance formInstance)
+		DDMFormInstance formInstance)
 		throws PortalException {
 
 		DDMFormValues formValues = getFormInstanceSettingsFormValues(
@@ -341,11 +341,33 @@ public class DDMFormInstanceLocalServiceImpl
 
 	@Override
 	public List<DDMFormInstance> search(
+		long companyId, long groupId, String keywords, Boolean publish,
+		int start, int end,
+		OrderByComparator<DDMFormInstance> orderByComparator) {
+
+		return ddmFormInstanceFinder.findByKeywords(
+			companyId, groupId, keywords, publish, start, end,
+			orderByComparator);
+	}
+
+	@Override
+	public List<DDMFormInstance> search(
 		long companyId, long groupId, String keywords, int start, int end,
 		OrderByComparator<DDMFormInstance> orderByComparator) {
 
 		return ddmFormInstanceFinder.findByKeywords(
 			companyId, groupId, keywords, start, end, orderByComparator);
+	}
+
+	@Override
+	public List<DDMFormInstance> search(
+		long companyId, long groupId, String[] names, String[] descriptions,
+		boolean publish, boolean andOperator, int start, int end,
+		OrderByComparator<DDMFormInstance> orderByComparator) {
+
+		return ddmFormInstanceFinder.findByC_G_N_D_P(
+			companyId, groupId, names, descriptions, publish, andOperator,
+			start, end, orderByComparator);
 	}
 
 	@Override
@@ -367,6 +389,14 @@ public class DDMFormInstanceLocalServiceImpl
 
 	@Override
 	public int searchCount(
+		long companyId, long groupId, String keywords, boolean publish) {
+
+		return ddmFormInstanceFinder.countByKeywords(
+			companyId, groupId, keywords, publish);
+	}
+
+	@Override
+	public int searchCount(
 		long companyId, long groupId, String[] names, String[] descriptions,
 		boolean andOperator) {
 
@@ -375,9 +405,18 @@ public class DDMFormInstanceLocalServiceImpl
 	}
 
 	@Override
+	public int searchCount(
+		long companyId, long groupId, String[] names, String[] descriptions,
+		boolean publish, boolean andOperator) {
+
+		return ddmFormInstanceFinder.countByC_G_N_D_P(
+			companyId, groupId, names, descriptions, publish, andOperator);
+	}
+
+	@Override
 	public void sendEmail(
-			long userId, String message, String subject,
-			String[] toEmailAddresses)
+		long userId, String message, String subject,
+		String[] toEmailAddresses)
 		throws Exception {
 
 		User user = _userLocalService.getUser(userId);
@@ -399,7 +438,7 @@ public class DDMFormInstanceLocalServiceImpl
 
 	@Override
 	public DDMFormInstance updateFormInstance(
-			long formInstanceId, DDMFormValues settingsDDMFormValues)
+		long formInstanceId, DDMFormValues settingsDDMFormValues)
 		throws PortalException {
 
 		Date date = new Date();
@@ -417,10 +456,10 @@ public class DDMFormInstanceLocalServiceImpl
 
 	@Override
 	public DDMFormInstance updateFormInstance(
-			long userId, long ddmFormInstanceId, Map<Locale, String> nameMap,
-			Map<Locale, String> descriptionMap, DDMForm ddmForm,
-			DDMFormLayout ddmFormLayout, DDMFormValues settingsDDMFormValues,
-			ServiceContext serviceContext)
+		long userId, long ddmFormInstanceId, Map<Locale, String> nameMap,
+		Map<Locale, String> descriptionMap, DDMForm ddmForm,
+		DDMFormLayout ddmFormLayout, DDMFormValues settingsDDMFormValues,
+		ServiceContext serviceContext)
 		throws PortalException {
 
 		DDMFormInstance ddmFormInstance =
@@ -438,9 +477,9 @@ public class DDMFormInstanceLocalServiceImpl
 
 	@Override
 	public DDMFormInstance updateFormInstance(
-			long ddmFormInstanceId, long ddmStructureId,
-			Map<Locale, String> nameMap, Map<Locale, String> descriptionMap,
-			DDMFormValues settingsDDMFormValues, ServiceContext serviceContext)
+		long ddmFormInstanceId, long ddmStructureId,
+		Map<Locale, String> nameMap, Map<Locale, String> descriptionMap,
+		DDMFormValues settingsDDMFormValues, ServiceContext serviceContext)
 		throws PortalException {
 
 		DDMFormInstance ddmFormInstance =
@@ -452,9 +491,9 @@ public class DDMFormInstanceLocalServiceImpl
 	}
 
 	protected DDMFormInstanceVersion addFormInstanceVersion(
-			long ddmStructureVersionId, User user,
-			DDMFormInstance ddmFormInstance, String version,
-			ServiceContext serviceContext)
+		long ddmStructureVersionId, User user,
+		DDMFormInstance ddmFormInstance, String version,
+		ServiceContext serviceContext)
 		throws PortalException {
 
 		long ddmFormInstanceVersionId = counterLocalService.increment();
@@ -487,10 +526,10 @@ public class DDMFormInstanceLocalServiceImpl
 	}
 
 	protected DDMFormInstance doUpdateFormInstance(
-			long userId, long ddmStructureId, Map<Locale, String> nameMap,
-			Map<Locale, String> descriptionMap,
-			DDMFormValues settingsDDMFormValues, ServiceContext serviceContext,
-			DDMFormInstance ddmFormInstance)
+		long userId, long ddmStructureId, Map<Locale, String> nameMap,
+		Map<Locale, String> descriptionMap,
+		DDMFormValues settingsDDMFormValues, ServiceContext serviceContext,
+		DDMFormInstance ddmFormInstance)
 		throws PortalException {
 
 		Locale defaultLocale = getDDMFormDefaultLocale(ddmStructureId);
@@ -512,7 +551,7 @@ public class DDMFormInstanceLocalServiceImpl
 		boolean updateVersion = false;
 
 		if ((latestDDMFormInstanceVersion.getStatus() ==
-				WorkflowConstants.STATUS_DRAFT) &&
+			 WorkflowConstants.STATUS_DRAFT) &&
 			(status == WorkflowConstants.STATUS_DRAFT)) {
 
 			updateVersion = true;
@@ -580,7 +619,7 @@ public class DDMFormInstanceLocalServiceImpl
 	}
 
 	protected DDMFormValues getFormInstanceSettingsFormValues(
-			String serializedSettingsDDMFormValues)
+		String serializedSettingsDDMFormValues)
 		throws PortalException {
 
 		DDMForm ddmForm = DDMFormFactory.create(DDMFormInstanceSettings.class);
@@ -591,7 +630,7 @@ public class DDMFormInstanceLocalServiceImpl
 
 		DDMFormValuesDeserializerDeserializeResponse
 			ddmFormValuesDeserializerDeserializeResponse =
-				_jsonDDMFormValuesDeserializer.deserialize(builder.build());
+			_jsonDDMFormValuesDeserializer.deserialize(builder.build());
 
 		return ddmFormValuesDeserializerDeserializeResponse.getDDMFormValues();
 	}
@@ -653,14 +692,14 @@ public class DDMFormInstanceLocalServiceImpl
 
 		DDMFormValuesSerializerSerializeResponse
 			ddmFormValuesSerializerSerializeResponse =
-				_jsonDDMFormValuesSerializer.serialize(builder.build());
+			_jsonDDMFormValuesSerializer.serialize(builder.build());
 
 		return ddmFormValuesSerializerSerializeResponse.getContent();
 	}
 
 	protected void updateFormInstanceVersion(
-			long ddmStructureVersionId, User user,
-			DDMFormInstance ddmFormInstance)
+		long ddmStructureVersionId, User user,
+		DDMFormInstance ddmFormInstance)
 		throws PortalException {
 
 		DDMFormInstanceVersion ddmFormInstanceVersion =
@@ -681,8 +720,8 @@ public class DDMFormInstanceLocalServiceImpl
 	}
 
 	protected void updateWorkflowDefinitionLink(
-			DDMFormInstance formInstance, DDMFormValues settingsDDMFormValues,
-			ServiceContext serviceContext)
+		DDMFormInstance formInstance, DDMFormValues settingsDDMFormValues,
+		ServiceContext serviceContext)
 		throws PortalException {
 
 		String workflowDefinition = getWorkflowDefinition(
@@ -699,7 +738,7 @@ public class DDMFormInstanceLocalServiceImpl
 
 			latestWorkflowDefinition =
 				workflowDefinition + StringPool.AT +
-					kaleoDefinition.getVersion();
+				kaleoDefinition.getVersion();
 		}
 
 		_workflowDefinitionLinkLocalService.updateWorkflowDefinitionLink(
@@ -709,9 +748,9 @@ public class DDMFormInstanceLocalServiceImpl
 	}
 
 	protected void validate(
-			long ddmStructureId, Locale defaultLocale,
-			Map<Locale, String> nameMap, DDMFormValues settingsDDMFormValues,
-			TimeZone timeZone)
+		long ddmStructureId, Locale defaultLocale,
+		Map<Locale, String> nameMap, DDMFormValues settingsDDMFormValues,
+		TimeZone timeZone)
 		throws PortalException {
 
 		validateStructureId(ddmStructureId);
@@ -722,14 +761,14 @@ public class DDMFormInstanceLocalServiceImpl
 	}
 
 	protected void validateFormInstanceSettings(
-			DDMFormValues settingsDDMFormValues, String timeZoneId)
+		DDMFormValues settingsDDMFormValues, String timeZoneId)
 		throws PortalException {
 
 		_ddmFormValuesValidator.validate(settingsDDMFormValues, timeZoneId);
 	}
 
 	protected void validateName(
-			Map<Locale, String> nameMap, Locale defaultLocale)
+		Map<Locale, String> nameMap, Locale defaultLocale)
 		throws PortalException {
 
 		String name = nameMap.get(defaultLocale);
@@ -749,7 +788,7 @@ public class DDMFormInstanceLocalServiceImpl
 		if (ddmStructure == null) {
 			throw new FormInstanceStructureIdException(
 				"No DDM structure exists with the DDM structure ID " +
-					ddmStructureId);
+				ddmStructureId);
 		}
 	}
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMFormInstanceServiceImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMFormInstanceServiceImpl.java
@@ -51,9 +51,9 @@ public class DDMFormInstanceServiceImpl extends DDMFormInstanceServiceBaseImpl {
 
 	@Override
 	public DDMFormInstance addFormInstance(
-			long groupId, long ddmStructureId, Map<Locale, String> nameMap,
-			Map<Locale, String> descriptionMap,
-			DDMFormValues settingsDDMFormValues, ServiceContext serviceContext)
+		long groupId, long ddmStructureId, Map<Locale, String> nameMap,
+		Map<Locale, String> descriptionMap,
+		DDMFormValues settingsDDMFormValues, ServiceContext serviceContext)
 		throws PortalException {
 
 		_portletResourcePermission.check(
@@ -66,10 +66,10 @@ public class DDMFormInstanceServiceImpl extends DDMFormInstanceServiceBaseImpl {
 
 	@Override
 	public DDMFormInstance addFormInstance(
-			long groupId, Map<Locale, String> nameMap,
-			Map<Locale, String> descriptionMap, DDMForm ddmForm,
-			DDMFormLayout ddmFormLayout, DDMFormValues settingsDDMFormValues,
-			ServiceContext serviceContext)
+		long groupId, Map<Locale, String> nameMap,
+		Map<Locale, String> descriptionMap, DDMForm ddmForm,
+		DDMFormLayout ddmFormLayout, DDMFormValues settingsDDMFormValues,
+		ServiceContext serviceContext)
 		throws PortalException {
 
 		_portletResourcePermission.check(
@@ -82,9 +82,9 @@ public class DDMFormInstanceServiceImpl extends DDMFormInstanceServiceBaseImpl {
 
 	@Override
 	public DDMFormInstance copyFormInstance(
-			long groupId, Map<Locale, String> nameMap,
-			DDMFormInstance ddmFormInstance,
-			DDMFormValues settingsDDMFormValues, ServiceContext serviceContext)
+		long groupId, Map<Locale, String> nameMap,
+		DDMFormInstance ddmFormInstance,
+		DDMFormValues settingsDDMFormValues, ServiceContext serviceContext)
 		throws PortalException {
 
 		_portletResourcePermission.check(
@@ -117,8 +117,8 @@ public class DDMFormInstanceServiceImpl extends DDMFormInstanceServiceBaseImpl {
 		}
 
 		if (_ddmFormInstanceModelResourcePermission.contains(
-				getPermissionChecker(), ddmFormInstance.getFormInstanceId(),
-				DDMActionKeys.ADD_FORM_INSTANCE_RECORD)) {
+			getPermissionChecker(), ddmFormInstance.getFormInstanceId(),
+			DDMActionKeys.ADD_FORM_INSTANCE_RECORD)) {
 
 			return ddmFormInstance;
 		}
@@ -135,8 +135,8 @@ public class DDMFormInstanceServiceImpl extends DDMFormInstanceServiceBaseImpl {
 		throws PortalException {
 
 		if (_ddmFormInstanceModelResourcePermission.contains(
-				getPermissionChecker(), ddmFormInstanceId,
-				DDMActionKeys.ADD_FORM_INSTANCE_RECORD)) {
+			getPermissionChecker(), ddmFormInstanceId,
+			DDMActionKeys.ADD_FORM_INSTANCE_RECORD)) {
 
 			return ddmFormInstanceLocalService.getFormInstance(
 				ddmFormInstanceId);
@@ -168,6 +168,28 @@ public class DDMFormInstanceServiceImpl extends DDMFormInstanceServiceBaseImpl {
 
 	@Override
 	public List<DDMFormInstance> search(
+		long companyId, long groupId, String keywords, boolean publish,
+		int status, int start, int end,
+		OrderByComparator<DDMFormInstance> orderByComparator) {
+
+		return ddmFormInstanceFinder.filterFindByKeywords(
+			companyId, groupId, keywords, publish, status, start, end,
+			orderByComparator);
+	}
+
+	@Override
+	public List<DDMFormInstance> search(
+		long companyId, long groupId, String keywords, boolean publish,
+		int start, int end,
+		OrderByComparator<DDMFormInstance> orderByComparator) {
+
+		return ddmFormInstanceFinder.filterFindByKeywords(
+			companyId, groupId, keywords, publish, start, end,
+			orderByComparator);
+	}
+
+	@Override
+	public List<DDMFormInstance> search(
 		long companyId, long groupId, String keywords, int status, int start,
 		int end, OrderByComparator<DDMFormInstance> orderByComparator) {
 
@@ -183,6 +205,17 @@ public class DDMFormInstanceServiceImpl extends DDMFormInstanceServiceBaseImpl {
 
 		return ddmFormInstanceFinder.filterFindByKeywords(
 			companyId, groupId, keywords, start, end, orderByComparator);
+	}
+
+	@Override
+	public List<DDMFormInstance> search(
+		long companyId, long groupId, String[] names, String[] descriptions,
+		boolean publish, boolean andOperator, int start, int end,
+		OrderByComparator<DDMFormInstance> orderByComparator) {
+
+		return ddmFormInstanceFinder.filterFindByC_G_N_D_P(
+			companyId, groupId, names, descriptions, publish, andOperator,
+			start, end, orderByComparator);
 	}
 
 	@Override
@@ -204,6 +237,23 @@ public class DDMFormInstanceServiceImpl extends DDMFormInstanceServiceBaseImpl {
 
 	@Override
 	public int searchCount(
+		long companyId, long groupId, String keywords, boolean publish) {
+
+		return ddmFormInstanceFinder.filterCountByKeywords(
+			companyId, groupId, keywords, publish);
+	}
+
+	@Override
+	public int searchCount(
+		long companyId, long groupId, String keywords, boolean publish,
+		int status) {
+
+		return ddmFormInstanceFinder.filterCountByKeywords(
+			companyId, groupId, keywords, publish, status);
+	}
+
+	@Override
+	public int searchCount(
 		long companyId, long groupId, String keywords, int status) {
 
 		return ddmFormInstanceFinder.filterCountByKeywords(
@@ -220,9 +270,18 @@ public class DDMFormInstanceServiceImpl extends DDMFormInstanceServiceBaseImpl {
 	}
 
 	@Override
+	public int searchCount(
+		long companyId, long groupId, String[] names, String[] descriptions,
+		boolean publish, boolean andOperator) {
+
+		return ddmFormInstanceFinder.filterCountByC_G_N_D_P(
+			companyId, groupId, names, descriptions, publish, andOperator);
+	}
+
+	@Override
 	public void sendEmail(
-			long formInstanceId, String message, String subject,
-			String[] toEmailAddresses)
+		long formInstanceId, String message, String subject,
+		String[] toEmailAddresses)
 		throws Exception {
 
 		_ddmFormInstanceModelResourcePermission.check(
@@ -244,7 +303,7 @@ public class DDMFormInstanceServiceImpl extends DDMFormInstanceServiceBaseImpl {
 	 */
 	@Override
 	public DDMFormInstance updateFormInstance(
-			long formInstanceId, DDMFormValues settingsDDMFormValues)
+		long formInstanceId, DDMFormValues settingsDDMFormValues)
 		throws PortalException {
 
 		_ddmFormInstanceModelResourcePermission.check(
@@ -256,10 +315,10 @@ public class DDMFormInstanceServiceImpl extends DDMFormInstanceServiceBaseImpl {
 
 	@Override
 	public DDMFormInstance updateFormInstance(
-			long ddmFormInstanceId, Map<Locale, String> nameMap,
-			Map<Locale, String> descriptionMap, DDMForm ddmForm,
-			DDMFormLayout ddmFormLayout, DDMFormValues settingsDDMFormValues,
-			ServiceContext serviceContext)
+		long ddmFormInstanceId, Map<Locale, String> nameMap,
+		Map<Locale, String> descriptionMap, DDMForm ddmForm,
+		DDMFormLayout ddmFormLayout, DDMFormValues settingsDDMFormValues,
+		ServiceContext serviceContext)
 		throws PortalException {
 
 		_ddmFormInstanceModelResourcePermission.check(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/impl/DDMFormInstanceFinderImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/persistence/impl/DDMFormInstanceFinderImpl.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.dao.orm.Type;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.security.permission.InlineSQLHelperUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
+import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
@@ -44,21 +45,28 @@ import org.osgi.service.component.annotations.Reference;
 public class DDMFormInstanceFinderImpl
 	extends DDMFormInstanceFinderBaseImpl implements DDMFormInstanceFinder {
 
-	public static final String COUNT_BY_C_G_N_D =
-		DDMFormInstanceFinder.class.getName() + ".countByC_G_N_D";
+	public static final String COUNT_BY_C_G_N_D_P =
+		DDMFormInstanceFinder.class.getName() + ".countByC_G_N_D_P";
 
-	public static final String COUNT_BY_C_G_N_D_S =
-		DDMFormInstanceFinder.class.getName() + ".countByC_G_N_D_S";
+	public static final String COUNT_BY_C_G_N_D_P_S =
+		DDMFormInstanceFinder.class.getName() + ".countByC_G_N_D_P_S";
 
-	public static final String FIND_BY_C_G_N_D =
-		DDMFormInstanceFinder.class.getName() + ".findByC_G_N_D";
+	public static final String FIND_BY_C_G_N_D_P =
+		DDMFormInstanceFinder.class.getName() + ".findByC_G_N_D_P";
 
-	public static final String FIND_BY_C_G_N_D_S =
-		DDMFormInstanceFinder.class.getName() + ".findByC_G_N_D_S";
+	public static final String FIND_BY_C_G_N_D_P_S =
+		DDMFormInstanceFinder.class.getName() + ".findByC_G_N_D_P_S";
 
 	@Override
 	public int countByKeywords(long companyId, long groupId, String keywords) {
-		return doCountByKeywords(companyId, groupId, keywords, false);
+		return countByKeywords(companyId, groupId, keywords, null);
+	}
+
+	@Override
+	public int countByKeywords(
+		long companyId, long groupId, String keywords, Boolean publish) {
+
+		return doCountByKeywords(companyId, groupId, keywords, publish, false);
 	}
 
 	@Override
@@ -66,8 +74,18 @@ public class DDMFormInstanceFinderImpl
 		long companyId, long groupId, String[] names, String[] descriptions,
 		boolean andOperator) {
 
-		return doCountByC_G_N_D(
-			companyId, groupId, names, descriptions, andOperator, false);
+		return countByC_G_N_D_P(
+			companyId, groupId, names, descriptions, null, andOperator);
+	}
+
+	@Override
+	public int countByC_G_N_D_P(
+		long companyId, long groupId, String[] names, String[] descriptions,
+		Boolean publish, boolean andOperator) {
+
+		return doCountByC_G_N_D_P(
+			companyId, groupId, names, descriptions, publish, andOperator,
+			false);
 	}
 
 	@Override
@@ -75,6 +93,22 @@ public class DDMFormInstanceFinderImpl
 		long companyId, long groupId, String keywords) {
 
 		return doCountByKeywords(companyId, groupId, keywords, true);
+	}
+
+	@Override
+	public int filterCountByKeywords(
+		long companyId, long groupId, String keywords, Boolean publish) {
+
+		return doCountByKeywords(companyId, groupId, keywords, publish, true);
+	}
+
+	@Override
+	public int filterCountByKeywords(
+		long companyId, long groupId, String keywords, Boolean publish,
+		int status) {
+
+		return doCountByKeywords(
+			companyId, groupId, keywords, publish, status, true);
 	}
 
 	@Override
@@ -99,9 +133,20 @@ public class DDMFormInstanceFinderImpl
 	}
 
 	@Override
+	public int filterCountByC_G_N_D_P(
+		long companyId, long groupId, String[] names, String[] descriptions,
+		Boolean publish, boolean andOperator) {
+
+		return doCountByC_G_N_D_P(
+			companyId, groupId, names, descriptions, publish, andOperator,
+			true);
+	}
+
+	@Override
 	public List<DDMFormInstance> filterFindByKeywords(
-		long companyId, long groupId, String keywords, int status, int start,
-		int end, OrderByComparator<DDMFormInstance> orderByComparator) {
+		long companyId, long groupId, String keywords, Boolean publish,
+		int status, int start, int end,
+		OrderByComparator<DDMFormInstance> orderByComparator) {
 
 		String[] names = null;
 		String[] descriptions = null;
@@ -115,9 +160,30 @@ public class DDMFormInstanceFinderImpl
 			andOperator = true;
 		}
 
-		return filterFindByC_G_N_D_S(
-			companyId, groupId, names, descriptions, status, andOperator, start,
-			end, orderByComparator);
+		return filterFindByC_G_N_D_P_S(
+			companyId, groupId, names, descriptions, publish, status,
+			andOperator, start, end, orderByComparator);
+	}
+
+	@Override
+	public List<DDMFormInstance> filterFindByKeywords(
+		long companyId, long groupId, String keywords, Boolean publish,
+		int start, int end,
+		OrderByComparator<DDMFormInstance> orderByComparator) {
+
+		return filterFindByKeywords(
+			companyId, groupId, keywords, publish, WorkflowConstants.STATUS_ANY,
+			start, end, orderByComparator);
+	}
+
+	@Override
+	public List<DDMFormInstance> filterFindByKeywords(
+		long companyId, long groupId, String keywords, int status, int start,
+		int end, OrderByComparator<DDMFormInstance> orderByComparator) {
+
+		return filterFindByKeywords(
+			companyId, groupId, keywords, null, status, start, end,
+			orderByComparator);
 	}
 
 	@Override
@@ -126,8 +192,8 @@ public class DDMFormInstanceFinderImpl
 		OrderByComparator<DDMFormInstance> orderByComparator) {
 
 		return filterFindByKeywords(
-			companyId, groupId, keywords, WorkflowConstants.STATUS_ANY, start,
-			end, orderByComparator);
+			companyId, groupId, keywords, null, WorkflowConstants.STATUS_ANY,
+			start, end, orderByComparator);
 	}
 
 	@Override
@@ -149,6 +215,17 @@ public class DDMFormInstanceFinderImpl
 	}
 
 	@Override
+	public List<DDMFormInstance> filterFindByC_G_N_D_P(
+		long companyId, long groupId, String[] names, String[] descriptions,
+		Boolean publish, boolean andOperator, int start, int end,
+		OrderByComparator<DDMFormInstance> orderByComparator) {
+
+		return doFindByC_G_N_D_P(
+			companyId, groupId, names, descriptions, publish, andOperator,
+			start, end, orderByComparator, true);
+	}
+
+	@Override
 	public List<DDMFormInstance> filterFindByC_G_N_D_S(
 		long companyId, long groupId, String[] names, String[] descriptions,
 		int status, boolean andOperator, int start, int end,
@@ -159,9 +236,20 @@ public class DDMFormInstanceFinderImpl
 			end, orderByComparator, true);
 	}
 
+	public List<DDMFormInstance> filterFindByC_G_N_D_P_S(
+		long companyId, long groupId, String[] names, String[] descriptions,
+		Boolean publish, int status, boolean andOperator, int start, int end,
+		OrderByComparator<DDMFormInstance> orderByComparator) {
+
+		return doFindByC_G_N_D_P_S(
+			companyId, groupId, names, descriptions, publish, status,
+			andOperator, start, end, orderByComparator, true);
+	}
+
 	@Override
 	public List<DDMFormInstance> findByKeywords(
-		long companyId, long groupId, String keywords, int start, int end,
+		long companyId, long groupId, String keywords, Boolean publish,
+		int start, int end,
 		OrderByComparator<DDMFormInstance> orderByComparator) {
 
 		String[] names = null;
@@ -176,9 +264,17 @@ public class DDMFormInstanceFinderImpl
 			andOperator = true;
 		}
 
-		return findByC_G_N_D(
-			companyId, groupId, names, descriptions, andOperator, start, end,
-			orderByComparator);
+		return findByC_G_N_D_P(
+			companyId, groupId, names, descriptions, publish, andOperator,
+			start, end, orderByComparator);
+	}
+
+	public List<DDMFormInstance> findByKeywords(
+		long companyId, long groupId, String keywords, int start, int end,
+		OrderByComparator<DDMFormInstance> orderByComparator) {
+
+		return findByKeywords(
+			companyId, groupId, keywords, null, start, end, orderByComparator);
 	}
 
 	@Override
@@ -187,9 +283,20 @@ public class DDMFormInstanceFinderImpl
 		boolean andOperator, int start, int end,
 		OrderByComparator<DDMFormInstance> orderByComparator) {
 
-		return doFindByC_G_N_D(
+		return findByC_G_N_D(
 			companyId, groupId, names, descriptions, andOperator, start, end,
-			orderByComparator, false);
+			orderByComparator);
+	}
+
+	@Override
+	public List<DDMFormInstance> findByC_G_N_D_P(
+		long companyId, long groupId, String[] names, String[] descriptions,
+		Boolean publish, boolean andOperator, int start, int end,
+		OrderByComparator<DDMFormInstance> orderByComparator) {
+
+		return doFindByC_G_N_D_P(
+			companyId, groupId, names, descriptions, publish, andOperator,
+			start, end, orderByComparator, false);
 	}
 
 	protected int doCountByKeywords(
@@ -197,13 +304,22 @@ public class DDMFormInstanceFinderImpl
 		boolean inlineSQLHelper) {
 
 		return doCountByKeywords(
-			companyId, groupId, keywords, WorkflowConstants.STATUS_ANY,
+			companyId, groupId, keywords, null, WorkflowConstants.STATUS_ANY,
 			inlineSQLHelper);
 	}
 
 	protected int doCountByKeywords(
-		long companyId, long groupId, String keywords, int status,
+		long companyId, long groupId, String keywords, Boolean publish,
 		boolean inlineSQLHelper) {
+
+		return doCountByKeywords(
+			companyId, groupId, keywords, publish, WorkflowConstants.STATUS_ANY,
+			inlineSQLHelper);
+	}
+
+	protected int doCountByKeywords(
+		long companyId, long groupId, String keywords, Boolean publish,
+		int status, boolean inlineSQLHelper) {
 
 		String[] names = null;
 		String[] descriptions = null;
@@ -217,23 +333,50 @@ public class DDMFormInstanceFinderImpl
 			andOperator = true;
 		}
 
-		return doCountByC_G_N_D_S(
-			companyId, groupId, names, descriptions, status, andOperator,
-			inlineSQLHelper);
+		return doCountByC_G_N_D_P_S(
+			companyId, groupId, names, descriptions, publish, status,
+			andOperator, inlineSQLHelper);
+	}
+
+	protected int doCountByKeywords(
+		long companyId, long groupId, String keywords, int status,
+		boolean inlineSQLHelper) {
+
+		return doCountByKeywords(
+			companyId, groupId, keywords, null, status, inlineSQLHelper);
 	}
 
 	protected int doCountByC_G_N_D(
 		long companyId, long groupId, String[] names, String[] descriptions,
 		boolean andOperator, boolean inlineSQLHelper) {
 
-		return doCountByC_G_N_D_S(
-			companyId, groupId, names, descriptions,
+		return doCountByC_G_N_D_P_S(
+			companyId, groupId, names, descriptions, null,
+			WorkflowConstants.STATUS_ANY, andOperator, inlineSQLHelper);
+	}
+
+	protected int doCountByC_G_N_D_P(
+		long companyId, long groupId, String[] names, String[] descriptions,
+		Boolean publish, boolean andOperator, boolean inlineSQLHelper) {
+
+		return doCountByC_G_N_D_P_S(
+			companyId, groupId, names, descriptions, publish,
 			WorkflowConstants.STATUS_ANY, andOperator, inlineSQLHelper);
 	}
 
 	protected int doCountByC_G_N_D_S(
 		long companyId, long groupId, String[] names, String[] descriptions,
 		int status, boolean andOperator, boolean inlineSQLHelper) {
+
+		return doCountByC_G_N_D_P_S(
+			companyId, groupId, names, descriptions, null, status, andOperator,
+			inlineSQLHelper);
+	}
+
+	protected int doCountByC_G_N_D_P_S(
+		long companyId, long groupId, String[] names, String[] descriptions,
+		Boolean publish, int status, boolean andOperator,
+		boolean inlineSQLHelper) {
 
 		names = _customSQL.keywords(names);
 		descriptions = _customSQL.keywords(descriptions, false);
@@ -246,10 +389,10 @@ public class DDMFormInstanceFinderImpl
 			String sql = "";
 
 			if (status == WorkflowConstants.STATUS_ANY) {
-				sql = _customSQL.get(getClass(), COUNT_BY_C_G_N_D);
+				sql = _customSQL.get(getClass(), COUNT_BY_C_G_N_D_P);
 			}
 			else {
-				sql = _customSQL.get(getClass(), COUNT_BY_C_G_N_D_S);
+				sql = _customSQL.get(getClass(), COUNT_BY_C_G_N_D_P_S);
 			}
 
 			if (inlineSQLHelper) {
@@ -269,6 +412,17 @@ public class DDMFormInstanceFinderImpl
 			sql = _customSQL.replaceKeywords(
 				sql, "DDMFormInstance.description", StringPool.LIKE, true,
 				descriptions);
+
+			if (publish != null) {
+				sql = StringUtil.replace(
+					sql, "[DDMFormInstanceSettingsFilterPublished]",
+					getPublishFilterQuery(publish));
+			}
+			else {
+				sql = StringUtil.removeSubstring(
+					sql, "[DDMFormInstanceSettingsFilterPublished]");
+			}
+
 			sql = _customSQL.replaceAndOperator(sql, andOperator);
 
 			SQLQuery sqlQuery = session.createSynchronizedSQLQuery(sql);
@@ -315,8 +469,20 @@ public class DDMFormInstanceFinderImpl
 		OrderByComparator<DDMFormInstance> orderByComparator,
 		boolean inlineSQLHelper) {
 
-		return doFindByC_G_N_D_S(
-			companyId, groupId, names, descriptions,
+		return doFindByC_G_N_D_P_S(
+			companyId, groupId, names, descriptions, null,
+			WorkflowConstants.STATUS_ANY, andOperator, start, end,
+			orderByComparator, inlineSQLHelper);
+	}
+
+	protected List<DDMFormInstance> doFindByC_G_N_D_P(
+		long companyId, long groupId, String[] names, String[] descriptions,
+		Boolean publish, boolean andOperator, int start, int end,
+		OrderByComparator<DDMFormInstance> orderByComparator,
+		boolean inlineSQLHelper) {
+
+		return doFindByC_G_N_D_P_S(
+			companyId, groupId, names, descriptions, publish,
 			WorkflowConstants.STATUS_ANY, andOperator, start, end,
 			orderByComparator, inlineSQLHelper);
 	}
@@ -324,6 +490,17 @@ public class DDMFormInstanceFinderImpl
 	protected List<DDMFormInstance> doFindByC_G_N_D_S(
 		long companyId, long groupId, String[] names, String[] descriptions,
 		int status, boolean andOperator, int start, int end,
+		OrderByComparator<DDMFormInstance> orderByComparator,
+		boolean inlineSQLHelper) {
+
+		return doFindByC_G_N_D_P_S(
+			companyId, groupId, names, descriptions, null, status, andOperator,
+			start, end, orderByComparator, inlineSQLHelper);
+	}
+
+	protected List<DDMFormInstance> doFindByC_G_N_D_P_S(
+		long companyId, long groupId, String[] names, String[] descriptions,
+		Boolean publish, int status, boolean andOperator, int start, int end,
 		OrderByComparator<DDMFormInstance> orderByComparator,
 		boolean inlineSQLHelper) {
 
@@ -338,10 +515,10 @@ public class DDMFormInstanceFinderImpl
 			String sql = "";
 
 			if (status == WorkflowConstants.STATUS_ANY) {
-				sql = _customSQL.get(getClass(), FIND_BY_C_G_N_D);
+				sql = _customSQL.get(getClass(), FIND_BY_C_G_N_D_P);
 			}
 			else {
-				sql = _customSQL.get(getClass(), FIND_BY_C_G_N_D_S);
+				sql = _customSQL.get(getClass(), FIND_BY_C_G_N_D_P_S);
 			}
 
 			if (inlineSQLHelper) {
@@ -361,6 +538,17 @@ public class DDMFormInstanceFinderImpl
 			sql = _customSQL.replaceKeywords(
 				sql, "DDMFormInstance.description", StringPool.LIKE, true,
 				descriptions);
+
+			if (publish != null) {
+				sql = StringUtil.replace(
+					sql, "[DDMFormInstanceSettingsFilterPublished]",
+					getPublishFilterQuery(publish));
+			}
+			else {
+				sql = StringUtil.removeSubstring(
+					sql, "[DDMFormInstanceSettingsFilterPublished]");
+			}
+
 			sql = _customSQL.replaceAndOperator(sql, andOperator);
 			sql = _customSQL.replaceOrderBy(sql, orderByComparator);
 
@@ -392,6 +580,23 @@ public class DDMFormInstanceFinderImpl
 			closeSession(session);
 		}
 	}
+
+	protected String getPublishFilterQuery(boolean publish) {
+		StringBundler sb = new StringBundler(4);
+
+		sb.append(_PUBLISH_FILTER_QUERY_CONTEXT);
+		sb.append(_PUBLISH_FILTER_QUERY_RESTRICTIONS);
+		sb.append(Boolean.toString(publish));
+		sb.append("\"%'");
+
+		return sb.toString();
+	}
+
+	private static final String _PUBLISH_FILTER_QUERY_CONTEXT =
+		"AND DDMFormInstance.settings_ ";
+
+	private static final String _PUBLISH_FILTER_QUERY_RESTRICTIONS =
+		"LIKE '%\"fieldReference\":\"published\",\"value\":\"";
 
 	@Reference
 	private CustomSQL _customSQL;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/META-INF/custom-sql/default.xml
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/META-INF/custom-sql/default.xml
@@ -42,7 +42,7 @@
 				DDMDataProviderInstance.dataProviderInstanceId DESC
 		]]>
 	</sql>
-	<sql id="com.liferay.dynamic.data.mapping.service.persistence.DDMFormInstanceFinder.countByC_G_N_D">
+	<sql id="com.liferay.dynamic.data.mapping.service.persistence.DDMFormInstanceFinder.countByC_G_N_D_P">
 		<![CDATA[
 			SELECT
 				COUNT(DISTINCT DDMFormInstance.formInstanceId) AS COUNT_VALUE
@@ -55,9 +55,10 @@
 					(LOWER(DDMFormInstance.name) LIKE ? [$AND_OR_NULL_CHECK$]) [$AND_OR_CONNECTOR$]
 					(DDMFormInstance.description LIKE ? [$AND_OR_NULL_CHECK$])
 				)
+				[DDMFormInstanceSettingsFilterPublished]
 		]]>
 	</sql>
-	<sql id="com.liferay.dynamic.data.mapping.service.persistence.DDMFormInstanceFinder.countByC_G_N_D_S">
+	<sql id="com.liferay.dynamic.data.mapping.service.persistence.DDMFormInstanceFinder.countByC_G_N_D_P_S">
 		<![CDATA[
 			SELECT
 				COUNT(DISTINCT DDMFormInstance.formInstanceId) AS COUNT_VALUE
@@ -72,9 +73,10 @@
 					(DDMFormInstance.description LIKE ? [$AND_OR_NULL_CHECK$])
 				) AND
 				(DDMFormInstanceVersion.status = ?)
+				[DDMFormInstanceSettingsFilterPublished]
 		]]>
 	</sql>
-	<sql id="com.liferay.dynamic.data.mapping.service.persistence.DDMFormInstanceFinder.findByC_G_N_D">
+	<sql id="com.liferay.dynamic.data.mapping.service.persistence.DDMFormInstanceFinder.findByC_G_N_D_P">
 		<![CDATA[
 			SELECT
 				{DDMFormInstance.*}
@@ -91,6 +93,7 @@
 							(LOWER(DDMFormInstance.name) LIKE ? [$AND_OR_NULL_CHECK$]) [$AND_OR_CONNECTOR$]
 							(DDMFormInstance.description LIKE ? [$AND_OR_NULL_CHECK$])
 						)
+						[DDMFormInstanceSettingsFilterPublished]
 				)
 				TEMP_TABLE
 					INNER JOIN
@@ -100,7 +103,7 @@
 				DDMFormInstance.formInstanceId DESC
 		]]>
 	</sql>
-	<sql id="com.liferay.dynamic.data.mapping.service.persistence.DDMFormInstanceFinder.findByC_G_N_D_S">
+	<sql id="com.liferay.dynamic.data.mapping.service.persistence.DDMFormInstanceFinder.findByC_G_N_D_P_S">
 		<![CDATA[
 			SELECT
 				{DDMFormInstance.*}
@@ -119,6 +122,7 @@
 							(DDMFormInstance.description LIKE ? [$AND_OR_NULL_CHECK$])
 						) AND
 						(DDMFormInstanceVersion.status = ?)
+						[DDMFormInstanceSettingsFilterPublished]
 				)
 				TEMP_TABLE
 					INNER JOIN

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/com/liferay/dynamic/data/mapping/service/http/packageinfo
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/com/liferay/dynamic/data/mapping/service/http/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0


### PR DESCRIPTION
Related Issue: https://issues.liferay.com/browse/LPS-148805

- d4bab328092f LPS-148805 baseline
- 93e3b02a537c LPS-148805 Use method to also filter by publish status
- 9bfdfcab3633 LPS-148805 build services
- 1b91d5b6a376 LPS-148805 Add method to also filter by publish status
- 885ddeb6f5ef LPS-148805 Prevent unpublished form from showing on widget

Hi, this PR intends to improve the user usability when unpublishing a form. 

On "Prevent unpublished form from showing on widget", a new condition for isFormAvailable is created to avoid Saved and Unpublished forms to be available to the user on a widget page.
The following commits indent to modify the Search container to filter by the Publish status as well and not only by its Workflow status. 

Thanks!
 