### PR TITLE
LPS-148748 Decimal value is being round when viewing Form entry with more than 20 decimal places

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMFormValuesMergerImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMFormValuesMergerImpl.java
@@ -15,23 +15,14 @@
 package com.liferay.dynamic.data.mapping.internal.util;
 
 import com.liferay.dynamic.data.mapping.model.DDMForm;
-import com.liferay.dynamic.data.mapping.model.DDMFormField;
 import com.liferay.dynamic.data.mapping.model.Value;
 import com.liferay.dynamic.data.mapping.storage.DDMFormFieldValue;
 import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
 import com.liferay.dynamic.data.mapping.util.DDMFormValuesMerger;
-import com.liferay.dynamic.data.mapping.util.NumericDDMFormFieldUtil;
-import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.StringUtil;
-
-import java.text.DecimalFormat;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
-import java.util.stream.Stream;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -105,27 +96,9 @@ public class DDMFormValuesMergerImpl implements DDMFormValuesMerger {
 					ddmForm = ddmFormValues.getDDMForm();
 				}
 
-				Map<String, DDMFormField> ddmFormFieldsMap =
-					ddmForm.getDDMFormFieldsMap(true);
-
-				Collection<DDMFormField> ddmFormFields =
-					ddmFormFieldsMap.values();
-
-				Stream<DDMFormField> stream = ddmFormFields.stream();
-
-				DDMFormField ddmFormField = stream.filter(
-					p -> p.getName(
-					).equals(
-						newDDMFormFieldValue.getName()
-					)
-				).findFirst(
-				).orElseGet(
-					() -> null
-				);
-
 				_mergeValue(
 					newDDMFormFieldValue.getValue(),
-					actualDDMFormFieldValue.getValue(), ddmFormField);
+					actualDDMFormFieldValue.getValue());
 
 				List<DDMFormFieldValue> mergedNestedDDMFormFieldValues =
 					_mergeDDMFormFieldValues(
@@ -146,28 +119,13 @@ public class DDMFormValuesMergerImpl implements DDMFormValuesMerger {
 		return mergedDDMFormFieldValues;
 	}
 
-	private void _mergeValue(
-		Value newValue, Value existingValue, DDMFormField ddmFormField) {
-
+	private void _mergeValue(Value newValue, Value existingValue) {
 		if ((newValue == null) || (existingValue == null)) {
 			return;
 		}
 
 		for (Locale locale : existingValue.getAvailableLocales()) {
 			String value = newValue.getString(locale);
-
-			if (StringUtil.equals(ddmFormField.getDataType(), "double") &&
-				!GetterUtil.getBoolean(ddmFormField.getProperty("inputMask"))) {
-
-				DecimalFormat decimalFormat =
-					NumericDDMFormFieldUtil.getDecimalFormat(locale);
-
-				newValue.addString(
-					locale,
-					decimalFormat.format(
-						GetterUtil.getDouble(
-							value, newValue.getDefaultLocale())));
-			}
 
 			if (value == null) {
 				newValue.addString(locale, existingValue.getString(locale));


### PR DESCRIPTION
Hi @liferay-forms team!
This PR is for fixing the [LPS-148748](https://issues.liferay.com/browse/LPS-148748)
I've found out that the problem may come from this [line of code](https://github.com/liferay/liferay-portal/blob/93720ccdbebdeb15eaa62d4d0241ab6909147ede/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMFormValuesMergerImpl.java#L156). When you call getDouble() method, it will go to NumberFormat, and parse the value. Then the value will be rounded if the decimal places is long (more than 16 places) by the Java library standard. So that why the issue occur.
So I think that we no need to format the number because in 7.4 form, I see that we can not change the language of submitted form.
Please review and hope to get your comment.
Thanks,
Quan