### PR TITLE
LPS-154627 Improve Forms Accessibility

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/ColorPicker/ColorPicker.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/ColorPicker/ColorPicker.es.js
@@ -33,6 +33,7 @@ const DEFAULT_COLORS = [
 ];
 
 const ClayColorPickerWithState = ({
+	id,
 	inputValue,
 	name,
 	onBlur,
@@ -59,6 +60,7 @@ const ClayColorPickerWithState = ({
 			<ClayColorPicker
 				colors={customColors}
 				disabled={readOnly}
+				id={id}
 				label={Liferay.Language.get('color-field-type-label')}
 				onBlur={onBlur}
 				onColorsChange={setCustoms}
@@ -136,6 +138,8 @@ const ColorPicker = ({
 		observer.observe(colorDropdownNode, {attributes: true});
 	};
 
+	const fieldDetailsId = `${name}_fieldDetails`;
+
 	return (
 		<FieldBase
 			name={name}
@@ -145,6 +149,7 @@ const ColorPicker = ({
 			{...otherProps}
 		>
 			<ClayColorPickerWithState
+				id={fieldDetailsId}
 				inputValue={value ? value : predefinedValue}
 				name={name}
 				onBlur={onBlur}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/DatePicker/DatePicker.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/DatePicker/DatePicker.es.js
@@ -250,6 +250,8 @@ export default function DatePicker({
 		}
 	};
 
+	const fieldDetailsId = `${name}_fieldDetails`;
+
 	return (
 		<FieldBase
 			localizedValue={localizedValue}
@@ -263,6 +265,7 @@ export default function DatePicker({
 				disabled={readOnly}
 				expanded={expanded}
 				firstDayOfWeek={firstDayOfWeek}
+				id={fieldDetailsId}
 				months={months}
 				onBlur={onBlur}
 				onExpandedChange={handleExpandedChange}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
@@ -210,7 +210,9 @@ export function FieldBase({
 		warningMessage,
 	});
 
-	const fieldDetailsId = `${id ?? name}_fieldDetails`;
+	const fieldDetailsId = `${id ?? name}${
+		type === 'document_library' ? 'inputFile' : '_fieldDetails'
+	}`;
 
 	const hiddenTranslations = useMemo(() => {
 		if (!localizedValue) {
@@ -243,15 +245,13 @@ export function FieldBase({
 		type === 'radio';
 	const showPopover = fieldName === 'inputMaskFormat';
 	const showFor =
-		type === 'text' ||
-		type === 'numeric' ||
-		type === 'image' ||
-		type === 'search_location' ||
-		type === 'select';
+		type === 'text' || type === 'numeric' || type === 'search_location';
 
 	const accessibleProps = {
-		...(accessible && fieldDetails && {'aria-labelledby': fieldDetailsId}),
-		...(showFor ? {htmlFor: id ?? name} : {tabIndex: 0}),
+		...(!showFor &&
+			accessible &&
+			fieldDetails && {htmlFor: fieldDetailsId}),
+		...(showFor ? {htmlFor: id ?? name} : ''),
 	};
 
 	const defaultRows = nestedFields?.map((field) => ({
@@ -404,16 +404,6 @@ export function FieldBase({
 				helpMessage={typeof tip === 'string' ? tip : undefined}
 				warningMessage={warningMessage}
 			/>
-
-			{accessible && fieldDetails && (
-				<span
-					className="sr-only"
-					dangerouslySetInnerHTML={{
-						__html: fieldDetails,
-					}}
-					id={fieldDetailsId}
-				/>
-			)}
 
 			{defaultRows && <Layout itemPath={itemPath} rows={defaultRows} />}
 		</ClayForm.Group>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/ImagePicker/ImagePicker.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/ImagePicker/ImagePicker.es.js
@@ -288,6 +288,8 @@ const Main = ({
 		return null;
 	};
 
+	const fieldDetailsId = `${id ?? name}_fieldDetails`;
+
 	return (
 		<FieldBase
 			{...otherProps}
@@ -300,7 +302,7 @@ const Main = ({
 		>
 			<ImagePicker
 				editingLanguageId={editingLanguageId}
-				id={id ?? name}
+				id={fieldDetailsId}
 				inputValue={
 					transformValue(inputValue) ??
 					transformValue(value) ??

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Radio/Radio.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Radio/Radio.es.js
@@ -67,10 +67,11 @@ const Radio = ({
 					<ClayRadio
 						checked={currentValue === option.value}
 						disabled={disabled}
+						id={`${name}_${index}`}
 						inline={inline}
 						key={option.value}
 						label={option.label}
-						name={`${name}_${index}`}
+						name={name}
 						onChange={(event) => {
 							setCurrentValue(option.value);
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Select/Select.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Select/Select.es.js
@@ -250,6 +250,7 @@ const DropdownListWithSearch = ({
 const Trigger = forwardRef(
 	(
 		{
+			fieldDetailsId,
 			onCloseButtonClicked,
 			onTriggerClicked,
 			onTriggerKeyDown,
@@ -265,6 +266,7 @@ const Trigger = forwardRef(
 					<HiddenSelectInput value={value} {...otherProps} />
 				)}
 				<VisibleSelectInput
+					fieldDetailsId={fieldDetailsId}
 					onClick={onTriggerClicked}
 					onCloseButtonClicked={onCloseButtonClicked}
 					onKeyDown={onTriggerKeyDown}
@@ -280,6 +282,7 @@ const Trigger = forwardRef(
 
 const Select = ({
 	defaultSearch,
+	fieldDetailsId,
 	multiple,
 	onCloseButtonClicked,
 	onDropdownItemClicked,
@@ -360,6 +363,7 @@ const Select = ({
 	return (
 		<>
 			<Trigger
+				fieldDetailsId={fieldDetailsId}
 				multiple={multiple}
 				onCloseButtonClicked={({event, value}) => {
 					const newValue = removeValue({
@@ -496,6 +500,8 @@ const Main = ({
 	const predefinedValueArray = toArray(predefinedValue);
 	const valueArray = toArray(value);
 
+	const fieldDetailsId = `${name}_fieldDetails`;
+
 	const normalizedOptions = useMemo(
 		() =>
 			normalizeOptions({
@@ -538,6 +544,7 @@ const Main = ({
 		>
 			<Select
 				defaultSearch={defaultSearch}
+				fieldDetailsId={fieldDetailsId}
 				multiple={multiple}
 				name={`${name}_field`}
 				onCloseButtonClicked={({event, value}) =>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Select/VisibleSelectInput.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Select/VisibleSelectInput.es.js
@@ -14,7 +14,6 @@
 
 import './VisibleSelectInput.scss';
 
-import ClayIcon from '@clayui/icon';
 import ClayLabel from '@clayui/label';
 import classNames from 'classnames';
 import React, {forwardRef} from 'react';
@@ -41,20 +40,20 @@ const LabelOptionListItem = ({onCloseButtonClicked, option, readOnly}) => (
 );
 
 const OptionSelected = ({isPlaceholder, label}) => (
-	<div
+	<span
 		className={classNames('option-selected', {
 			'option-selected-placeholder': isPlaceholder,
 		})}
 	>
 		{label}
-	</div>
+	</span>
 );
 
 const VisibleSelectInput = forwardRef(
 	(
 		{
 			className,
-			id,
+			fieldDetailsId,
 			multiple,
 			onClick,
 			onCloseButtonClicked,
@@ -94,17 +93,18 @@ const VisibleSelectInput = forwardRef(
 				onKeyDown={onKeyDown}
 				ref={ref}
 			>
-				<div
+				<button
+					aria-haspopup="listbox"
 					className={classNames(
-						'form-control results-chosen select-field-trigger',
+						'form-control form-control-select results-chosen select-field-trigger',
 						{
 							'disabled': readOnly,
 							'multiple-label-list': multiple,
 						}
 					)}
 					disabled={readOnly}
-					id={id}
-					tabIndex="0"
+					id={fieldDetailsId}
+					type="button"
 				>
 					{isValueEmpty || (value.length === 1 && !multiple) ? (
 						<OptionSelected
@@ -135,13 +135,7 @@ const VisibleSelectInput = forwardRef(
 							})}
 						</>
 					)}
-
-					<div className="lfr__ddm-form-field-type-select-arrow-down">
-						<a className="select-arrow-down-container">
-							<ClayIcon symbol="caret-double" />
-						</a>
-					</div>
-				</div>
+				</button>
 			</div>
 		);
 	}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-154627

This pr maps the form element's `<label>` to the visible input and other accessibility fixes. This provides a few benefits:

1) Clicking on the `label` will focus the input
2) Screen readers will announce the label text when an input is focused
3) We don't need an `sr-only` element to announce text

Edit: Currently rerunning tests, but it looks like the failures are related to changing `div` to `button` at https://github.com/liferay-forms/liferay-portal/blob/741c56c5fc1a0c058cc66ac172c992aafd43e50d/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Select/VisibleSelectInput.es.js#L96. Can we update the tests to account for this?
