### PR TITLE
LPS-84862 create new endpoint for copying dataDefinition objects and use it to fix bug

### DIFF
--- a/modules/apps/data-engine/data-engine-rest-api/bnd.bnd
+++ b/modules/apps/data-engine/data-engine-rest-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Data Engine REST API
 Bundle-SymbolicName: com.liferay.data.engine.rest.api
-Bundle-Version: 30.0.2
+Bundle-Version: 30.1.0
 Export-Package:\
 	com.liferay.data.engine.rest.dto.v2_0,\
 	com.liferay.data.engine.rest.dto.v2_0.util,\

--- a/modules/apps/data-engine/data-engine-rest-api/src/main/java/com/liferay/data/engine/rest/resource/v2_0/DataDefinitionResource.java
+++ b/modules/apps/data-engine/data-engine-rest-api/src/main/java/com/liferay/data/engine/rest/resource/v2_0/DataDefinitionResource.java
@@ -87,6 +87,9 @@ public interface DataDefinitionResource {
 	public Response putDataDefinitionBatch(String callbackURL, Object object)
 		throws Exception;
 
+	public DataDefinition postDataDefinitionCopy(Long dataDefinitionId)
+		throws Exception;
+
 	public Page<com.liferay.portal.vulcan.permission.Permission>
 			getDataDefinitionPermissionsPage(
 				Long dataDefinitionId, String roleNames)

--- a/modules/apps/data-engine/data-engine-rest-api/src/main/resources/com/liferay/data/engine/rest/resource/v2_0/packageinfo
+++ b/modules/apps/data-engine/data-engine-rest-api/src/main/resources/com/liferay/data/engine/rest/resource/v2_0/packageinfo
@@ -1,1 +1,1 @@
-version 8.1.0
+version 8.2.0

--- a/modules/apps/data-engine/data-engine-rest-client/src/main/java/com/liferay/data/engine/rest/client/resource/v2_0/DataDefinitionResource.java
+++ b/modules/apps/data-engine/data-engine-rest-client/src/main/java/com/liferay/data/engine/rest/client/resource/v2_0/DataDefinitionResource.java
@@ -112,6 +112,13 @@ public interface DataDefinitionResource {
 			String callbackURL, Object object)
 		throws Exception;
 
+	public DataDefinition postDataDefinitionCopy(Long dataDefinitionId)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse postDataDefinitionCopyHttpResponse(
+			Long dataDefinitionId)
+		throws Exception;
+
 	public Page<Permission> getDataDefinitionPermissionsPage(
 			Long dataDefinitionId, String roleNames)
 		throws Exception;
@@ -980,6 +987,87 @@ public interface DataDefinitionResource {
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
 						"/o/data-engine/v2.0/data-definitions/batch");
+
+			httpInvoker.userNameAndPassword(
+				_builder._login + ":" + _builder._password);
+
+			return httpInvoker.invoke();
+		}
+
+		public DataDefinition postDataDefinitionCopy(Long dataDefinitionId)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				postDataDefinitionCopyHttpResponse(dataDefinitionId);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return DataDefinitionSerDes.toDTO(content);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse postDataDefinitionCopyHttpResponse(
+				Long dataDefinitionId)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/data-engine/v2.0/data-definitions/{dataDefinitionId}/copy");
+
+			httpInvoker.path("dataDefinitionId", dataDefinitionId);
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);

--- a/modules/apps/data-engine/data-engine-rest-impl/rest-openapi.yaml
+++ b/modules/apps/data-engine/data-engine-rest-impl/rest-openapi.yaml
@@ -505,6 +505,26 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/DataDefinition"
             tags: ["DataDefinition"]
+    "/data-definitions/{dataDefinitionId}/copy":
+        post:
+            operationId: postDataDefinitionCopy
+            parameters:
+                - in: path
+                  name: dataDefinitionId
+                  required: true
+                  schema:
+                      format: int64
+                      type: integer
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/DataDefinition"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/DataDefinition"
+            tags: ["DataDefinition"]
     "/data-definitions/{dataDefinitionId}/data-definition-field-links":
         get:
             operationId: getDataDefinitionDataDefinitionFieldLinksPage

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/graphql/mutation/v2_0/Mutation.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/graphql/mutation/v2_0/Mutation.java
@@ -181,6 +181,19 @@ public class Mutation {
 	}
 
 	@GraphQLField
