### PR TITLE
LPS-155021 Add conditions for fieldset and ddm-paragraph for translation

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/com/liferay/dynamic/data/mapping/service/dependencies/ddm/paragraph.ftl
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/com/liferay/dynamic/data/mapping/service/dependencies/ddm/paragraph.ftl
@@ -1,9 +1,14 @@
 <#include "../init.ftl">
 
-<#assign style = fieldStructure.style!"" />
+<@liferay_aui["field-wrapper"]
+	cssClass="form-builder-field"
+	data=data
+>
+	<#assign style = fieldStructure.style!"" />
 
-<p style="${escapeAttribute(style)}">
-	${escape(label)}
+	<p style="${escapeAttribute(style)}">
+		${escape(label)}
 
-	${fieldStructure.children}
-</p>
+		${fieldStructure.children}
+	</p>
+</@>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -3081,6 +3081,18 @@ AUI.add(
 						.get('container')
 						.all('> fieldset > div > .field-wrapper');
 				},
+
+				setLabel(label) {
+					const instance = this;
+
+					const containerNode = instance.get('container')._node;
+
+					const fieldSet = containerNode.getElementsByClassName(
+						'legend'
+					)[0];
+
+					fieldSet.textContent = label;
+				},
 			},
 		});
 
@@ -3458,6 +3470,24 @@ AUI.add(
 		});
 
 		FieldTypes['ddm-geolocation'] = GeolocationField;
+
+		const ParagraphField = A.Component.create({
+			EXTENDS: Field,
+
+			prototype: {
+				setLabel(label) {
+					const instance = this;
+
+					const containerNode = instance.get('container')._node;
+
+					const paragraph = containerNode.firstElementChild;
+
+					paragraph.textContent = label;
+				},
+			},
+		});
+
+		FieldTypes['ddm-paragraph'] = ParagraphField;
 
 		const TextHTMLField = A.Component.create({
 			EXTENDS: Field,


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-155021

When a field is nested inside a fieldset and the user changes the language, the field's translation will be set to the translation of the fieldset, rather than its original translation.
This is occurring since the setLabel looks for instance.getLabelNode();. This will result in getting the field information when the instance is the fieldset. The field will then be translated into the fieldset information.

In order to resolve this, I included a condition that will check if the type is a fieldset and correctly translate it. I also accounted for ddm-paragraph by adding a field-wrapper and condition for translation.

Let me know if there are any questions or comments about this.
Thank you!