### PR TITLE
LPS-151592 When upgrading from 6.2 to 7.4, the pollsQuestion table do…

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_0_0/PollsToDDMUpgradeProcess.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_0_0/PollsToDDMUpgradeProcess.java
@@ -917,6 +917,14 @@ public class PollsToDDMUpgradeProcess extends UpgradeProcess {
 				_defaultLocale = LocaleUtil.fromLanguageId(
 					LocalizationUtil.getDefaultLanguageId(title));
 
+				Timestamp lastPublishDate = null;
+
+				try {
+					lastPublishDate = resultSet.getTimestamp("lastPublishDate");
+				}
+				catch (Exception exception) {
+				}
+
 				_upgradePollsQuestion(
 					questionId, resultSet.getLong("groupId"),
 					resultSet.getLong("companyId"), resultSet.getLong("userId"),
@@ -925,8 +933,7 @@ public class PollsToDDMUpgradeProcess extends UpgradeProcess {
 					resultSet.getTimestamp("modifiedDate"),
 					_getName(resultSet.getString("title")),
 					resultSet.getString("description"),
-					resultSet.getTimestamp("expirationDate"),
-					resultSet.getTimestamp("lastPublishDate"),
+					resultSet.getTimestamp("expirationDate"), lastPublishDate,
 					resultSet.getTimestamp("lastVoteDate"));
 			}
 		}


### PR DESCRIPTION
Related Issue: https://issues.liferay.com/browse/LPS-151592

LPS-138675 removed the polls modules, and all related polls upgrades, however, when upgrading from Liferay 6.2, the polls tables do not have the lastPublishDate column so an exception is thrown when the PollsToDDMUpgradeProcess is run.