+	public DataDefinition createDataDefinitionCopy(
+			@GraphQLName("dataDefinitionId") Long dataDefinitionId)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_dataDefinitionResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			dataDefinitionResource ->
+				dataDefinitionResource.postDataDefinitionCopy(
+					dataDefinitionId));
+	}
+
+	@GraphQLField
 	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
 			updateDataDefinitionPermissionsPage(
 				@GraphQLName("dataDefinitionId") Long dataDefinitionId,

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/graphql/servlet/v2_0/ServletDataImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/graphql/servlet/v2_0/ServletDataImpl.java
@@ -143,6 +143,11 @@ public class ServletDataImpl implements ServletData {
 							DataDefinitionResourceImpl.class,
 							"putDataDefinitionBatch"));
 					put(
+						"mutation#createDataDefinitionCopy",
+						new ObjectValuePair<>(
+							DataDefinitionResourceImpl.class,
+							"postDataDefinitionCopy"));
+					put(
 						"mutation#updateDataDefinitionPermissionsPage",
 						new ObjectValuePair<>(
 							DataDefinitionResourceImpl.class,

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataDefinitionResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataDefinitionResourceImpl.java
@@ -473,6 +473,38 @@ public abstract class BaseDataDefinitionResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
+	 * curl -X 'POST' 'http://localhost:8080/o/data-engine/v2.0/data-definitions/{dataDefinitionId}/copy'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "dataDefinitionId"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(name = "DataDefinition")
+		}
+	)
+	@javax.ws.rs.Path("/data-definitions/{dataDefinitionId}/copy")
+	@javax.ws.rs.POST
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public DataDefinition postDataDefinitionCopy(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("dataDefinitionId")
+			Long dataDefinitionId)
+		throws Exception {
+
+		return new DataDefinition();
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
 	 * curl -X 'GET' 'http://localhost:8080/o/data-engine/v2.0/data-definitions/{dataDefinitionId}/permissions'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Parameters(

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataDefinitionResourceTestCase.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataDefinitionResourceTestCase.java
@@ -716,6 +716,25 @@ public abstract class BaseDataDefinitionResourceTestCase {
 	}
 
 	@Test
+	public void testPostDataDefinitionCopy() throws Exception {
+		DataDefinition randomDataDefinition = randomDataDefinition();
+
+		DataDefinition postDataDefinition =
+			testPostDataDefinitionCopy_addDataDefinition(randomDataDefinition);
+
+		assertEquals(randomDataDefinition, postDataDefinition);
+		assertValid(postDataDefinition);
+	}
+
+	protected DataDefinition testPostDataDefinitionCopy_addDataDefinition(
+			DataDefinition dataDefinition)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
 	public void testGetDataDefinitionPermissionsPage() throws Exception {
 		DataDefinition postDataDefinition =
 			testGetDataDefinitionPermissionsPage_addDataDefinition();

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/CopyDataDefinitionMVCActionCommand.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/CopyDataDefinitionMVCActionCommand.java
@@ -22,7 +22,6 @@ import com.liferay.document.library.kernel.model.DLFileEntryMetadata;
 import com.liferay.dynamic.data.mapping.constants.DDMTemplateConstants;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.service.DDMTemplateService;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseTransactionalMVCActionCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -84,17 +83,14 @@ public class CopyDataDefinitionMVCActionCommand
 			).build();
 
 		DataDefinition dataDefinition =
-			dataDefinitionResource.getDataDefinition(ddmStructureId);
+			dataDefinitionResource.postDataDefinitionCopy(ddmStructureId);
 
-		dataDefinition.setDataDefinitionKey(StringPool.BLANK);
 		dataDefinition.setDescription(
 			LocalizedValueUtil.toStringObjectMap(descriptionMap));
 		dataDefinition.setName(LocalizedValueUtil.toStringObjectMap(nameMap));
 
-		dataDefinition =
-			dataDefinitionResource.postSiteDataDefinitionByContentType(
-				themeDisplay.getScopeGroupId(), "document-library",
-				dataDefinition);
+		dataDefinitionResource.putDataDefinition(
+			dataDefinition.getId(), dataDefinition);
 
 		boolean copyTemplates = ParamUtil.getBoolean(
 			actionRequest, "copyTemplates");

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/CopyDataDefinitionMVCActionCommand.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/CopyDataDefinitionMVCActionCommand.java
@@ -16,20 +16,12 @@ package com.liferay.journal.web.internal.portlet.action;
 
 import com.liferay.data.engine.field.type.util.LocalizedValueUtil;
 import com.liferay.data.engine.rest.dto.v2_0.DataDefinition;
-import com.liferay.data.engine.rest.dto.v2_0.DataDefinitionField;
-import com.liferay.data.engine.rest.dto.v2_0.DataLayout;
-import com.liferay.data.engine.rest.dto.v2_0.DataLayoutColumn;
-import com.liferay.data.engine.rest.dto.v2_0.DataLayoutPage;
-import com.liferay.data.engine.rest.dto.v2_0.DataLayoutRow;
 import com.liferay.data.engine.rest.resource.v2_0.DataDefinitionResource;
 import com.liferay.dynamic.data.mapping.constants.DDMTemplateConstants;
-import com.liferay.dynamic.data.mapping.form.field.type.constants.DDMFormFieldTypeConstants;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
-import com.liferay.dynamic.data.mapping.service.DDMStructureService;
 import com.liferay.dynamic.data.mapping.service.DDMTemplateService;
 import com.liferay.journal.constants.JournalPortletKeys;
 import com.liferay.journal.model.JournalArticle;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
@@ -44,7 +36,6 @@ import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 
 import javax.portlet.ActionRequest;
 import javax.portlet.ActionResponse;
@@ -92,112 +83,41 @@ public class CopyDataDefinitionMVCActionCommand
 		Map<Locale, String> nameMap = _localization.getLocalizationMap(
 			actionRequest, "name");
 
-		DataDefinitionResource.Builder dataDefinitionResourcedBuilder =
+		DataDefinitionResource.Builder dataDefinitionResourceBuilder =
 			_dataDefinitionResourceFactory.create();
 
 		DataDefinitionResource dataDefinitionResource =
-			dataDefinitionResourcedBuilder.user(
+			dataDefinitionResourceBuilder.user(
 				themeDisplay.getUser()
 			).build();
 
 		DataDefinition dataDefinition =
-			dataDefinitionResource.getDataDefinition(ddmStructureId);
+			dataDefinitionResource.postDataDefinitionCopy(ddmStructureId);
 
-		_uniquifyDataDefinitionFields(dataDefinition);
-
-		dataDefinition.setDataDefinitionKey(StringPool.BLANK);
 		dataDefinition.setDescription(
 			LocalizedValueUtil.toStringObjectMap(descriptionMap));
 		dataDefinition.setName(LocalizedValueUtil.toStringObjectMap(nameMap));
 
-		dataDefinition =
-			dataDefinitionResource.postSiteDataDefinitionByContentType(
-				themeDisplay.getScopeGroupId(), "journal", dataDefinition);
+		dataDefinitionResource.putDataDefinition(
+			dataDefinition.getId(), dataDefinition);
 
 		boolean copyTemplates = ParamUtil.getBoolean(
 			actionRequest, "copyTemplates");
 
 		if (copyTemplates) {
-			DDMStructure ddmStructure = _ddmStructureService.getStructure(
-				themeDisplay.getScopeGroupId(),
-				_portal.getClassNameId(JournalArticle.class),
-				dataDefinition.getDataDefinitionKey());
-
 			ServiceContext serviceContext = ServiceContextFactory.getInstance(
 				DDMStructure.class.getName(), actionRequest);
 
 			_ddmTemplateService.copyTemplates(
 				_portal.getClassNameId(DDMStructure.class), ddmStructureId,
 				_portal.getClassNameId(JournalArticle.class),
-				ddmStructure.getStructureId(),
+				dataDefinition.getId(),
 				DDMTemplateConstants.TEMPLATE_TYPE_DISPLAY, serviceContext);
-		}
-	}
-
-	private void _uniquifyDataDefinitionFields(DataDefinition dataDefinition) {
-		for (DataDefinitionField dataDefinitionField :
-				dataDefinition.getDataDefinitionFields()) {
-
-			_uniquifyDataDefinitionFields(dataDefinitionField);
-		}
-
-		_updateDataLayout(dataDefinition.getDefaultDataLayout());
-	}
-
-	private void _uniquifyDataDefinitionFields(
-		DataDefinitionField dataDefinitionField) {
-
-		dataDefinitionField.setName("CopyOf" + dataDefinitionField.getName());
-
-		Map<String, Object> customProperties =
-			dataDefinitionField.getCustomProperties();
-
-		if (customProperties.containsKey("fieldReference")) {
-			customProperties.put(
-				"fieldReference",
-				"CopyOf" + customProperties.get("fieldReference"));
-		}
-
-		if (!customProperties.containsKey("structureId") &&
-			!Objects.equals(
-				dataDefinitionField.getFieldType(),
-				DDMFormFieldTypeConstants.FIELDSET)) {
-
-			for (DataDefinitionField nestedDataDefinitionField :
-					dataDefinitionField.getNestedDataDefinitionFields()) {
-
-				_uniquifyDataDefinitionFields(nestedDataDefinitionField);
-			}
-		}
-	}
-
-	private void _updateDataLayout(DataLayout dataLayout) {
-		for (DataLayoutPage dataLayoutPage : dataLayout.getDataLayoutPages()) {
-			_updateDataLayoutRows(dataLayoutPage.getDataLayoutRows());
-		}
-	}
-
-	private void _updateDataLayoutRows(DataLayoutRow[] dataLayoutRows) {
-		for (DataLayoutRow dataLayoutRow : dataLayoutRows) {
-			for (DataLayoutColumn dataLayoutColumn :
-					dataLayoutRow.getDataLayoutColumns()) {
-
-				String[] dataLayoutColumnFieldNames =
-					dataLayoutColumn.getFieldNames();
-
-				for (int i = 0; i < dataLayoutColumnFieldNames.length; i++) {
-					dataLayoutColumnFieldNames[i] =
-						"CopyOf" + dataLayoutColumnFieldNames[i];
-				}
-			}
 		}
 	}
 
 	@Reference
 	private DataDefinitionResource.Factory _dataDefinitionResourceFactory;
-
-	@Reference
-	private DDMStructureService _ddmStructureService;
 
 	@Reference
 	private DDMTemplateService _ddmTemplateService;


### PR DESCRIPTION
[LPS-84862](https://issues.liferay.com/browse/LPS-84862) - Did the implementation requested in this [PR ](https://github.com/liferay-objects/liferay-portal/pull/1346). It consisted in creating a new endpoint for copying dataDefinition objects (which copies the permissions) and then calling it in the CopyDataDefinitionMVCActionCommand for journal and document-library.