### PR TITLE
LPS-170221 add validation for duplicate field references

### DIFF
--- a/modules/apps/data-engine/data-engine-rest-api/bnd.bnd
+++ b/modules/apps/data-engine/data-engine-rest-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Data Engine REST API
 Bundle-SymbolicName: com.liferay.data.engine.rest.api
-Bundle-Version: 30.1.1
+Bundle-Version: 30.2.0
 Export-Package:\
 	com.liferay.data.engine.rest.dto.v2_0,\
 	com.liferay.data.engine.rest.dto.v2_0.util,\

--- a/modules/apps/data-engine/data-engine-rest-api/src/main/java/com/liferay/data/engine/rest/resource/exception/DataDefinitionValidationException.java
+++ b/modules/apps/data-engine/data-engine-rest-api/src/main/java/com/liferay/data/engine/rest/resource/exception/DataDefinitionValidationException.java
@@ -61,6 +61,28 @@ public class DataDefinitionValidationException extends RuntimeException {
 
 	}
 
+	public static class MustNotDuplicateFieldReference
+		extends DataDefinitionValidationException {
+
+		public MustNotDuplicateFieldReference(
+			Set<String> duplicatedFieldReferences) {
+
+			super(
+				String.format(
+					"Field references %s were defined more than once",
+					duplicatedFieldReferences));
+
+			_duplicatedFieldReferences = duplicatedFieldReferences;
+		}
+
+		public Set<String> getDuplicatedFieldReferences() {
+			return _duplicatedFieldReferences;
+		}
+
+		private final Set<String> _duplicatedFieldReferences;
+
+	}
+
 	/**
 	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
 	 */

