### PR TITLE
LPS-115860 Add translate untranslated label in DDM when the elements are not available in the DOM

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/html/start.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/html/start.jsp
@@ -209,6 +209,16 @@
 					'#<portlet:namespace /><%= fieldsNamespace %>PaletteContentBox a'
 				);
 
+				const triggerMenu = A.one(
+					'#<portlet:namespace /><%= fieldsNamespace %>Menu'
+				);
+
+				const listContainer = triggerMenu.getData('menuListContainer');
+
+				if (childrenItems._nodes && !childrenItems._nodes.length && listContainer) {
+					childrenItems = listContainer.all(childrenItems._query);
+				}
+
 				childrenItems.each((item) => {
 					if (item.hasClass('active')) {
 						item.removeClass('active');
@@ -223,7 +233,7 @@
 
 				languageId = languageId.replace('_', '-');
 
-				var triggerContent = Lang.sub(
+				const triggerContent = Lang.sub(
 					'<span class="inline-item">{flag}</span><span class="btn-section">{languageId}</span>',
 					{
 						flag: Liferay.Util.getLexiconIconTpl(languageId.toLowerCase()),
@@ -231,9 +241,8 @@
 					}
 				);
 
-				var trigger = A.one('#<portlet:namespace /><%= fieldsNamespace %>Menu');
-
-				trigger.setHTML(triggerContent);
+				triggerMenu.setHTML(triggerContent);
+				triggerMenu.setData('menuListContainer', listContainer);
 			};
 
 			Liferay.on('inputLocalized:localeChanged', onLocaleChange);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -1237,13 +1237,24 @@ AUI.add(
 						.getInputName()
 						.replace(regexpFieldsNamespace, '');
 
-					const labelItem = A.one(
+					const labelItemSelector =
 						'#' +
-							fieldsNamespace +
-							'PaletteContentBox a[data-value="' +
-							locale +
-							'"] .label'
+						fieldsNamespace +
+						'PaletteContentBox a[data-value="' +
+						locale +
+						'"] .label';
+
+					let labelItem = A.one(labelItemSelector);
+
+					const triggerMenu = A.one('#' + fieldsNamespace + 'Menu');
+
+					const listContainer = triggerMenu.getData(
+						'menuListContainer'
 					);
+
+					if (!labelItem && listContainer) {
+						labelItem = listContainer.one(labelItemSelector);
+					}
 
 					if (
 						labelItem &&
@@ -1265,6 +1276,8 @@ AUI.add(
 							labelItem.addClass('label-success');
 						}
 					}
+
+					triggerMenu.setData('menuListContainer', listContainer);
 				},
 
 				syncValueUI() {


### PR DESCRIPTION
Previous pull: https://github.com/liferay-forms/liferay-portal/pull/2019

I needed to add an extra [commit](https://github.com/liferay-forms/liferay-portal/pull/2026/commits/9906fc43a85e101510672e2716e0adacc3e17b1b) as I did not take into account that if you press on another menu, the items are not available in the DOM and I need to update `triggerMenu.getData('menuListContainer');`.

Steps to reproduce this case on 7.3.x or 7.2.x web content, on master this is not reproducible as on DDL we don't have more language button to change:
1. Press on the menu to open the language selector for the fields, change to a different untranslated language then default
2. Translate any field on this language
3. Press on the menu to open the language selector for the title, change language from there
4. Open again the menu for language selector for the fields, and see that is not displayed translated

Any questions, please let me know.

Regards.