### PR TITLE
LPS-145168 Removing translation name over sidebar

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/css/_portlet-forms-admin.scss
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/css/_portlet-forms-admin.scss
@@ -3,6 +3,15 @@
 	.ddm-translation-manager {
 		margin-top: 1.25rem;
 
+		.lfr-translationmanager {
+			width: 70%;
+			z-index: 0;
+
+			@media (max-width: 992px) {
+				width: 50%;
+			}
+		}
+
 		.modal-sm {
 			max-width: 300px;
 			position: relative;


### PR DESCRIPTION
Hello Reviewer!
Related Issue: https://issues.liferay.com/browse/LPS-145168

For the solution I used a media query, to break the line in a given 'px' not letting it stay below the side bar