### PR TITLE
LRAC-11043

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/DatePicker/DatePicker.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/DatePicker/DatePicker.es.js
@@ -235,6 +235,21 @@ export default function DatePicker({
 		}
 	};
 
+	const [expanded, setExpanded] = useState(false);
+
+	const handleExpandedChange = (value) => {
+		if (value !== expanded) {
+			setExpanded(value);
+
+			if (value) {
+				onFocus?.();
+			}
+			else {
+				onBlur?.();
+			}
+		}
+	};
+
 	return (
 		<FieldBase
 			localizedValue={localizedValue}
@@ -246,9 +261,11 @@ export default function DatePicker({
 				dateFormat={clayFormat}
 				dir={dir}
 				disabled={readOnly}
+				expanded={expanded}
 				firstDayOfWeek={firstDayOfWeek}
 				months={months}
 				onBlur={onBlur}
+				onExpandedChange={handleExpandedChange}
 				onFocus={onFocus}
 				onInput={({target: {value}}) => maskRef.current.update(value)}
 				onValueChange={handleValueChange}


### PR DESCRIPTION
Hi team!

This pull request intends to fix this [LRAC-11043](https://issues.liferay.com/browse/LRAC-11043)

Basically, `fieldFocused` and `fieldBlured` events were not sent properly to AC for `ColorPicker` and `DatePicker` fields.

For `ColorPicker` field, the events were only sent when clicking on the dropdown button (we fixed this in https://github.com/liferay-forms/liferay-portal/pull/1274) and when focusing the input field, but they weren't when bluring it. Playing a little bit at the [Clay Color Picker's page](https://clayui.com/docs/components/color-picker.html), I realized it doesn't support onBlur. So, my proposed solution for it is getting the input, by using `useRef` and `querySelector`,
and attach onBlur manually. 

For the `DatePicker`, it works as expected for the input, but it doesn't for dropdown button. The solution here would be pretty similar to what we did in https://github.com/liferay-forms/liferay-portal/pull/1274, which is adding an observer for dropdown menu when clicking on the dropdown button.

Please let me know if you guys have any questions or concerns about this.

Thanks a lot