### PR TITLE
[TS] LPS-168328 | Creating a Structure with Boolean-fieldset results in a blank page

### DIFF
--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/utils/dataConverter.ts
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/utils/dataConverter.ts
@@ -128,7 +128,11 @@ export function getDDMFormFieldSettingsContext({
 				value,
 			};
 
-			if (type === 'select' && fieldName === 'predefinedValue') {
+			if (
+				type === 'select' &&
+				fieldName === 'predefinedValue' &&
+				dataDefinitionField.customProperties.options !== undefined
+			) {
 				newField.multiple =
 					dataDefinitionField.customProperties.multiple;
 				newField.options = (dataDefinitionField.customProperties


### PR DESCRIPTION
Hi Team,
Could you please review this pull request?
https://issues.liferay.com/browse/LPS-168328
Thank you!

----

**Steps to reproduce:**

When a fieldset is created for structures with a boolean field it results in an NPE as it tries to cast the options of the boolean to LocalizedValue. I added a check to only do this if the given options exist.

1. Go to Menu -> Content & Data -> Web Content -> Structures
2. Click on Add
3. Click on Fieldsets -> Create New Fieldset
4. Drag Boolean field on to the page -> Name it -> Save it
5. Drag the newly created fieldset onto Structure's page

 **Actual behavior:** Page goes blank and errors shown in browser console
 **Expected behavior:** Structure with Boolean-fieldset is created and can be saved

Addition question: Is there a reason why the modification only deployed locally after I bumped the version number?