### PR TITLE
LPS-125089 - Content is temporarily unavailable in Date field after editing in Spreadsheet View

### DIFF
--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/java/com/liferay/dynamic/data/lists/web/internal/portlet/action/UpdateRecordMVCResourceCommand.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/java/com/liferay/dynamic/data/lists/web/internal/portlet/action/UpdateRecordMVCResourceCommand.java
@@ -32,6 +32,7 @@ import com.liferay.portal.kernel.service.ServiceContextFactory;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
 import java.util.ArrayList;
@@ -124,9 +125,22 @@ public class UpdateRecordMVCResourceCommand extends BaseMVCResourceCommand {
 				while (iterator.hasNext()) {
 					String languageId = iterator.next();
 
+					String valueJSONObjectString = valueJSONObject.getString(
+						languageId);
+
+					if (jsonObject.getString(
+							"name"
+						).equals(
+							"eventDate"
+						)) {
+
+						valueJSONObjectString = StringUtil.removeChars(
+							valueJSONObjectString, '[', ']', '"');
+					}
+
 					localizedValue.addString(
 						LocaleUtil.fromLanguageId(languageId),
-						valueJSONObject.getString(languageId));
+						valueJSONObjectString);
 				}
 
 				ddmFormFieldValue.setValue(localizedValue);


### PR DESCRIPTION
Relevant Issue: [LPS-125089](https://issues.liferay.com/browse/LPS-125089)
The issue is occurring because the date is being saved with a bunch of extra characters ( ' " ', '[', ']') when updated through the spreadsheet view.
Proposed fix is to filter the string before saving.