### PR TITLE
LPS-157997 | Master - Bravo Team

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Geolocation/Geolocation.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Geolocation/Geolocation.es.js
@@ -55,6 +55,11 @@ const Geolocation = ({
 
 	return (
 		<div {...otherProps} className="ddm-geolocation field-labels-inline">
+
+			<div className="glyphicon glyphicon-map-marker">
+			<span id={`address_label_${instanceId}`}></span>
+			</div>
+			
 			{!disabled || viewMode ? (
 				<dl>
 					<dt className="text-capitalize"></dt>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Geolocation/Geolocation.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Geolocation/Geolocation.es.js
@@ -56,10 +56,10 @@ const Geolocation = ({
 	return (
 		<div {...otherProps} className="ddm-geolocation field-labels-inline">
 
-			<div className="glyphicon glyphicon-map-marker">
+			<div><ClayIcon symbol="geolocation"/>
 			<span id={`address_label_${instanceId}`}></span>
 			</div>
-			
+
 			{!disabled || viewMode ? (
 				<dl>
 					<dt className="text-capitalize"></dt>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Geolocation/useGeolocation.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Geolocation/useGeolocation.es.js
@@ -110,8 +110,11 @@ export function useGeolocation({
 	const eventHandlerPositionChanged = useCallback(
 		(event) => {
 			const {
-				newVal: {location},
+				newVal: {location, address},
 			} = event;
+
+			const locationNode = document.getElementById(`address_label_${instanceId}`);
+			locationNode.innerHTML = address;
 
 			onChange(JSON.stringify(location));
 		},

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Geolocation/useGeolocation.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Geolocation/useGeolocation.es.js
@@ -110,7 +110,7 @@ export function useGeolocation({
 	const eventHandlerPositionChanged = useCallback(
 		(event) => {
 			const {
-				newVal: {location, address},
+				newVal: {address, location},
 			} = event;
 
 			const locationNode = document.getElementById(`address_label_${instanceId}`);


### PR DESCRIPTION
### Motivation
The address is not showing above the map anymore when editing a geolocation fragment from a web content. 7.2 version has this feature working just fine. It was discovered that the files used in 7.2 are no longer the same used as in the latest version.

### Proposed Solution
New implementation to create a label for address and add the address information on the HTML along with the Clay Icon for Geolocation.

### Steps to Verify
1. Set up a vanilla bundle
2. Startup and create a web content structure with a geolocation
3. Create a web content with the new structure
4. Set a location and observe that the location as text is not appearing


### Related Issue
https://issues.liferay.com/browse/LPS-157977

### Commits Included
- LPS-157977 Show address as text on Geolocation Web Content Edit Page
- LPS-157977 Replace Glyphicon with ClayIcon
- LPS-157977 SF