### PR TITLE
LPS-169759 Check the value from calculation result first so that the numeric field can be overwritten

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Numeric/Numeric.tsx
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Numeric/Numeric.tsx
@@ -203,9 +203,8 @@ const Numeric: React.FC<IProps> = ({
 
 	const inputValue = useMemo<IMaskedNumber>(() => {
 		let newValue =
-			((localizedValue?.[editingLanguageId] ??
-				localizedValue?.[defaultLanguageId]) ||
-				value) ??
+			((value ?? localizedValue?.[editingLanguageId]) ||
+				localizedValue?.[defaultLanguageId]) ??
 			predefinedValue ??
 			'';
 


### PR DESCRIPTION
**Bug found:** https://issues.liferay.com/browse/LPS-169759

The customer reported that after creating a Form with 3 Numeric fields and one of them being only for calculation purposes (after applying the rule for this field to be only for calculation purposes), you are able to edit this calculation field and the system does not have any kind of overwriting that would prevent the result value of being modified. He/she said that this was not possible to do back on 7.2.

**Steps to reproduce**

1. Start by creating a new Form
2. Add 3 Numeric fields (Value 1, Value 2, Calculation)
3. Add a rule (If Field Value 1 is not empty Calculate [Value 1]+[Value 2] into Calculation)
4. Return to the Form tab
5. Save the form
6. Click the Preview button
7. Type any number into the Value 1 field
8. Change the value in the Calculated field
9. Update Value 1 or set a value in Value 2 (the calculation field isn't updated)

**Results of Testing:**
I'm able to populate the Calculation field and the result is not being calculated and displayed anymore.

**Expected Result:**
It is expected that the calculation rule would be overwriting the field with the result value as it was in 7.2 in that the field was essentially read-only and could not be updated by the user as the field is populated based on other field conditions.