### PR TITLE
LPS-168563 We should always define rememberMe variable

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/display/view.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/display/view.jsp
@@ -419,7 +419,7 @@ boolean limitToOneSubmissionPerUser = DDMFormInstanceSubmissionLimitStatusUtil.i
 						</c:choose>
 					}
 
-					var rememberMe = '<%= ddmFormDisplayContext.isRememberMe() %>';
+					var rememberMe = <%= ddmFormDisplayContext.isRememberMe() %>;
 
 					window.<portlet:namespace />sessionIntervalId = setInterval(() => {
 						if (Liferay.Session || rememberMe) {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/display/view.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/display/view.jsp
@@ -419,9 +419,7 @@ boolean limitToOneSubmissionPerUser = DDMFormInstanceSubmissionLimitStatusUtil.i
 						</c:choose>
 					}
 
-					<c:if test="<%= ddmFormDisplayContext.isRememberMe() %>">
-						var rememberMe = true;
-					</c:if>
+					var rememberMe = '<%= ddmFormDisplayContext.isRememberMe() %>';
 
 					window.<portlet:namespace />sessionIntervalId = setInterval(() => {
 						if (Liferay.Session || rememberMe) {


### PR DESCRIPTION
Hi guys,

Can you review this pull request, please?

It is one of those cases when it is easier to see the mistake in the code than trying to reproduce it since, in general, that `rememberMe` variable is not checked because `Liferay.Session` is already defined in the browser, but in case that module has not been loaded yet for whatever reason, `rememberMe` value is checked and in case `ddmFormDisplayContext.isRememberMe()` is returning `false`, the variable is not defined causing a Javascript error and stopping the form to be loaded.

Thanks.

Regards.