### PR TITLE
LPS-160947 Notification template title in header is not dynamically updated depending on notification template name

### DIFF
--- a/modules/apps/notification/notification-web/src/main/resources/META-INF/resources/js/components/EditNotificationTemplate.tsx
+++ b/modules/apps/notification/notification-web/src/main/resources/META-INF/resources/js/components/EditNotificationTemplate.tsx
@@ -142,6 +142,8 @@ export default function EditNotificationTemplate({
 		validate,
 	});
 
+	const [title, setTitle] = useState('');
+
 	useEffect(() => {
 		if (notificationTemplateId !== 0) {
 			API.getNotificationTemplate(notificationTemplateId).then(
@@ -157,7 +159,7 @@ export default function EditNotificationTemplate({
 					objectDefinitionId,
 					subject,
 					to,
-				}) =>
+				}) => {
 					setValues({
 						...values,
 						attachmentObjectFieldIds,
@@ -171,9 +173,15 @@ export default function EditNotificationTemplate({
 						objectDefinitionId,
 						subject,
 						to,
-					})
+					});
+					setTitle(name);
+				}
 			);
 		}
+		else {
+			setTitle(Liferay.Language.get('notification-templates'));
+		}
+
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [notificationTemplateId]);
 
@@ -181,7 +189,7 @@ export default function EditNotificationTemplate({
 		<ClayForm onSubmit={handleSubmit}>
 			<ClayManagementToolbar className="lfr__notification-template-management-tollbar">
 				<ClayManagementToolbar.ItemList>
-					<h2>{Liferay.Language.get('notification-templates')}</h2>
+					<h2>{title}</h2>
 				</ClayManagementToolbar.ItemList>
 
 				<ClayManagementToolbar.ItemList>


### PR DESCRIPTION
Issue: https://issues.liferay.com/browse/LPS-160947

I've added a new useState to control the value of the title and a condition to control it in an useEffect that already exists. If the id of the Notification Template isn't 0 (the template is created), the state receive the value of the name input, if not, the state is set to be the standard value "Notification Template".