### PR TITLE
LPS-160949 Exceptions are not been thrown because the variable is not properly set.

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/DocumentLibrary/DocumentLibrary.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/DocumentLibrary/DocumentLibrary.es.js
@@ -260,7 +260,7 @@ const Main = ({
 	_onBlur,
 	_onFocus,
 	allowGuestUsers,
-	displayErrors: initialDisplayErrors,
+	displayErrors: initialDisplayErrors = false,
 	editingLanguageId,
 	errorMessage: initialErrorMessage,
 	fieldName,


### PR DESCRIPTION
Hi Team, 
I would like to open a pull request for [https://issues.liferay.com/browse/LPS-160949](https://issues.liferay.com/browse/LPS-160949).

The root cause seems to be the variables that holds the state of `displayErrors` is not properly set.
This fix has been passed our internal review, therefore please take a look at it and give us your feedback.

CC: @locpham97
Thank you,
Vy

