### PR TITLE
LPS-155981 - Web content's field's reference doesn't start with alphabet

### DIFF
--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/utils/fields.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/utils/fields.es.js
@@ -15,7 +15,9 @@
 import {PagesVisitor} from './visitors.es';
 
 export function checkValidFieldNameCharacter(character) {
-	return /[A-Za-z0-9_]/g.test(character);
+	return /[一-龠]+|[ぁ-ゔ]+|[ァ-ヴー]+|[A-Za-z0-9_]+|[々〆〤ヶ]+|[ا-ي]+|[贼-阿]/g.test(
+		character
+	);
 }
 
 export function normalizeFieldName(fieldName) {


### PR DESCRIPTION
LPS: https://issues.liferay.com/browse/LPS-155981
Notice: This bug implies other problems related to those languages that use symbols, such as Arabic, Japanese and Chinese. In all form fields that use the normlizaFieldName function, due to another function that is called to validate the fieldName, which is checkValidFieldNameCharacter, where it returns a regular expression: (Regex)
where the solution updates the regex making it recognize the three symbol languages mentioned.
current:/[A-Za-z0-9_]/
solution:/[一-龠]+|[ぁ-ゔ]+|[ァ-ヴー]+|[A-Za-z0-9_]+|[々〆〤ヶ]+|[ا-ي_٩]+| [贼-阿]/
  However I do not know if it is a good solution due to other problems that could be created. So I removed the normalizeFieldName function from getDefaultFieldName, since the function just generates a random fieldReference that is created with a generateInstanceId function, concatenated to type.label.
