### PR TITLE
[TECHNICAL SUPPORT] LPS-167775 Repeated DDM html field will associate with ddmPortlet instead of where ddm is consumed

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/html/start.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/html/start.jsp
@@ -163,6 +163,7 @@
 					isPrivateLayoutsEnabled: <%= group.isPrivateLayoutsEnabled() %>,
 					mode: '<%= HtmlUtil.escapeJS(mode) %>',
 					p_l_id: <%= themeDisplay.getPlid() %>,
+					portletId: '<%= themeDisplay.getPpid() %>',
 					portletNamespace: '<portlet:namespace />',
 					repeatable: <%= repeatable %>,
 					requestedLocale:

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/portlet/action/RenderStructureFieldMVCResourceCommand.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/portlet/action/RenderStructureFieldMVCResourceCommand.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.Map;
@@ -96,12 +97,17 @@ public class RenderStructureFieldMVCResourceCommand
 
 		String mode = ParamUtil.getString(httpServletRequest, "mode");
 		String namespace = ParamUtil.getString(httpServletRequest, "namespace");
+		String portletId = ParamUtil.getString(httpServletRequest, "portletId");
 		String portletNamespace = ParamUtil.getString(
 			httpServletRequest, "portletNamespace");
 		boolean readOnly = ParamUtil.getBoolean(httpServletRequest, "readOnly");
 
 		DDMFormFieldRenderingContext ddmFormFieldRenderingContext =
 			new DDMFormFieldRenderingContext();
+
+		if (Validator.isNotNull(portletId)) {
+			httpServletRequest.setAttribute(WebKeys.PORTLET_ID, portletId);
+		}
 
 		httpServletRequest.setAttribute(
 			"aui:form:portletNamespace", portletNamespace);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -132,6 +132,8 @@ AUI.add(
 
 			p_l_id: {},
 
+			portletId: {},
+
 			portletNamespace: {},
 		};
 
@@ -242,6 +244,7 @@ AUI.add(
 					p_p_resource_id:
 						'/dynamic_data_mapping/render_structure_field',
 					p_p_state: 'pop_up',
+					portletId: instance.get('portletId'),
 					portletNamespace: instance.get('portletNamespace'),
 					readOnly: instance.get('readOnly'),
 				};


### PR DESCRIPTION
Previous PR: https://github.com/liferay-forms/liferay-portal-ee/pull/140

Hey,
[LPS-167775](https://issues.liferay.com/browse/LPS-167775)

The issue here is that repeated ddm fields will be associated with dynamic-data-mapping instead of the portlet where ddm is consumed. The solution was to override the portletId of the httpServletRequest when we create the renderingContext of the DDM fields. I did not find any downside of overwriting the attribute.

Please review the changes,

cc @marcelabc 