### PR TITLE
[TS] LPS-167438 - select fields need an accessible label explicitly associated to them

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
@@ -245,7 +245,8 @@ export function FieldBase({
 		type === 'text' ||
 		type === 'numeric' ||
 		type === 'image' ||
-		type === 'search_location';
+		type === 'search_location' ||
+		type === 'select';
 
 	const accessibleProps = {
 		...(accessible && fieldDetails && {'aria-labelledby': fieldDetailsId}),


### PR DESCRIPTION
Hi @liferay-forms team!

https://issues.liferay.com/browse/LPP-45746

This is a fix for an accessibility issue related to labels and input fields. Previously all labels fields were explicitly related to their input fields, but this was removed in LPS-116665 since technically the 3.3.2 success criterion would still be covered. However, without this relation we run into issues with success criterion 1.3.1. See https://www.w3.org/WAI/WCAG21/Techniques/html/H44 which notes that it should be explicitly related a swell as LPS-151194 where the issue was fixed for the Text and Numeric fields. This fix adds Select/Select from List fields as another field that should have a 'for' attribute to explicitly relate the label and form field.