### PR TITLE
LPS-163762 Adapting focus on forms according PTR-3342

### DIFF
--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/components/AutoFocus.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/components/AutoFocus.es.js
@@ -41,11 +41,28 @@ export function AutoFocus({children}) {
 						document.activeElement.querySelector('input').type ===
 							'hidden')
 				) {
-					const currentPage = childRef.current.closest(
-						'.ddm-form-page'
+					removeTabs();
+
+					const currentTitle = containerElement?.current.parentNode.getElementsByClassName(
+						'lfr-ddm__default-page-header-title'
+					)[0];
+
+					scrollComponentToTop(currentTitle);
+
+					const componentTitle = currentTitle?.innerHTML;
+
+					const currentDescription = containerElement?.current.parentNode.getElementsByClassName(
+						'.lfr-ddm__default-page-header-description'
+					)[0];
+
+					const componentDescription = currentDescription?.innerHTML;
+
+					const currentPage = document.activeElement.querySelector(
+						'.ddm-layout-builder:not(.hide)'
 					);
-					const firstInput = currentPage.querySelector(
-						'input:first-of-type'
+
+					const firstInput = currentPage?.querySelector(
+						'input:not([type="hidden"])'
 					);
 
 					const sidebarOpen = document.querySelector(
@@ -56,7 +73,11 @@ export function AutoFocus({children}) {
 						'.ddm-user-view-content'
 					);
 
+					const defaultTitle = Liferay.Language.get('untitled-form');
+
 					if (
+						(!componentTitle || componentTitle === defaultTitle) &&
+						!componentDescription &&
 						firstInput &&
 						!containerElement.current.contains(
 							document.activeElement
@@ -64,7 +85,7 @@ export function AutoFocus({children}) {
 						(sidebarOpen || userViewContent)
 					) {
 						firstInput.focus({
-							behavior: 'instant',
+							behavior: 'smooth',
 							preventScroll: false,
 						});
 
@@ -72,6 +93,8 @@ export function AutoFocus({children}) {
 							firstInput.select();
 						}
 					}
+
+					scrollComponentToTop(currentTitle);
 				}
 			}
 		}
@@ -82,4 +105,32 @@ export function AutoFocus({children}) {
 			childRef.current = node;
 		},
 	});
+}
+
+function scrollComponentToTop(currentTitle) {
+	const containerPosition = currentTitle.getBoundingClientRect();
+
+	const menuSize = document.querySelector('.control-menu-container')
+		?.clientHeight;
+
+	window.scroll(
+		containerPosition.x - menuSize,
+		containerPosition.y - menuSize
+	);
+}
+
+function removeTabs() {
+	const firstPageComponent = document.querySelector(
+		'div[class^="lfr-layout-structure-item'
+	);
+
+	const formPortlet = firstPageComponent?.querySelector('.portlet-forms');
+
+	if (!formPortlet) {
+		document
+			.querySelectorAll(
+				'.lfr-ddm__default-page-header-title,.lfr-ddm__default-page-header-description,.lfr-ddm-form-page-title,.lfr-ddm-form-page-description'
+			)
+			?.forEach((element) => element.removeAttribute('tabindex'));
+	}
 }

--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/components/PageRenderer/DefaultVariant.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/components/PageRenderer/DefaultVariant.es.js
@@ -148,9 +148,15 @@ Page.displayName = 'DefaultVariant.Page';
 export function PageHeader({description, title}) {
 	return (
 		<>
-			{title && <h2 className="lfr-ddm-form-page-title">{title}</h2>}
+			{title && (
+				<h2 className="lfr-ddm-form-page-title" tabIndex={0}>
+					{title}
+				</h2>
+			)}
 			{description && (
-				<h3 className="lfr-ddm-form-page-description">{description}</h3>
+				<h3 className="lfr-ddm-form-page-description" tabIndex={0}>
+					{description}
+				</h3>
 			)}
 		</>
 	);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/components/DefaultPageHeader.tsx
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/components/DefaultPageHeader.tsx
@@ -44,10 +44,15 @@ const DefaultPageHeader: React.FC<IProps> = ({
 				</ClayButton>
 			)}
 			<div className="lfr-ddm__default-page-header">
-				<h1 className="lfr-ddm__default-page-header-title">{title}</h1>
+				<h1 className="lfr-ddm__default-page-header-title" tabIndex={0}>
+					{title}
+				</h1>
 
 				{description && (
-					<span className="lfr-ddm__default-page-header-description">
+					<span
+						className="lfr-ddm__default-page-header-description"
+						tabIndex={0}
+					>
 						{description}
 					</span>
 				)}


### PR DESCRIPTION
[IMPROVING] When changing pages, focus is getting back to the beggining of the content. Form without title, focus working with or without paragraph field. 

[IMPROVING] Untab components when there is something other than a form

[IMPROVING] Adding tabs to Form headings for correct reading by Screen Readers

[IMPROVING] Update of untitled form and permission to only one scroll

[IMPROVING] Persisting content change and modularizing

[IMPROVING] SF