### PR TITLE
LPS-139178 When filling a decimal numeric on a Form with the Arabic language not is possible type in Arabic

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Numeric/Numeric.tsx
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Numeric/Numeric.tsx
@@ -131,11 +131,16 @@ const getFormattedValue = ({
 		prefix: '',
 	};
 
+	const charCode = symbols.decimalSymbol.charAt(0);
+
 	if (dataType === 'double') {
 		config.allowDecimal = true;
 		config.decimalLimit = null;
-		config.decimalSymbol = symbols.decimalSymbol;
+		charCode.charCodeAt(0) === 1643
+			? (config.decimalSymbol = ',')
+			: (config.decimalSymbol = symbols.decimalSymbol);
 	}
+
 	const mask = createNumberMask(config);
 
 	const {conformedValue: masked}: {conformedValue: string} = conformToMask(
@@ -209,11 +214,16 @@ const Numeric: React.FC<IProps> = ({
 			predefinedValue ??
 			'';
 
+		const charCode = symbols.decimalSymbol.charCodeAt(0);
+
 		if (dataType === 'double') {
 			const symbolsValue = newValue.match(/[^-\d]/g);
 
 			newValue = symbolsValue
-				? newValue.replace(symbolsValue[0], symbols.decimalSymbol)
+				? newValue.replace(
+						symbolsValue[0],
+						charCode === 1643 ? ',' : symbols.decimalSymbol
+				  )
 				: newValue;
 		}
 
@@ -271,7 +281,7 @@ const Numeric: React.FC<IProps> = ({
 			inputValue.masked?.length > value.length &&
 			(inputValueRaw?.length ?? 0) === rawValue.length
 		) {
-			value = inputValueRaw.slice(0, -1);
+			value = inputValueRaw.slice(0, inputValueRaw.length);
 		}
 
 		const {masked, raw} = inputMask


### PR DESCRIPTION
Issue: https://issues.liferay.com/browse/LPS-139178

The main problem is that the comma that was beeing used in the conformToMask function when the arabic language is selected was in arabic unicode, making the function don't recognize it. So I made two verifications to ensure that the right symbol was beeing passed to the function.

Note: I also fixed another bug in this commit. When the user tries to delete the symbol (, or .) from the input, the previous character also was beeing erased. I solve it in line 284, but I don't know if was an open LPS for this bug.