### PR TITLE
LPS-166541 Add validations in the move event

### DIFF
--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/reducers/fieldEditableReducer.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/reducers/fieldEditableReducer.es.js
@@ -646,12 +646,20 @@ export default function fieldEditableReducer(state, action, config) {
 				fieldHovered: action.payload,
 			};
 		case EVENT_TYPES.DND.MOVE: {
-			state.focusedField = FormSupport.findFieldByFieldName(
-				state.pages,
-				state.focusedField.fieldName
+			const {focusedField, pages} = state;
+
+			if (!focusedField.fieldName) {
+				return state;
+			}
+
+			const updatedFocusedField = FormSupport.findFieldByFieldName(
+				pages,
+				focusedField.fieldName
 			);
 
-			return state;
+			return {
+				focusedField: updatedFocusedField,
+			};
 		}
 		case EVENT_TYPES.SECTION.ADD: {
 			const {


### PR DESCRIPTION
Related issue: https://issues.liferay.com/browse/LPS-166541
 
The bug occurred when the move event was triggered without a focusedField. That was causing the value assigned to “state.focusedField”  to be undefined. 
The solution was to add a validation that verifies if a focusedField exists in the current state.