### PR TITLE
LPS-157997 | Master - Bravo Team

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Geolocation/Geolocation.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Geolocation/Geolocation.es.js
@@ -56,30 +56,32 @@ const Geolocation = ({
 
 	return (
 		<div {...otherProps} className="ddm-geolocation field-labels-inline">
-			<div>
-				<ClayIcon symbol="geolocation" />
-
-				<span id={`address_label_${instanceId}`}></span>
-			</div>
-
 			{!disabled || viewMode ? (
-				<dl>
-					<dt className="text-capitalize"></dt>
+				<div>
+					<div>
+						<ClayIcon symbol="geolocation" />
 
-					<dd>
-						<NoRender
-							className="lfr-map"
-							id={`map_${instanceId}`}
-							style={{height: '280px'}}
-						/>
+						<span id={`address_label_${instanceId}`}></span>
+					</div>
 
-						<input
-							id={`input_value_${instanceId}`}
-							name={name}
-							type="hidden"
-						/>
-					</dd>
-				</dl>
+					<dl>
+						<dt className="text-capitalize"></dt>
+
+						<dd>
+							<NoRender
+								className="lfr-map"
+								id={`map_${instanceId}`}
+								style={{height: '280px'}}
+							/>
+
+							<input
+								id={`input_value_${instanceId}`}
+								name={name}
+								type="hidden"
+							/>
+						</dd>
+					</dl>
+				</div>
 			) : (
 				<img
 					alt={Liferay.Language.get('geolocation')}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Geolocation/Geolocation.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Geolocation/Geolocation.es.js
@@ -14,6 +14,7 @@
 
 import 'leaflet/dist/leaflet.css';
 import React from 'react';
+import ClayIcon from '@clayui/icon';
 
 import {FieldBase} from '../FieldBase/ReactFieldBase.es';
 import {MAP_PROVIDER, useGeolocation} from './useGeolocation.es';
@@ -55,11 +56,12 @@ const Geolocation = ({
 
 	return (
 		<div {...otherProps} className="ddm-geolocation field-labels-inline">
+			<div>
+				<ClayIcon symbol="geolocation" />
 
-			<div className="glyphicon glyphicon-map-marker">
-			<span id={`address_label_${instanceId}`}></span>
+				<span id={`address_label_${instanceId}`}></span>
 			</div>
-			
+
 			{!disabled || viewMode ? (
 				<dl>
 					<dt className="text-capitalize"></dt>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Geolocation/Geolocation.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Geolocation/Geolocation.es.js
@@ -43,13 +43,15 @@ const Geolocation = ({
 	viewMode,
 	...otherProps
 }) => {
-
 	const [address, setAddress] = useState();
 
-	const handleChange = useCallback(({newVal: {address, location}}) => {
-		setAddress(address);
-		onChange(JSON.stringify(location));
-	}, [onChange, setAddress]);
+	const handleChange = useCallback(
+		({newVal: {address, location}}) => {
+			setAddress(address);
+			onChange(JSON.stringify(location));
+		},
+		[onChange, setAddress]
+	);
 
 	useGeolocation({
 		disabled,
@@ -68,6 +70,7 @@ const Geolocation = ({
 				<div>
 					<div>
 						<ClayIcon symbol="geolocation" />
+
 						{address}
 					</div>
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Geolocation/Geolocation.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Geolocation/Geolocation.es.js
@@ -13,8 +13,8 @@
  */
 
 import 'leaflet/dist/leaflet.css';
-import React from 'react';
 import ClayIcon from '@clayui/icon';
+import React from 'react';
 
 import {FieldBase} from '../FieldBase/ReactFieldBase.es';
 import {MAP_PROVIDER, useGeolocation} from './useGeolocation.es';

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Geolocation/Geolocation.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Geolocation/Geolocation.es.js
@@ -14,7 +14,7 @@
 
 import 'leaflet/dist/leaflet.css';
 import ClayIcon from '@clayui/icon';
-import React from 'react';
+import React, {useCallback, useState} from 'react';
 
 import {FieldBase} from '../FieldBase/ReactFieldBase.es';
 import {MAP_PROVIDER, useGeolocation} from './useGeolocation.es';
@@ -43,13 +43,21 @@ const Geolocation = ({
 	viewMode,
 	...otherProps
 }) => {
+
+	const [address, setAddress] = useState();
+
+	const handleChange = useCallback(({newVal: {address, location}}) => {
+		setAddress(address);
+		onChange(JSON.stringify(location));
+	}, [onChange, setAddress]);
+
 	useGeolocation({
 		disabled,
 		googleMapsAPIKey,
 		instanceId,
 		mapProviderKey,
 		name,
-		onChange,
+		onChange: handleChange,
 		value,
 		viewMode,
 	});
@@ -60,8 +68,7 @@ const Geolocation = ({
 				<div>
 					<div>
 						<ClayIcon symbol="geolocation" />
-
-						<span id={`address_label_${instanceId}`}></span>
+						{address}
 					</div>
 
 					<dl>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Geolocation/Geolocation.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Geolocation/Geolocation.es.js
@@ -55,6 +55,11 @@ const Geolocation = ({
 
 	return (
 		<div {...otherProps} className="ddm-geolocation field-labels-inline">
+
+			<div className="glyphicon glyphicon-map-marker">
+			<span id={`address_label_${instanceId}`}></span>
+			</div>
+			
 			{!disabled || viewMode ? (
 				<dl>
 					<dt className="text-capitalize"></dt>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Geolocation/useGeolocation.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Geolocation/useGeolocation.es.js
@@ -16,7 +16,7 @@ import MapGoogleMaps from '@liferay/map-google-maps/js/MapGoogleMaps.es';
 import MapOpenStreetMap from '@liferay/map-openstreetmap/js/MapOpenStreetMap.es';
 import {parseName} from 'data-engine-js-components-web';
 import Leaflet from 'leaflet';
-import {useCallback, useEffect, useRef} from 'react';
+import {useEffect, useRef} from 'react';
 
 export const MAP_PROVIDER = {
 	googleMaps: 'GoogleMaps',
@@ -107,22 +107,6 @@ export function useGeolocation({
 	value,
 	viewMode,
 }) {
-	const eventHandlerPositionChanged = useCallback(
-		(event) => {
-			const {
-				newVal: {address, location},
-			} = event;
-
-			const locationNode = document.getElementById(
-				`address_label_${instanceId}`
-			);
-			locationNode.innerHTML = address;
-
-			onChange(JSON.stringify(location));
-		},
-		[instanceId, onChange]
-	);
-
 	const mapRef = useRef(null);
 
 	useEffect(() => {
@@ -179,9 +163,9 @@ export function useGeolocation({
 		if (mapRef.current) {
 			mapRef.current.removeAllListeners('positionChange');
 
-			mapRef.current.on('positionChange', eventHandlerPositionChanged);
+			mapRef.current.on('positionChange', onChange);
 		}
-	}, [eventHandlerPositionChanged]);
+	}, [onChange]);
 
 	useEffect(() => {
 		if (value && mapRef.current) {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Geolocation/useGeolocation.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Geolocation/useGeolocation.es.js
@@ -110,15 +110,17 @@ export function useGeolocation({
 	const eventHandlerPositionChanged = useCallback(
 		(event) => {
 			const {
-				newVal: {location, address},
+				newVal: {address, location},
 			} = event;
 
-			const locationNode = document.getElementById(`address_label_${instanceId}`);
+			const locationNode = document.getElementById(
+				`address_label_${instanceId}`
+			);
 			locationNode.innerHTML = address;
 
 			onChange(JSON.stringify(location));
 		},
-		[onChange]
+		[instanceId, onChange]
 	);
 
 	const mapRef = useRef(null);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Geolocation/useGeolocation.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Geolocation/useGeolocation.es.js
@@ -110,8 +110,11 @@ export function useGeolocation({
 	const eventHandlerPositionChanged = useCallback(
 		(event) => {
 			const {
-				newVal: {location},
+				newVal: {location, address},
 			} = event;
+
+			const locationNode = document.getElementById(`address_label_${instanceId}`);
+			locationNode.innerHTML = address;
 
 			onChange(JSON.stringify(location));
 		},


### PR DESCRIPTION
### Motivation
The address is not showing above the map anymore when editing a geolocation fragment from a web content. 7.2 version has this feature working just fine. It was discovered that the files used in 7.2 are no longer the same used as in the latest version.

### Proposed Solution
New implementation to create a label for address and add the address information on the HTML along with the Clay Icon for Geolocation.

### Steps to Verify
1. Set up a vanilla bundle
2. Startup and create a web content structure with a geolocation
3. Create a web content with the new structure
4. Set a location and observe that the location as text is not appearing


### Related Issue
https://issues.liferay.com/browse/LPS-157997

### Commits Included
- LPS-157977 Show address as text on Geolocation Web Content Edit Page
- LPS-157977 Replace Glyphicon with ClayIcon
- LPS-157977 SF