### PR TITLE
LPS-164276 Do not use a parameter to represent forms display language

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/display/view.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/display/view.jsp
@@ -201,9 +201,9 @@ boolean limitToOneSubmissionPerUser = DDMFormInstanceSubmissionLimitStatusUtil.i
 							<clay:container-fluid>
 								<div class="locale-actions">
 									<liferay-ui:language
-										formAction="<%= currentURL %>"
 										languageId="<%= languageId %>"
 										languageIds="<%= ddmFormDisplayContext.getAvailableLanguageIds() %>"
+										useNamespace="<%= false %>"
 									/>
 								</div>
 							</clay:container-fluid>

--- a/portal-web/test/functional/com/liferay/portalweb/macros/FormPortlet.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/FormPortlet.macro
@@ -44,6 +44,14 @@ definition {
 		Click(locator1 = "Button#PREVIOUS");
 	}
 
+	macro setUserLocale {
+		Object.assertValidLocale(locale = "${locale}");
+
+		var portalURL = PropsUtil.get("portal.url");
+
+		Navigator.openSpecificURL(url = "${portalURL}/c/portal/update_language?languageId=${locale}");
+	}
+
 	macro submit {
 		if (IsElementPresent(locator1 = "FormPortlet#PORTLET_CONTENT")) {
 			Click(locator1 = "FormPortlet#PORTLET_CONTENT");
@@ -53,6 +61,18 @@ definition {
 
 		FormPortlet.clickSubmit();
 	}
+
+	macro submitLocalized {
+		if (IsElementPresent(locator1 = "FormPortlet#PORTLET_CONTENT")) {
+			Click(locator1 = "FormPortlet#PORTLET_CONTENT");
+		}
+
+		WaitForElementPresent(locator1 = "FormPortlet#SUBMIT_BUTTON");
+
+		AssertClick(
+			locator1 = "FormPortlet#SUBMIT_BUTTON",
+			value1 = "${buttonName}");
+    }
 
 	macro submitLocalizedSuccessfully {
 		AssertClick(

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/fields/FormsDateField.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/fields/FormsDateField.testcase
@@ -1455,7 +1455,9 @@ definition {
 			fieldName = "Date",
 			fieldValue = "01/01/${futureYear}");
 
-		FormPortlet.submitSuccessfully();
+		FormPortlet.submitLocalizedSuccessfully(buttonName = "Submeter");
+
+		FormPortlet.setUserLocale(locale = "en_US");
 	}
 
 	@description = "Verify if that with date validation in the datefield the error message appears correctly on forms"

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/fields/FormsNumericField.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/fields/FormsNumericField.testcase
@@ -108,7 +108,7 @@ definition {
 			fieldName = "Numeric",
 			fieldValue = "1,1");
 
-		FormPortlet.submitSuccessfully();
+		FormPortlet.submitLocalizedSuccessfully(buttonName = "Submeter");
 	}
 
 	@description = "Verify that a Numeric Field can be created"
@@ -1295,7 +1295,7 @@ definition {
 			fieldName = "Numeric",
 			fieldValue = "1000");
 
-		FormPortlet.submitSuccessfully();
+		FormPortlet.submitLocalizedSuccessfully(buttonName = "Submeter");
 	}
 
 	@description = "Verify if Input Mask On Decimal With Decimal Places is working correctly"
@@ -2013,7 +2013,9 @@ definition {
 			fieldName = "Numeric",
 			fieldValue = "2222222222222");
 
-		FormPortlet.submitSuccessfully();
+		FormPortlet.submitLocalizedSuccessfully(buttonName = "Submeter");
+
+		FormPortlet.setUserLocale(locale = "en_US");
 	}
 
 	@description = "Verify that input mask on integers working on rules"

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/fields/FormsTextField.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/fields/FormsTextField.testcase
@@ -1358,7 +1358,7 @@ definition {
 
 		FormPortlet.changeLocale(locale = "português-Brasil");
 
-		FormPortlet.submit();
+		FormPortlet.submitLocalized(buttonName = "Submeter");
 
 		FormPortlet.viewValidationErrorMessage(validationErrorMessage = "Essa é uma mensagem customizada para o português brasileiro");
 
@@ -1368,9 +1368,11 @@ definition {
 
 		FormPortlet.waitForValidationErrorNotPresent(validationErrorMessage = "Essa é uma mensagem customizada para o português brasileiro");
 
-		FormPortlet.submit();
+		FormPortlet.submitLocalized(buttonName = "Submeter");
 
 		Alert.viewSuccessMessage();
+
+		FormPortlet.setUserLocale(locale = "en_US");
 
 		FormsAdmin.openFormsAdmin(siteURLKey = "guest");
 


### PR DESCRIPTION
Hi team, this pull fixes https://issues.liferay.com/browse/LPS-164276

**Reproduction steps:**

1. Create a new form and translate to english and spanish
2. Click on Share
3. Copy the shared URL and open it in a new window
4. Once you see the form in English, click on the flag to translate the form to Spanish

 **Actual behavior:**
If the shared url is accessed, the form is displayed in english and in the HTML, the HTML tag is:
 `<html class="ltr" dir="ltr" lang="en-US">`
If the locale is changed to Spanish using the language selector, the HTML tag stays the same showing mistakenly the english locale:
`<html class="ltr" dir="ltr" lang="en-US">`

 **Expected behavior:**
If the shared url is accessed, the form is displayed in english and in the HTML, the HTML tag is:
` <html class="ltr" dir="ltr" lang="en-US">`
If the locale is changed to Spanish using the language selector, the HTML tag changes according to the displayed locale which is Spanish:
`<html class="ltr" dir="ltr" lang="es-ES">`

**Additional info:**
With this, accesiblity will be improved as indicated by criterion '3.1.1 Language of Page' of WCAG 2.1. For this, the first [sufficient technique](https://www.w3.org/WAI/WCAG21/quickref/#language-of-page) is to use language attributes [in the html tag](https://www.w3.org/WAI/WCAG21/Techniques/html/H57.html) that indicates the language in which the content is displayed.