### PR TITLE
LPS-151862 New way to deal with feature flags on front-end

### DIFF
--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/hooks/useFlag.tsx
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/hooks/useFlag.tsx
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {useState} from 'react';
+
+export function useFlag() {
+	const [flags] = useState(
+		(Liferay as any).FeatureFlags as {[key: string]: boolean}
+	);
+
+	return flags;
+}

--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/index.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/index.es.js
@@ -52,6 +52,7 @@ export {Layout} from './core/components/PageRenderer/Layout.es';
 export {default as Pages} from './core/components/Pages.es';
 export * from './core/config/index.es';
 export {ConfigProvider, useConfig} from './core/hooks/useConfig.es';
+export {useFlag} from './core/hooks/useFlag';
 export {FormProvider, useForm, useFormState} from './core/hooks/useForm.es';
 export {PageProvider, usePage} from './core/hooks/usePage.es';
 export {useFieldTypesResource} from './core/hooks/useResource.es';

--- a/modules/apps/data-engine/data-engine-js-components-web/types/src/main/resources/META-INF/resources/js/core/hooks/useFlag.d.ts
+++ b/modules/apps/data-engine/data-engine-js-components-web/types/src/main/resources/META-INF/resources/js/core/hooks/useFlag.d.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+export declare function useFlag(): {
+	[key: string]: boolean;
+};

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/init.jsp
@@ -68,7 +68,6 @@ page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
 page import="com.liferay.portal.kernel.model.LayoutConstants" %><%@
 page import="com.liferay.portal.kernel.model.ModelHintsConstants" %><%@
 page import="com.liferay.portal.kernel.util.Constants" %><%@
-page import="com.liferay.portal.kernel.util.GetterUtil" %><%@
 page import="com.liferay.portal.kernel.util.HashMapBuilder" %><%@
 page import="com.liferay.portal.kernel.util.KeyValuePair" %><%@
 page import="com.liferay.portal.kernel.util.ParamUtil" %><%@

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/EditObjectField.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/EditObjectField.tsx
@@ -15,6 +15,7 @@
 import ClayButton from '@clayui/button';
 import ClayForm, {ClayRadio, ClayRadioGroup, ClayToggle} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
+import {useFlag} from 'data-engine-js-components-web';
 import {fetch} from 'frontend-js-web';
 import React, {useEffect, useMemo, useRef, useState} from 'react';
 import {createTextMaskInputElement} from 'text-mask-core';
