### PR TITLE
[TS] LPS-166896 In a webcontent numeric field, when using Spanish language, it is not possible to enter a negative decimal number that starts with -0,xxx

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/storage/constants/FieldConstants.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/storage/constants/FieldConstants.java
@@ -16,6 +16,7 @@ package com.liferay.dynamic.data.mapping.storage.constants;
 
 import com.liferay.dynamic.data.mapping.util.NumberUtil;
 import com.liferay.dynamic.data.mapping.util.NumericDDMFormFieldUtil;
+import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.log.Log;
@@ -147,6 +148,12 @@ public class FieldConstants {
 						formattedValue, StringPool.PERIOD,
 						value.substring(
 							NumberUtil.getDecimalSeparatorIndex(value) + 1));
+				}
+
+				if ((formattedValue.charAt(0) != CharPool.MINUS) &&
+					(value.charAt(0) == CharPool.MINUS)) {
+
+					formattedValue = StringPool.MINUS + formattedValue;
 				}
 
 				serializable = getSerializable(type, formattedValue);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/storage/constants/FieldConstants.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/storage/constants/FieldConstants.java
@@ -119,8 +119,6 @@ public class FieldConstants {
 				Number number = decimalFormat.parse(
 					GetterUtil.getString(value));
 
-				String formattedValue = String.valueOf(number);
-
 				if (number.doubleValue() > Integer.MAX_VALUE) {
 					return value;
 				}
@@ -140,6 +138,8 @@ public class FieldConstants {
 						return value;
 					}
 				}
+
+				String formattedValue = String.valueOf(number);
 
 				if (!NumberUtil.hasDecimalSeparator(formattedValue) &&
 					NumberUtil.hasDecimalSeparator(value)) {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/test/java/com/liferay/dynamic/data/mapping/storage/constants/FieldConstantsTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/test/java/com/liferay/dynamic/data/mapping/storage/constants/FieldConstantsTest.java
@@ -72,6 +72,32 @@ public class FieldConstantsTest {
 	}
 
 	@Test
+	public void testGetSerializableReturnNegativeDecimalWithCommaDecimalSeparator() {
+		Serializable serializable = FieldConstants.getSerializable(
+			LocaleUtil.US, LocaleUtil.US, FieldConstants.DOUBLE, "-0,5");
+
+		Assert.assertEquals(Double.valueOf(-0.5), (Double)serializable);
+
+		serializable = FieldConstants.getSerializable(
+			LocaleUtil.SPAIN, LocaleUtil.SPAIN, FieldConstants.DOUBLE, "-0,5");
+
+		Assert.assertEquals(Double.valueOf(-0.5), (Double)serializable);
+	}
+
+	@Test
+	public void testGetSerializableReturnNegativeDecimalWithPeriodSeparator() {
+		Serializable serializable = FieldConstants.getSerializable(
+			LocaleUtil.US, LocaleUtil.US, FieldConstants.DOUBLE, "-0.5");
+
+		Assert.assertEquals(Double.valueOf(-0.5), (Double)serializable);
+
+		serializable = FieldConstants.getSerializable(
+			LocaleUtil.SPAIN, LocaleUtil.SPAIN, FieldConstants.DOUBLE, "-0.5");
+
+		Assert.assertEquals(Double.valueOf(-0.5), (Double)serializable);
+	}
+
+	@Test
 	public void testGetSerializableReturnNumberArray() {
 		List<Serializable> values = Arrays.asList(
 			"1", 1.0, 1000, "10000000000");


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-166896

In a webcontent numeric field, when using Spanish language, it is not possible to enter a negative decimal number that starts with -0,xxx

If you enter any negative number with that format, it will lose the negative sign. For example: -0,5 => 0,5
The error is not reproduced with negative decimal numbers that starts with -1,xxx or smaller

**Root cause:**

- The com.liferay.dynamic.data.mapping.storage.constants.FieldConstants.getSerializable method handles decimal numbers with the following decimal separators: ".", "," and "٫"
- In some situations this method splits the number in two: integer part and decimal part.
    Once it is split, the number is concatenated again with the correct decimal separator.
- But if the integer part of the number is zero, it loses the sign, as zero has no sign.

