### PR TITLE
LPS-133031 Changing end date entry to fix bug

### DIFF
--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/resources/com/liferay/dynamic/data/lists/internal/events/dependencies/default-dynamic-data-lists-structures.xml
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/resources/com/liferay/dynamic/data/lists/internal/events/dependencies/default-dynamic-data-lists-structures.xml
@@ -355,7 +355,7 @@
 			</dynamic-element>
 			<dynamic-element dataType="date" fieldNamespace="ddm" indexType="keyword" name="endDate" required="false" showLabel="true" type="ddm-date">
 				<meta-data locale="[$LOCALE_DEFAULT$]">
-					<entry name="label"><![CDATA[end date]]></entry>
+					<entry name="label"><![CDATA[end-date]]></entry>
 					<entry name="predefinedValue"><![CDATA[]]></entry>
 				</meta-data>
 			</dynamic-element>


### PR DESCRIPTION
[LPS-133107](https://issues.liferay.com/browse/LPS-133107) The key-language where End Date is called is not set properly, so, instead of end date (wrong sentence), now it's referenced as end-date (correct sentence), . 