@@ -59,7 +60,6 @@ function closeSidePanel() {
 }
 
 export default function EditObjectField({
-	allowUploadDocAndMedia,
 	forbiddenChars,
 	forbiddenLastChars,
 	forbiddenNames,
@@ -155,7 +155,6 @@ export default function EditObjectField({
 				/>
 
 				<ObjectFieldFormBase
-					allowUploadDocAndMedia={allowUploadDocAndMedia}
 					disabled={disabled}
 					errors={errors}
 					handleChange={handleChange}
@@ -166,7 +165,6 @@ export default function EditObjectField({
 				>
 					{values.businessType === 'Attachment' && (
 						<AttachmentProperties
-							allowUploadDocAndMedia={allowUploadDocAndMedia}
 							errors={errors}
 							objectFieldSettings={
 								values.objectFieldSettings as ObjectFieldSetting[]
@@ -409,37 +407,36 @@ function MaxLengthProperties({
 }
 
 function AttachmentProperties({
-	allowUploadDocAndMedia,
 	errors,
 	objectFieldSettings,
 	onSettingsChange,
 }: IAttachmentPropertiesProps) {
+	const flags = useFlag();
 	const settings = normalizeFieldSettings(objectFieldSettings);
 
 	return (
 		<>
 			<ClayForm.Group>
-				{allowUploadDocAndMedia &&
-					settings.showFilesInDocumentsAndMedia && (
-						<Input
-							error={errors.storageDLFolderPath}
-							feedbackMessage={Liferay.Util.sub(
-								Liferay.Language.get(
-									'input-the-path-of-the-chosen-folder-in-documents-and-media-an-example-of-a-valid-path-is-x'
-								),
-								'/myDocumentsAndMediaFolder'
-							)}
-							label={Liferay.Language.get('storage-folder')}
-							onChange={({target: {value}}) =>
-								onSettingsChange({
-									name: 'storageDLFolderPath',
-									value,
-								})
-							}
-							required
-							value={settings.storageDLFolderPath as string}
-						/>
-					)}
+				{flags['LPS-148112'] && settings.showFilesInDocumentsAndMedia && (
+					<Input
+						error={errors.storageDLFolderPath}
+						feedbackMessage={Liferay.Util.sub(
+							Liferay.Language.get(
+								'input-the-path-of-the-chosen-folder-in-documents-and-media-an-example-of-a-valid-path-is-x'
+							),
+							'/myDocumentsAndMediaFolder'
+						)}
+						label={Liferay.Language.get('storage-folder')}
+						onChange={({target: {value}}) =>
+							onSettingsChange({
+								name: 'storageDLFolderPath',
+								value,
+							})
+						}
+						required
+						value={settings.storageDLFolderPath as string}
+					/>
+				)}
 			</ClayForm.Group>
 			<Input
 				component="textarea"
@@ -475,7 +472,6 @@ function AttachmentProperties({
 }
 
 interface IAttachmentPropertiesProps {
-	allowUploadDocAndMedia?: boolean;
 	errors: ObjectFieldErrors;
 	objectFieldSettings: ObjectFieldSetting[];
 	onSettingsChange: (setting: ObjectFieldSetting) => void;
@@ -491,7 +487,6 @@ interface IMaxLengthPropertiesProps {
 }
 
 interface IProps {
-	allowUploadDocAndMedia?: boolean;
 	forbiddenChars: string[];
 	forbiddenLastChars: string[];
 	forbiddenNames: string[];

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModalAddObjectField.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModalAddObjectField.tsx
@@ -32,7 +32,6 @@ const headers = new Headers({
 });
 
 function ModalAddObjectField({
-	allowUploadDocAndMedia,
 	apiURL,
 	objectFieldTypes,
 	objectName,
@@ -113,7 +112,6 @@ function ModalAddObjectField({
 					/>
 
 					<ObjectFieldFormBase
-						allowUploadDocAndMedia={allowUploadDocAndMedia}
 						errors={errors}
 						handleChange={handleChange}
 						objectField={values}
@@ -145,7 +143,6 @@ function ModalAddObjectField({
 }
 
 export default function ModalWithProvider({
-	allowUploadDocAndMedia,
 	apiURL,
 	objectFieldTypes,
 	objectName,
@@ -163,7 +160,6 @@ export default function ModalWithProvider({
 		<ClayModalProvider>
 			{isVisible && (
 				<ModalAddObjectField
-					allowUploadDocAndMedia={allowUploadDocAndMedia}
 					apiURL={apiURL}
 					objectFieldTypes={objectFieldTypes}
 					objectName={objectName}
@@ -176,13 +172,11 @@ export default function ModalWithProvider({
 }
 
 interface IModal extends IProps {
-	allowUploadDocAndMedia: boolean;
 	observer: any;
 	onClose: () => void;
 }
 
 interface IProps {
-	allowUploadDocAndMedia: boolean;
 	apiURL: string;
 	objectFieldTypes: ObjectFieldType[];
 	objectName: string;

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectFieldFormBase.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectFieldFormBase.tsx
@@ -15,6 +15,7 @@
 import ClayForm, {ClayToggle} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import {ClayTooltipProvider} from '@clayui/tooltip';
+import {useFlag} from 'data-engine-js-components-web';
 import {fetch} from 'frontend-js-web';
 import React, {ChangeEventHandler, ReactNode, useMemo, useState} from 'react';
 
@@ -75,7 +76,6 @@ async function fetchPickList() {
 }
 
 export default function ObjectFieldFormBase({
-	allowUploadDocAndMedia,
 	children,
 	disabled,
 	errors,
@@ -186,7 +186,6 @@ export default function ObjectFieldFormBase({
 
 			{values.businessType === 'Attachment' && (
 				<AttachmentSourceProperty
-					allowUploadDocAndMedia={allowUploadDocAndMedia}
 					disabled={disabled}
 					error={errors.fileSource}
 					objectFieldSettings={
@@ -366,7 +365,6 @@ export function useObjectFieldForm({
 }
 
 function AttachmentSourceProperty({
-	allowUploadDocAndMedia,
 	disabled,
 	error,
 	objectFieldSettings,
@@ -374,6 +372,7 @@ function AttachmentSourceProperty({
 	onSettingsChange,
 	setValues,
 }: IAttachmentSourcePropertyProps) {
+	const flags = useFlag();
 	const settings = normalizeFieldSettings(objectFieldSettings);
 
 	const attachmentSource = attachmentSources.find(
@@ -382,7 +381,7 @@ function AttachmentSourceProperty({
 
 	const handleAttachmentSourceChange = ({value}: {value: string}) => {
 		const fileSource: ObjectFieldSetting = {name: 'fileSource', value};
-		if (!allowUploadDocAndMedia) {
+		if (!flags['LPS-148112']) {
 			onSettingsChange(fileSource);
 
 			return;
@@ -441,7 +440,7 @@ function AttachmentSourceProperty({
 				value={attachmentSource?.label}
 			/>
 
-			{allowUploadDocAndMedia && settings.fileSource === 'userComputer' && (
+			{flags['LPS-148112'] && settings.fileSource === 'userComputer' && (
 				<ClayForm.Group className="lfr-objects__object-field-form-base-container">
 					<ClayToggle
 						disabled={disabled}
@@ -473,7 +472,6 @@ function AttachmentSourceProperty({
 }
 
 interface IAttachmentSourcePropertyProps {
-	allowUploadDocAndMedia?: boolean;
 	disabled?: boolean;
 	error?: string;
 	objectFieldSettings: ObjectFieldSetting[];
@@ -494,7 +492,6 @@ interface IPickList {
 }
 
 interface IProps {
-	allowUploadDocAndMedia?: boolean;
 	children?: ReactNode;
 	disabled?: boolean;
 	errors: ObjectFieldErrors;

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_definitions/edit_object_field.jsp
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_definitions/edit_object_field.jsp
@@ -29,8 +29,6 @@ ObjectField objectField = (ObjectField)request.getAttribute(ObjectWebKeys.OBJECT
 		module="js/components/EditObjectField"
 		props='<%=
 			HashMapBuilder.<String, Object>put(
-				"allowUploadDocAndMedia", GetterUtil.getBoolean(PropsUtil.get("feature.flag.LPS-148112"))
-			).put(
 				"forbiddenChars", PropsUtil.getArray(PropsKeys.DL_CHAR_BLACKLIST)
 			).put(
 				"forbiddenLastChars", objectDefinitionsFieldsDisplayContext.getForbiddenLastCharacters()

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_definitions/object_definition/fields.jsp
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_definitions/object_definition/fields.jsp
@@ -47,8 +47,6 @@ renderResponse.setTitle(objectDefinition.getLabel(locale, true));
 		module="js/components/ModalAddObjectField"
 		props='<%=
 			HashMapBuilder.<String, Object>put(
-				"allowUploadDocAndMedia", GetterUtil.getBoolean(PropsUtil.get("feature.flag.LPS-148112"))
-			).put(
 				"apiURL", objectDefinitionsFieldsDisplayContext.getAPIURL()
 			).put(
 				"forbiddenChars", PropsUtil.getArray(PropsKeys.DL_CHAR_BLACKLIST)

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/type-declarations/data-engine-js-components-web.d.ts
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/type-declarations/data-engine-js-components-web.d.ts
@@ -17,11 +17,15 @@ declare module 'data-engine-js-components-web' {
 		errorMessage,
 		helpMessage,
 		warningMessage,
-	}: IProps): JSX.Element;
+	}: {
+		errorMessage?: string;
+		helpMessage?: string;
+		warningMessage?: string;
+	}): JSX.Element;
+
+	function useFlag(): {
+		[key in Flags]: boolean;
+	};
 }
 
-interface IProps {
-	errorMessage?: string;
-	helpMessage?: string;
-	warningMessage?: string;
-}
+type Flags = 'LPS-148112';

--- a/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/EditObjectField.d.ts
+++ b/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/EditObjectField.d.ts
@@ -16,7 +16,6 @@
 
 import './EditObjectField.scss';
 export default function EditObjectField({
-	allowUploadDocAndMedia,
 	forbiddenChars,
 	forbiddenLastChars,
 	forbiddenNames,
@@ -27,7 +26,6 @@ export default function EditObjectField({
 	readOnly,
 }: IProps): JSX.Element;
 interface IProps {
-	allowUploadDocAndMedia?: boolean;
 	forbiddenChars: string[];
 	forbiddenLastChars: string[];
 	forbiddenNames: string[];

--- a/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ModalAddObjectField.d.ts
+++ b/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ModalAddObjectField.d.ts
@@ -15,13 +15,11 @@
 /// <reference types="react" />
 
 export default function ModalWithProvider({
-	allowUploadDocAndMedia,
 	apiURL,
 	objectFieldTypes,
 	objectName,
 }: IProps): JSX.Element;
 interface IProps {
-	allowUploadDocAndMedia: boolean;
 	apiURL: string;
 	objectFieldTypes: ObjectFieldType[];
 	objectName: string;

--- a/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ObjectFieldFormBase.d.ts
+++ b/modules/apps/object/object-web/types/src/main/resources/META-INF/resources/js/components/ObjectFieldFormBase.d.ts
@@ -16,7 +16,6 @@ import React, {ChangeEventHandler, ReactNode} from 'react';
 import {FormError} from '../hooks/useForm';
 import './ObjectFieldFormBase.scss';
 export default function ObjectFieldFormBase({
-	allowUploadDocAndMedia,
 	children,
 	disabled,
 	errors,
@@ -58,7 +57,6 @@ interface IUseObjectFieldForm {
 	onSubmit: (field: ObjectField) => void;
 }
 interface IProps {
-	allowUploadDocAndMedia?: boolean;
 	children?: ReactNode;
 	disabled?: boolean;
 	errors: ObjectFieldErrors;

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -14,7 +14,9 @@
 
 package com.liferay.portal.util;
 
+import com.liferay.portal.json.JSONObjectImpl;
 import com.liferay.portal.kernel.configuration.Filter;
+import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.util.CookieKeys;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
@@ -22,6 +24,9 @@ import com.liferay.portal.kernel.util.ServerDetector;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.TextFormatter;
 import com.liferay.portal.kernel.util.Time;
+
+import java.util.Map;
+import java.util.Properties;
 
 /**
  * @author Brian Wing Shun Chan
@@ -825,6 +830,22 @@ public class PropsValues {
 		GetterUtil.getBoolean(
 			PropsUtil.get(
 				PropsKeys.FACEBOOK_CONNECT_VERIFIED_ACCOUNT_REQUIRED));
+
+	public static final JSONObject FEATURE_FLAGS_JSON_OBJECT =
+		new JSONObjectImpl() {
+			{
+				Properties properties = PropsUtil.getProperties(
+					"feature.flag.", true);
+
+				for (Map.Entry<Object, Object> property :
+						properties.entrySet()) {
+
+					put(
+						GetterUtil.getString(property.getKey()),
+						GetterUtil.getBoolean(property.getValue()));
+				}
+			}
+		};
 
 	public static final String[] FIELD_EDITABLE_DOMAINS = PropsUtil.getArray(
 		PropsKeys.FIELD_EDITABLE_DOMAINS);

--- a/portal-web/docroot/html/common/themes/top_js.jspf
+++ b/portal-web/docroot/html/common/themes/top_js.jspf
@@ -152,6 +152,8 @@
 			};
 		})();
 
+		Liferay.FeatureFlags = <%= PropsValues.FEATURE_FLAGS_JSON_OBJECT %>;
+
 		Liferay.PortletKeys = {
 			DOCUMENT_LIBRARY: '<%= PortletKeys.DOCUMENT_LIBRARY %>',
 			DYNAMIC_DATA_MAPPING: 'com_liferay_dynamic_data_mapping_web_portlet_DDMPortlet',


### PR DESCRIPTION
Related Issue: https://issues.liferay.com/browse/LPS-151862

This PR code is an attempt to simplify the way we deal with feature flags on front-end side.

It creates a custom hook that should be directly imported by the React component where the flag is needed in order to avoid [prop drilling](https://kentcdodds.com/blog/prop-drilling), minimizing changes (possibly reducing conflicts between PRs) and ease the use, addition and deletion of a feature flag.

This hook captures all the feature flags existent in the `bundles/portal-ext.properties` and provides a type check in order to identify misuses once the flag is removed.

### Step-by-step:

1.  Go to `bundles/portal-ext.properties` and add the feature flag property

```properties
feature.flag.LPS-xxxxxx=true
```
2. Add the flag to the `data-engine-js-components-web` type definition:
```ts
declare module 'data-engine-js-components-web' {
	function useFlag(): {
		[key in Flags]: boolean;
	};
} 

type Flags = 'LPS-xxxxxx;
```
**Note**: Since the `data-engine-js-components-web` is not being imported by the `tsconfig.json` (due to a build performance issue) it will be necessary to create a type definition file like this into the module using the feature flag, in order to provide the type check for the available flags: 
`modules/apps/<project>/<project>-web/src/main/resources/META-INF/resources/type-declarations/data-engine-js-components-web.d.ts`

3. Go to the React component where the flag is needed and use it
```jsx
import {useFlag} from 'data-engine-js-components-web';
...

function MyComponent() {
	const flags = useFlag();
	...

	return (
		<div>
			{flags['LPS-xxxxxx'] && (
				<input />
			)}
		</div>
	);
}
```

### Console error (TypeScript code only)
By remove a flag from the type definition file is expected errors coming from every files using this flag. It will help the developer to identify all the flag's usages
```console
src/main/resources/META-INF/resources/js/components/ObjectFieldFormBase.tsx:443:5 - error TS7053: Element implicitly has an 'any' type because expression of type '"LPS-148112"' can't be used to index type '{ "LPS-xxxxxx": boolean; }'.
  Property 'LPS-148112' does not exist on type '{ "LPS-xxxxxx": boolean; }'.

443    {flags['LPS-148112'] && settings.fileSource === 'userComputer' && (
        ~~~~~~~~~~~~~~~~~~~
``` 

### Co-author: @rodrigopaulino 