### PR TITLE
LPS-90833 fixed the bug by creating a new class for the label tag and adding a css rule

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/FieldBase.scss
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/FieldBase.scss
@@ -14,6 +14,10 @@
 	}
 }
 
+.ddm-label.ddm-repeatable {
+	padding-right: 48px;
+}
+
 .lfr-ddm-legend {
 	color: #272833;
 	font-size: 0.875rem;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
@@ -349,6 +349,7 @@ export function FieldBase({
 								className={classNames({
 									'ddm-empty': !showLabel && !required,
 									'ddm-label': showLabel || required,
+									'ddm-repeatable': repeatable,
 								})}
 							>
 								{showLabel && label && (

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/FieldBase/__snapshots__/ReactFieldBase.es.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/FieldBase/__snapshots__/ReactFieldBase.es.js.snap
@@ -26,7 +26,7 @@ exports[`ReactFieldBase does not render the add button when repeatable is true a
     </div>
     <label
       aria-labelledby="undefined_fieldDetails"
-      class="ddm-empty"
+      class="ddm-empty ddm-repeatable"
       tabindex="0"
     />
     <input
@@ -226,7 +226,7 @@ exports[`ReactFieldBase renders the add button when repeatable is true 1`] = `
     </div>
     <label
       aria-labelledby="undefined_fieldDetails"
-      class="ddm-empty"
+      class="ddm-empty ddm-repeatable"
       tabindex="0"
     />
     <input


### PR DESCRIPTION
[LPS](https://issues.liferay.com/browse/LPS-90833) - The solution was to add padding to the field’s label when the field is marked as repeatable. For that, I created a className “repeatable” that is assigned to the ‘label’ tag only when the ‘repeatable’ argument is true. In addition, I added a css rule that targets the label only when it has that className.