--- a/modules/apps/data-engine/data-engine-rest-api/src/main/resources/com/liferay/data/engine/rest/resource/exception/packageinfo
+++ b/modules/apps/data-engine/data-engine-rest-api/src/main/resources/com/liferay/data/engine/rest/resource/exception/packageinfo
@@ -1,1 +1,1 @@
-version 3.1.0
+version 3.2.0

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/jaxrs/exception/mapper/DataDefinitionMustNotDuplicateFieldReferenceValidationExceptionMapper.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/jaxrs/exception/mapper/DataDefinitionMustNotDuplicateFieldReferenceValidationExceptionMapper.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.data.engine.rest.internal.jaxrs.exception.mapper;
+
+import com.liferay.data.engine.rest.resource.exception.DataDefinitionValidationException;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.BaseExceptionMapper;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.Problem;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Pedro Tavares
+ */
+@Component(
+	property = {
+		"osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Data.Engine.REST)",
+		"osgi.jaxrs.extension=true",
+		"osgi.jaxrs.name=Liferay.Data.Engine.REST.DataDefinitionMustNotDuplicateFieldReferenceValidationExceptionMapper"
+	},
+	service = ExceptionMapper.class
+)
+public class
+	DataDefinitionMustNotDuplicateFieldReferenceValidationExceptionMapper
+		extends BaseExceptionMapper
+			<DataDefinitionValidationException.MustNotDuplicateFieldReference> {
+
+	@Override
+	protected Problem getProblem(
+		DataDefinitionValidationException.MustNotDuplicateFieldReference
+			mustNotDuplicateFieldReference) {
+
+		return new Problem(
+			StringUtil.merge(
+				mustNotDuplicateFieldReference.getDuplicatedFieldReferences(),
+				StringPool.COMMA),
+			Response.Status.BAD_REQUEST,
+			mustNotDuplicateFieldReference.getMessage(),
+			"MustNotDuplicateFieldReference");
+	}
+
+}

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/DataDefinitionResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/DataDefinitionResourceImpl.java
@@ -1285,6 +1285,20 @@ public class DataDefinitionResourceImpl extends BaseDataDefinitionResourceImpl {
 		}
 
 		if (ddmFormValidationException instanceof
+				DDMFormValidationException.MustNotDuplicateFieldReference) {
+
+			DDMFormValidationException.MustNotDuplicateFieldReference
+				mustNotDuplicateFieldReference =
+					(DDMFormValidationException.MustNotDuplicateFieldReference)
+						ddmFormValidationException;
+
+			return new DataDefinitionValidationException.
+				MustNotDuplicateFieldReference(
+					mustNotDuplicateFieldReference.
+						getDuplicatedFieldReferences());
+		}
+
+		if (ddmFormValidationException instanceof
 				DDMFormValidationException.MustSetAvailableLocales) {
 
 			return new DataDefinitionValidationException.

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/DataLayoutResourceTest.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/DataLayoutResourceTest.java
@@ -42,6 +42,7 @@ import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.hamcrest.CoreMatchers;
@@ -224,6 +225,8 @@ public class DataLayoutResourceTest extends BaseDataLayoutResourceTestCase {
 						dataDefinitionFields = new DataDefinitionField[] {
 							new DataDefinitionField() {
 								{
+									customProperties = Collections.singletonMap(
+										"fieldReference", "fieldReference1");
 									fieldType = "text";
 									label = HashMapBuilder.<String, Object>put(
 										"en_US", RandomTestUtil.randomString()
@@ -235,6 +238,8 @@ public class DataLayoutResourceTest extends BaseDataLayoutResourceTestCase {
 							},
 							new DataDefinitionField() {
 								{
+									customProperties = Collections.singletonMap(
+										"fieldReference", "fieldReference2");
 									fieldType = "text";
 									label = HashMapBuilder.<String, Object>put(
 										"en_US", RandomTestUtil.randomString()

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/resources/com/liferay/data/engine/rest/resource/v2_0/test/util/dependencies/data-definition-child.json
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/resources/com/liferay/data/engine/rest/resource/v2_0/test/util/dependencies/data-definition-child.json
@@ -8,6 +8,7 @@
 				"collapsible": true,
 				"ddmStructureId": 36004,
 				"ddmStructureLayoutId": "",
+				"fieldReference": "Parent",
 				"rows": [
 					{
 						"columns": [
@@ -36,6 +37,7 @@
 						"ddmDataProviderInstanceOutput": "[]",
 						"displayStyle": "singleline",
 						"fieldNamespace": "",
+						"fieldReference": "Text",
 						"options": {
 							"en_US": [
 								{

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/resources/com/liferay/data/engine/rest/resource/v2_0/test/util/dependencies/data-definition-with-fields-group.json
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/resources/com/liferay/data/engine/rest/resource/v2_0/test/util/dependencies/data-definition-with-fields-group.json
@@ -8,6 +8,7 @@
 			"customProperties": {
 				"dataType": "string",
 				"fieldNamespace": "",
+				"fieldReference": "MultipleSelection",
 				"inline": true,
 				"options": {
 					"en_US": [
@@ -76,6 +77,7 @@
 			"customProperties": {
 				"dataType": "string",
 				"fieldNamespace": "",
+				"fieldReference": "Color",
 				"visibilityExpression": ""
 			},
 			"defaultValue": {
@@ -106,6 +108,7 @@
 			"customProperties": {
 				"dataType": "string",
 				"fieldNamespace": "",
+				"fieldReference": "Date",
 				"validation": {
 					"errorMessage": {
 					},
@@ -144,6 +147,7 @@
 			"customProperties": {
 				"dataType": "string",
 				"fieldNamespace": "",
+				"fieldReference": "Upload",
 				"validation": {
 					"errorMessage": {
 					},
@@ -180,7 +184,8 @@
 		},
 		{
 			"customProperties": {
-				"dataType": "string"
+				"dataType": "string",
+				"fieldReference": "Geolocation"
 			},
 			"defaultValue": {
 				"en_US": "",
@@ -236,6 +241,7 @@
 				},
 				"dataType": "string",
 				"fieldNamespace": "",
+				"fieldReference": "Grid",
 				"rows": {
 					"en_US": [
 						{
@@ -303,6 +309,7 @@
 			"customProperties": {
 				"dataType": "string",
 				"fieldNamespace": "",
+				"fieldReference": "Image",
 				"visibilityExpression": ""
 			},
 			"defaultValue": {
@@ -333,6 +340,7 @@
 			"customProperties": {
 				"dataType": "journal-article",
 				"fieldNamespace": "",
+				"fieldReference": "WebContent",
 				"visibilityExpression": ""
 			},
 			"defaultValue": {
@@ -363,6 +371,7 @@
 			"customProperties": {
 				"dataType": "link-to-page",
 				"fieldNamespace": "",
+				"fieldReference": "LinkToPage",
 				"visibilityExpression": ""
 			},
 			"defaultValue": {
@@ -396,6 +405,7 @@
 					"vertical"
 				],
 				"fieldNamespace": "",
+				"fieldReference": "Numeric",
 				"placeholder": {
 					"en_US": "Placeholder Text",
 					"pt_BR": "Texto Placeholder"
@@ -442,6 +452,7 @@
 			"customProperties": {
 				"dataType": "string",
 				"fieldNamespace": "",
+				"fieldReference": "SingleSelection",
 				"inline": true,
 				"options": {
 					"en_US": [
@@ -509,6 +520,7 @@
 			"customProperties": {
 				"dataType": "string",
 				"fieldNamespace": "",
+				"fieldReference": "RichText",
 				"visibilityExpression": ""
 			},
 			"defaultValue": {
@@ -544,6 +556,7 @@
 				"ddmDataProviderInstanceOutput": [
 				],
 				"fieldNamespace": "",
+				"fieldReference": "SelectFromList",
 				"multiple": true,
 				"options": {
 					"en_US": [
@@ -610,6 +623,7 @@
 		{
 			"customProperties": {
 				"dataType": "",
+				"fieldReference": "Separator",
 				"style": {
 					"en_US": "",
 					"pt_BR": ""
@@ -644,6 +658,7 @@
 				],
 				"displayStyle": "multiline",
 				"fieldNamespace": "",
+				"fieldReference": "Text",
 				"options": {
 				},
 				"placeholder": {

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/resources/com/liferay/data/engine/rest/resource/v2_0/test/util/dependencies/data-definition.json
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/resources/com/liferay/data/engine/rest/resource/v2_0/test/util/dependencies/data-definition.json
@@ -8,6 +8,7 @@
 			"customProperties": {
 				"dataType": "string",
 				"fieldNamespace": "",
+				"fieldReference": "MultipleSelection",
 				"inline": true,
 				"options": {
 					"en_US": [
@@ -76,6 +77,7 @@
 			"customProperties": {
 				"dataType": "string",
 				"fieldNamespace": "",
+				"fieldReference": "Color",
 				"visibilityExpression": ""
 			},
 			"defaultValue": {
@@ -106,6 +108,7 @@
 			"customProperties": {
 				"dataType": "string",
 				"fieldNamespace": "",
+				"fieldReference": "Date",
 				"validation": {
 					"errorMessage": {
 					},
@@ -144,6 +147,7 @@
 			"customProperties": {
 				"dataType": "string",
 				"fieldNamespace": "",
+				"fieldReference": "Upload",
 				"validation": {
 					"errorMessage": {
 					},
@@ -180,7 +184,8 @@
 		},
 		{
 			"customProperties": {
-				"dataType": "string"
+				"dataType": "string",
+				"fieldReference": "Geolocation"
 			},
 			"defaultValue": {
 				"en_US": "",
@@ -236,6 +241,7 @@
 				},
 				"dataType": "string",
 				"fieldNamespace": "",
+				"fieldReference": "Grid",
 				"rows": {
 					"en_US": [
 						{
@@ -303,6 +309,7 @@
 			"customProperties": {
 				"dataType": "string",
 				"fieldNamespace": "",
+				"fieldReference": "Image",
 				"visibilityExpression": ""
 			},
 			"defaultValue": {
@@ -333,6 +340,7 @@
 			"customProperties": {
 				"dataType": "journal-article",
 				"fieldNamespace": "",
+				"fieldReference": "WebContent",
 				"visibilityExpression": ""
 			},
 			"defaultValue": {
@@ -363,6 +371,7 @@
 			"customProperties": {
 				"dataType": "link-to-page",
 				"fieldNamespace": "",
+				"fieldReference": "LinkToPage",
 				"visibilityExpression": ""
 			},
 			"defaultValue": {
@@ -393,6 +402,7 @@
 			"customProperties": {
 				"dataType": "integer",
 				"fieldNamespace": "",
+				"fieldReference": "Numeric",
 				"placeholder": {
 					"en_US": "Placeholder Text",
 					"pt_BR": "Texto Placeholder"
@@ -439,6 +449,7 @@
 			"customProperties": {
 				"dataType": "string",
 				"fieldNamespace": "",
+				"fieldReference": "SingleSelection",
 				"inline": true,
 				"options": {
 					"en_US": [
@@ -506,6 +517,7 @@
 			"customProperties": {
 				"dataType": "string",
 				"fieldNamespace": "",
+				"fieldReference": "RichText",
 				"visibilityExpression": ""
 			},
 			"defaultValue": {
@@ -541,6 +553,7 @@
 				"ddmDataProviderInstanceOutput": [
 				],
 				"fieldNamespace": "",
+				"fieldReference": "SelectFromList",
 				"multiple": true,
 				"options": {
 					"en_US": [
@@ -607,6 +620,7 @@
 		{
 			"customProperties": {
 				"dataType": "",
+				"fieldReference": "Separator",
 				"style": {
 					"en_US": "",
 					"pt_BR": ""
@@ -638,6 +652,7 @@
 				"dataType": "string",
 				"displayStyle": "multiline",
 				"fieldNamespace": "",
+				"fieldReference": "Text",
 				"options": {
 				},
 				"placeholder": {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/bnd.bnd
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Dynamic Data Mapping API
 Bundle-SymbolicName: com.liferay.dynamic.data.mapping.api
-Bundle-Version: 19.0.1
+Bundle-Version: 19.1.0
 Export-Package:\
 	com.liferay.dynamic.data.mapping.annotations,\
 	com.liferay.dynamic.data.mapping.configuration,\

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/validator/DDMFormValidationException.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/validator/DDMFormValidationException.java
@@ -87,6 +87,28 @@ public class DDMFormValidationException extends PortalException {
 
 	}
 
+	public static class MustNotDuplicateFieldReference
+		extends DDMFormValidationException {
+
+		public MustNotDuplicateFieldReference(
+			Set<String> duplicatedFieldReferences) {
+
+			super(
+				String.format(
+					"Field references %s were defined more than once",
+					duplicatedFieldReferences));
+
+			_duplicatedFieldReferences = duplicatedFieldReferences;
+		}
+
+		public Set<String> getDuplicatedFieldReferences() {
+			return _duplicatedFieldReferences;
+		}
+
+		private final Set<String> _duplicatedFieldReferences;
+
+	}
+
 	public static class MustSetAvailableLocales
 		extends DDMFormValidationException {
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/resources/com/liferay/dynamic/data/mapping/validator/packageinfo
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/resources/com/liferay/dynamic/data/mapping/validator/packageinfo
@@ -1,1 +1,1 @@
-version 1.6.0
+version 1.7.0

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-validator/src/test/java/com/liferay/dynamic/data/mapping/validator/internal/DDMFormValidatorTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-validator/src/test/java/com/liferay/dynamic/data/mapping/validator/internal/DDMFormValidatorTest.java
@@ -160,15 +160,17 @@ public class DDMFormValidatorTest {
 			createAvailableLocales(LocaleUtil.US), LocaleUtil.US);
 
 		ddmForm.addDDMFormField(
-			new DDMFormField("Name1", DDMFormFieldType.TEXT));
+			_createDDMFormField(
+				"FieldReference1", "Name1", DDMFormFieldType.TEXT));
 
-		DDMFormField name2DDMFormField = new DDMFormField(
-			"Name2", DDMFormFieldType.TEXT);
+		DDMFormField ddmFormField = _createDDMFormField(
+			"FieldReference2", "Name2", DDMFormFieldType.TEXT);
 
-		name2DDMFormField.addNestedDDMFormField(
-			new DDMFormField("Name1", DDMFormFieldType.TEXT));
+		ddmFormField.addNestedDDMFormField(
+			_createDDMFormField(
+				"FieldReference3", "Name1", DDMFormFieldType.TEXT));
 
-		ddmForm.addDDMFormField(name2DDMFormField);
+		ddmForm.addDDMFormField(ddmFormField);
 
 		_ddmFormValidatorImpl.validate(ddmForm);
 	}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-validator/src/test/java/com/liferay/dynamic/data/mapping/validator/internal/DDMFormValidatorTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-validator/src/test/java/com/liferay/dynamic/data/mapping/validator/internal/DDMFormValidatorTest.java
@@ -27,6 +27,7 @@ import com.liferay.dynamic.data.mapping.model.DDMFormRule;
 import com.liferay.dynamic.data.mapping.model.LocalizedValue;
 import com.liferay.dynamic.data.mapping.test.util.DDMFormTestUtil;
 import com.liferay.dynamic.data.mapping.validator.DDMFormValidationException.MustNotDuplicateFieldName;
+import com.liferay.dynamic.data.mapping.validator.DDMFormValidationException.MustNotDuplicateFieldReference;
 import com.liferay.dynamic.data.mapping.validator.DDMFormValidationException.MustSetAvailableLocales;
 import com.liferay.dynamic.data.mapping.validator.DDMFormValidationException.MustSetDefaultLocale;
 import com.liferay.dynamic.data.mapping.validator.DDMFormValidationException.MustSetDefaultLocaleAsAvailableLocale;
@@ -168,6 +169,27 @@ public class DDMFormValidatorTest {
 			new DDMFormField("Name1", DDMFormFieldType.TEXT));
 
 		ddmForm.addDDMFormField(name2DDMFormField);
+
+		_ddmFormValidatorImpl.validate(ddmForm);
+	}
+
+	@Test(expected = MustNotDuplicateFieldReference.class)
+	public void testDuplicateFieldReference() throws Exception {
+		DDMForm ddmForm = DDMFormTestUtil.createDDMForm(
+			createAvailableLocales(LocaleUtil.US), LocaleUtil.US);
+
+		ddmForm.addDDMFormField(
+			_createDDMFormField(
+				"FieldReference1", "Name1", DDMFormFieldType.TEXT));
+
+		DDMFormField ddmFormField = _createDDMFormField(
+			"FieldReference2", "Name2", DDMFormFieldType.TEXT);
+
+		ddmFormField.addNestedDDMFormField(
+			_createDDMFormField(
+				"fieldReference1", "Name3", DDMFormFieldType.TEXT));
+
+		ddmForm.addDDMFormField(ddmFormField);
 
 		_ddmFormValidatorImpl.validate(ddmForm);
 	}
@@ -567,6 +589,16 @@ public class DDMFormValidatorTest {
 
 	protected Set<Locale> createAvailableLocales(Locale... locales) {
 		return DDMFormTestUtil.createAvailableLocales(locales);
+	}
+
+	private DDMFormField _createDDMFormField(
+		String fieldReference, String name, String type) {
+
+		DDMFormField ddmFormField = new DDMFormField(name, type);
+
+		ddmFormField.setFieldReference(fieldReference);
+
+		return ddmFormField;
 	}
 
 	private void _setUpBeanPropertiesUtil() {


### PR DESCRIPTION
[LPS-170221](https://issues.liferay.com/browse/LPS-170221) The bug was happening because there was no validation for if the fields of the dataDefinition had duplicate references. 
The solution was to create a new method to do this validation and have it throw a custom exception.
