### PR TITLE
LPS-155637 Importing web content structures with fieldsets fails

### DIFF
--- a/modules/apps/data-engine/data-engine-service/src/main/java/com/liferay/data/engine/internal/exportimport/data/handler/DEDataDefinitionFieldLinkStagedModelDataHandler.java
+++ b/modules/apps/data-engine/data-engine-service/src/main/java/com/liferay/data/engine/internal/exportimport/data/handler/DEDataDefinitionFieldLinkStagedModelDataHandler.java
@@ -28,6 +28,7 @@ import com.liferay.exportimport.staged.model.repository.StagedModelRepository;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.xml.Element;
 
 import java.util.Map;
@@ -146,19 +147,27 @@ public class DEDataDefinitionFieldLinkStagedModelDataHandler
 					"link-class-name")));
 		importedDEDataDefinitionFieldLink.setDdmStructureId(ddmStructureId);
 
-		DDMStructure ddmStructure = _ddmStructureLocalService.getDDMStructure(
-			ddmStructureId);
+		if (StringUtil.equals(
+				importedDEDataDefinitionFieldLink.getClassName(),
+				DDMStructureLayout.class.getName())) {
 
-		DDMStructureVersion structureVersion =
-			ddmStructure.getStructureVersion();
+			DDMStructureLayout structureLayout =
+				_ddmStructureLayoutLocalService.getStructureLayout(
+					importedDEDataDefinitionFieldLink.getClassPK());
 
-		DDMStructureLayout structureLayout =
-			_ddmStructureLayoutLocalService.
-				getStructureLayoutByStructureVersionId(
-					structureVersion.getStructureVersionId());
+			DDMStructure ddmStructure = structureLayout.getDDMStructure();
 
-		importedDEDataDefinitionFieldLink.setClassPK(
-			structureLayout.getStructureLayoutId());
+			DDMStructureVersion structureVersion =
+				ddmStructure.getStructureVersion();
+
+			structureLayout =
+				_ddmStructureLayoutLocalService.
+					getStructureLayoutByStructureVersionId(
+						structureVersion.getStructureVersionId());
+
+			importedDEDataDefinitionFieldLink.setClassPK(
+				structureLayout.getStructureLayoutId());
+		}
 
 		DEDataDefinitionFieldLink existingDEDataDefinitionFieldLink =
 			_stagedModelRepository.fetchStagedModelByUuidAndGroupId(


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

The root cause of the issue was that during the import, the importedDEDataDefinitionFieldLink's classPK is wrongly deduced:
`ddmStructureId -> DDMStructure -> DDMStructureVersion -> DDMStructureLayout -> structureLayout.getStructureLayoutId() -> classPK.`
More than one DEDataDefinitionFieldLink's may have the same ddmStructureId which may lead to a unique constraint violation.

Therefore, an alternative derivation of the classPK should be used:


`if the previous classPK is the ID of a DDMStructureLayout:`
`old classPK -> DDMStructureLayout -> DDMStructure -> latest DDMStructureVersion -> latest DDMStructureLayout -> structureLayout.getStructureLayoutId() -> new classPK`


Thank you and best regards,
István