### PR TITLE
LPS-157455 Get the user portal language every time the form report is displayed

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/util/DDMFormReportDataUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/util/DDMFormReportDataUtil.java
@@ -35,6 +35,7 @@ import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.DateUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.LocaleThreadLocal;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Time;
@@ -255,6 +256,13 @@ public class DDMFormReportDataUtil {
 	}
 
 	private static String _getValue(Value value) {
+		Locale portalUserLanguage = LocaleThreadLocal.getThemeDisplayLocale();
+		Map<Locale, String> languages = value.getValues();
+
+		if (languages.containsKey(portalUserLanguage)) {
+			return value.getString(portalUserLanguage);
+		}
+
 		return value.getString(value.getDefaultLocale());
 	}
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/util/DDMFormReportDataUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/util/DDMFormReportDataUtil.java
@@ -256,11 +256,11 @@ public class DDMFormReportDataUtil {
 	}
 
 	private static String _getValue(Value value) {
-		Locale portalUserLanguage = LocaleThreadLocal.getThemeDisplayLocale();
-		Map<Locale, String> languages = value.getValues();
+		Set<Locale> availableLocales = value.getAvailableLocales();
+        Locale locale = LocaleThreadLocal.getThemeDisplayLocale();
 
-		if (languages.containsKey(portalUserLanguage)) {
-			return value.getString(portalUserLanguage);
+		if (availableLocales.contains(locale)) {
+			return value.getString(locale);
 		}
 
 		return value.getString(value.getDefaultLocale());

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/util/DDMFormReportDataUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/util/DDMFormReportDataUtil.java
@@ -257,7 +257,7 @@ public class DDMFormReportDataUtil {
 
 	private static String _getValue(Value value) {
 		Set<Locale> availableLocales = value.getAvailableLocales();
-        Locale locale = LocaleThreadLocal.getThemeDisplayLocale();
+		Locale locale = LocaleThreadLocal.getThemeDisplayLocale();
 
 		if (availableLocales.contains(locale)) {
 			return value.getString(locale);


### PR DESCRIPTION
## Bug Found
The form report depends only on the first default language every time the form is created, even if it already has its defined translations.

https://issues.liferay.com/browse/LPS-157455

## Proposed Solution
Fetch the user portal language every time the report is displayed so the localization can work

- LPS-157455 Get the user portal language every time the form report is displayed
