### PR TITLE
[TS] LPS-156368 Show alert message when adding a documents and media field

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/form_builder.jspf
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/form_builder.jspf
@@ -59,14 +59,15 @@ if (Validator.isNotNull(script)) {
 	refresh="<%= false %>"
 >
 	<c:if test="<%= hasDocumentsAndMediaField %>">
-		<div class="alert alert-info lfr-message-response ddm-documents-and-media-field">
+		<div class="alert alert-info ddm-documents-and-media-field lfr-message-response">
 			<liferay-ui:message key="document-permissions-are-not-inherited-from-the-DDL-record" />
 		</div>
 	</c:if>
 
-	<div class="alert alert-info lfr-message-response ddm-documents-and-media-field hide">
+	<div class="alert alert-info ddm-documents-and-media-field hide lfr-message-response">
 		<liferay-ui:message key="document-permissions-are-not-inherited-from-the-DDL-record" />
 	</div>
+
 	<liferay-ui:section>
 		<div id="<portlet:namespace />formBuilderTab">
 			<aui:translation-manager availableLocales="<%= availableLocales %>" changeableDefaultLanguage="<%= changeableDefaultLanguage %>" defaultLanguageId="<%= defaultLanguageId %>" id="translationManager" initialize="<%= false %>" readOnly="<%= false %>" />

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/form_builder.jspf
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/form_builder.jspf
@@ -19,9 +19,19 @@ String defaultLanguageId = LocaleUtil.toLanguageId(LocaleUtil.getSiteDefault());
 
 Locale[] availableLocales = {LocaleUtil.getSiteDefault()};
 
+boolean hasDocumentsAndMediaField = false;
+
 if (Validator.isNotNull(script)) {
 	try {
 		DDMForm ddmForm = DDMUtil.getDDMForm(script);
+
+		for (DDMFormField ddmFormField : ddmForm.getDDMFormFields()) {
+			String dataType = ddmFormField.getType();
+
+			if (dataType.equals("ddm-documentlibrary")) {
+				hasDocumentsAndMediaField = true;
+			}
+		}
 
 		String ddmFormDefaultLanguageId = LocaleUtil.toLanguageId(ddmForm.getDefaultLocale());
 
@@ -48,6 +58,15 @@ if (Validator.isNotNull(script)) {
 	names='<%= LanguageUtil.get(request, "view[action]") + "," + LanguageUtil.get(request, "source") %>'
 	refresh="<%= false %>"
 >
+	<c:if test="<%= hasDocumentsAndMediaField %>">
+		<div class="alert alert-info lfr-message-response ddm-documents-and-media-field">
+			<liferay-ui:message key="document-permissions-are-not-inherited-from-the-DDL-record" />
+		</div>
+	</c:if>
+
+	<div class="alert alert-info lfr-message-response ddm-documents-and-media-field hide">
+		<liferay-ui:message key="document-permissions-are-not-inherited-from-the-DDL-record" />
+	</div>
 	<liferay-ui:section>
 		<div id="<portlet:namespace />formBuilderTab">
 			<aui:translation-manager availableLocales="<%= availableLocales %>" changeableDefaultLanguage="<%= changeableDefaultLanguage %>" defaultLanguageId="<%= defaultLanguageId %>" id="translationManager" initialize="<%= false %>" readOnly="<%= false %>" />

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/init.jsp
@@ -44,6 +44,7 @@ page import="com.liferay.dynamic.data.mapping.exception.TemplateSmallImageConten
 page import="com.liferay.dynamic.data.mapping.exception.TemplateSmallImageNameException" %><%@
 page import="com.liferay.dynamic.data.mapping.exception.TemplateSmallImageSizeException" %><%@
 page import="com.liferay.dynamic.data.mapping.model.DDMForm" %><%@
+page import="com.liferay.dynamic.data.mapping.model.DDMFormField" %><%@
 page import="com.liferay.dynamic.data.mapping.model.DDMStructure" %><%@
 page import="com.liferay.dynamic.data.mapping.model.DDMStructureVersion" %><%@
 page import="com.liferay.dynamic.data.mapping.model.DDMTemplate" %><%@

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/main.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/main.js
@@ -334,6 +334,8 @@ AUI.add(
 					if (activeTabIndex === SETTINGS_TAB_INDEX) {
 						instance.editField(event.newVal.item(0));
 					}
+
+					this._handleAlertMessages(instance.get('fields'));
 				},
 
 				_beforeGetEditor(record, column) {
@@ -512,6 +514,24 @@ AUI.add(
 					});
 
 					return fields;
+				},
+
+				_handleAlertMessages(fields) {
+					const hasDocumentLibrary = fields.some(
+						(field) => field.name === 'ddm-documentlibrary'
+					);
+					const documentsAndMediaField = document.querySelector(
+						'.ddm-documents-and-media-field'
+					);
+					const isHidden = documentsAndMediaField.classList.contains(
+						'hide'
+					);
+					if (hasDocumentLibrary && isHidden) {
+						documentsAndMediaField.classList.remove('hide');
+					}
+					else if (!isHidden) {
+						documentsAndMediaField.classList.add('hide');
+					}
 				},
 
 				_onDataTableRender(event) {

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -5365,6 +5365,7 @@ document-name=Document name
 document-names-must-end-with-one-of-the-following-extensions=Document names must end with one of the following extensions:
 document-needs-review-email=Document Needs Review Email
 document-path=Document Path
+document-permissions-are-not-inherited-from-the-DDL-record=Document permissions are not inherited from the DDL record, but from the Documents and Media application, where Documents are saved.
 document-profile=Document Profile
 document-properties=Document Properties
 document-services=Document Services


### PR DESCRIPTION
Hi Team,

**Issue**
The users don't know when they add an upload field to a DDL form that the uploaded document does not inherit the DDL's permission.

![without-alert-message](https://user-images.githubusercontent.com/97447507/183859923-adc453da-5095-4a09-bcb7-0e7a293c6f5a.png)

**Solution**
When there is an upload field (Documents and media) added to the form, the system will show an info alert. (decided on [PTR-3206](https://issues.liferay.com/browse/PTR-3206)) 

![image](https://user-images.githubusercontent.com/97447507/183860154-17844810-68c8-4274-9ff4-1109b5e7367e.png)


I implemented/tested it including @alinedoleron 's solution (PTR-3272) and it worked as expected in my local environment.

Please review my PR!

Thank you and best regards,
Évi