### PR TITLE
LPS-144644 Fixed bug of fields being duplicated when toggling side bar options

### DIFF
--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/reducers/fieldEditableReducer.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/reducers/fieldEditableReducer.es.js
@@ -645,6 +645,14 @@ export default function fieldEditableReducer(state, action, config) {
 			return {
 				fieldHovered: action.payload,
 			};
+		case EVENT_TYPES.DND.MOVE: {
+			state.focusedField = FormSupport.findFieldByFieldName(
+				state.pages,
+				state.focusedField.fieldName
+			);
+
+			return state;
+		}
 		case EVENT_TYPES.SECTION.ADD: {
 			const {
 				activePage,


### PR DESCRIPTION
[LPS-144644](https://issues.liferay.com/browse/LPS-144644) 
The bug was occurring because the 'focusedField' attribute of the ‘state’ object that is passed to the 'fieldEditableReducer' function was inconsistent with the actual current state, as it seemed to represent the previous state (before the field was moved). In that condition, when a ‘change’ event was triggered, this inconsistency was made permanent.
The solution was to create a new case in the ‘fieldEditableReducer’ function (for the move action.type) that updates the current ‘focusedField’.