### PR TITLE
LPS-164922 Make ck editor modal stay open while editing its options

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/data-engine/DataEngineLayoutBuilderHandler.es.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/data-engine/DataEngineLayoutBuilderHandler.es.js
@@ -41,7 +41,8 @@ export default function DataEngineLayoutBuilderHandler({namespace}) {
 				'.ddm-select-dropdown',
 				'.input-localized-content',
 				'.lfr-icon-menu-open',
-				'.multi-panel-sidebar'
+				'.multi-panel-sidebar',
+				'.cke_dialog'
 			)
 		) {
 			const dataLayoutBuilder = await getDataLayoutBuilder();

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/DataEngineLayoutBuilderHandler.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/DataEngineLayoutBuilderHandler.es.js
@@ -127,7 +127,8 @@ export default function DataEngineLayoutBuilderHandler({namespace}) {
 				'.ddm-form-builder-wrapper',
 				'.multi-panel-sidebar',
 				'.lfr-icon-menu-open',
-				'.input-localized-content'
+				'.input-localized-content',
+				'.cke_dialog'
 			)
 		) {
 			const dataLayoutBuilder = await getDataLayoutBuilder();


### PR DESCRIPTION
Related Issue: https://issues.liferay.com/browse/LPS-164922

**The solution:** Insert the CK Editor class inside the function `detectClickOutside` in the validation using `isElementInnerSelector`.

**Steps to Reproduce:**

1. Navigate to Site Menu > Content & Data > Document and Media > Document Types
2. Create a new document type.
3. Add a "Rich Text" field to the document type.
4. Open the "Advanced" tab of the "Rich Text" field.
5. In the "Predefined Value" field click on the "Table" icon in the editor toolbar. 
6. In the modal that opens, attempt to change the values.

**Expected Result:**
You are able to change the values with the modal staying open.

**Actual Result:**
The modal closes on mousedown or click.
