### PR TITLE
[TS] LPS-170829 Add updateRecord method with fieldsMap input to DLL services to make it callable from JSONWS API

### DIFF
--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-api/bnd.bnd
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Dynamic Data Lists API
 Bundle-SymbolicName: com.liferay.dynamic.data.lists.api
-Bundle-Version: 8.2.1
+Bundle-Version: 8.3.0
 Export-Package:\
 	com.liferay.dynamic.data.lists.constants,\
 	com.liferay.dynamic.data.lists.exception,\

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-api/src/main/java/com/liferay/dynamic/data/lists/service/DDLRecordLocalService.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-api/src/main/java/com/liferay/dynamic/data/lists/service/DDLRecordLocalService.java
@@ -660,6 +660,13 @@ public interface DDLRecordLocalService
 
 	@Indexable(type = IndexableType.REINDEX)
 	public DDLRecord updateRecord(
+			long userId, long recordId, int displayIndex,
+			Map<String, Serializable> fieldsMap, boolean mergeFields,
+			ServiceContext serviceContext)
+		throws PortalException;
+
+	@Indexable(type = IndexableType.REINDEX)
+	public DDLRecord updateRecord(
 			long userId, long recordId, long ddmStorageId,
 			ServiceContext serviceContext)
 		throws PortalException;

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-api/src/main/java/com/liferay/dynamic/data/lists/service/DDLRecordLocalServiceUtil.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-api/src/main/java/com/liferay/dynamic/data/lists/service/DDLRecordLocalServiceUtil.java
@@ -756,6 +756,17 @@ public class DDLRecordLocalServiceUtil {
 	}
 
 	public static DDLRecord updateRecord(
+			long userId, long recordId, int displayIndex,
+			Map<String, Serializable> fieldsMap, boolean mergeFields,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws PortalException {
+
+		return getService().updateRecord(
+			userId, recordId, displayIndex, fieldsMap, mergeFields,
+			serviceContext);
+	}
+
+	public static DDLRecord updateRecord(
 			long userId, long recordId, long ddmStorageId,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-api/src/main/java/com/liferay/dynamic/data/lists/service/DDLRecordLocalServiceWrapper.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-api/src/main/java/com/liferay/dynamic/data/lists/service/DDLRecordLocalServiceWrapper.java
@@ -829,6 +829,19 @@ public class DDLRecordLocalServiceWrapper
 
 	@Override
 	public DDLRecord updateRecord(
+			long userId, long recordId, int displayIndex,
+			java.util.Map<String, java.io.Serializable> fieldsMap,
+			boolean mergeFields,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _ddlRecordLocalService.updateRecord(
+			userId, recordId, displayIndex, fieldsMap, mergeFields,
+			serviceContext);
+	}
+
+	@Override
+	public DDLRecord updateRecord(
 			long userId, long recordId, long ddmStorageId,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-api/src/main/java/com/liferay/dynamic/data/lists/service/DDLRecordService.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-api/src/main/java/com/liferay/dynamic/data/lists/service/DDLRecordService.java
@@ -167,4 +167,25 @@ public interface DDLRecordService extends BaseService {
 			DDMFormValues ddmFormValues, ServiceContext serviceContext)
 		throws PortalException;
 
+	/**
+	 * Updates a record, replacing its display index and values.
+	 *
+	 * @param recordId the primary key of the record
+	 * @param displayIndex the index position in which the record is
+	 displayed in the spreadsheet view
+	 * @param fieldsMap the record values. The fieldsMap is a map of field
+	 names and its Serializable values.
+	 * @param mergeFields whether to merge the new fields with the existing
+	 ones; otherwise replace the existing fields
+	 * @param serviceContext the service context to be applied. This can
+	 set the record modified date.
+	 * @return the record
+	 * @throws PortalException if a portal exception occurred
+	 */
+	public DDLRecord updateRecord(
+			long recordId, int displayIndex,
+			Map<String, Serializable> fieldsMap, boolean mergeFields,
+			ServiceContext serviceContext)
+		throws PortalException;
+
 }

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-api/src/main/java/com/liferay/dynamic/data/lists/service/DDLRecordServiceUtil.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-api/src/main/java/com/liferay/dynamic/data/lists/service/DDLRecordServiceUtil.java
@@ -180,6 +180,31 @@ public class DDLRecordServiceUtil {
 			serviceContext);
 	}
 
+	/**
+	 * Updates a record, replacing its display index and values.
+	 *
+	 * @param recordId the primary key of the record
+	 * @param displayIndex the index position in which the record is
+	 displayed in the spreadsheet view
+	 * @param fieldsMap the record values. The fieldsMap is a map of field
+	 names and its Serializable values.
+	 * @param mergeFields whether to merge the new fields with the existing
+	 ones; otherwise replace the existing fields
+	 * @param serviceContext the service context to be applied. This can
+	 set the record modified date.
+	 * @return the record
+	 * @throws PortalException if a portal exception occurred
+	 */
+	public static DDLRecord updateRecord(
+			long recordId, int displayIndex,
+			Map<String, Serializable> fieldsMap, boolean mergeFields,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws PortalException {
+
+		return getService().updateRecord(
+			recordId, displayIndex, fieldsMap, mergeFields, serviceContext);
+	}
+
 	public static DDLRecordService getService() {
 		return _service;
 	}

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-api/src/main/java/com/liferay/dynamic/data/lists/service/DDLRecordServiceWrapper.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-api/src/main/java/com/liferay/dynamic/data/lists/service/DDLRecordServiceWrapper.java
@@ -185,6 +185,33 @@ public class DDLRecordServiceWrapper
 			serviceContext);
 	}
 
+	/**
+	 * Updates a record, replacing its display index and values.
+	 *
+	 * @param recordId the primary key of the record
+	 * @param displayIndex the index position in which the record is
+	 displayed in the spreadsheet view
+	 * @param fieldsMap the record values. The fieldsMap is a map of field
+	 names and its Serializable values.
+	 * @param mergeFields whether to merge the new fields with the existing
+	 ones; otherwise replace the existing fields
+	 * @param serviceContext the service context to be applied. This can
+	 set the record modified date.
+	 * @return the record
+	 * @throws PortalException if a portal exception occurred
+	 */
+	@Override
+	public DDLRecord updateRecord(
+			long recordId, int displayIndex,
+			java.util.Map<String, java.io.Serializable> fieldsMap,
+			boolean mergeFields,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _ddlRecordService.updateRecord(
+			recordId, displayIndex, fieldsMap, mergeFields, serviceContext);
+	}
+
 	@Override
 	public DDLRecordService getWrappedService() {
 		return _ddlRecordService;

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-api/src/main/resources/com/liferay/dynamic/data/lists/service/packageinfo
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-api/src/main/resources/com/liferay/dynamic/data/lists/service/packageinfo
@@ -1,1 +1,1 @@
-version 2.6.0
+version 2.7.0

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/service/http/DDLRecordServiceHttp.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/service/http/DDLRecordServiceHttp.java
@@ -337,6 +337,50 @@ public class DDLRecordServiceHttp {
 		}
 	}
 
+	public static com.liferay.dynamic.data.lists.model.DDLRecord updateRecord(
+			HttpPrincipal httpPrincipal, long recordId, int displayIndex,
+			java.util.Map<String, java.io.Serializable> fieldsMap,
+			boolean mergeFields,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				DDLRecordServiceUtil.class, "updateRecord",
+				_updateRecordParameterTypes7);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, recordId, displayIndex, fieldsMap, mergeFields,
+				serviceContext);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.dynamic.data.lists.model.DDLRecord)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
 	private static Log _log = LogFactoryUtil.getLog(DDLRecordServiceHttp.class);
 
 	private static final Class<?>[] _addRecordParameterTypes0 = new Class[] {
@@ -364,6 +408,10 @@ public class DDLRecordServiceHttp {
 	private static final Class<?>[] _updateRecordParameterTypes6 = new Class[] {
 		long.class, boolean.class, int.class,
 		com.liferay.dynamic.data.mapping.storage.DDMFormValues.class,
+		com.liferay.portal.kernel.service.ServiceContext.class
+	};
+	private static final Class<?>[] _updateRecordParameterTypes7 = new Class[] {
+		long.class, int.class, java.util.Map.class, boolean.class,
 		com.liferay.portal.kernel.service.ServiceContext.class
 	};
 

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/service/impl/DDLRecordServiceImpl.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/service/impl/DDLRecordServiceImpl.java
@@ -209,6 +209,38 @@ public class DDLRecordServiceImpl extends DDLRecordServiceBaseImpl {
 			serviceContext);
 	}
 
+	/**
+	 * Updates a record, replacing its display index and values.
+	 *
+	 * @param      recordId the primary key of the record
+	 * @param      displayIndex the index position in which the record is
+	 *             displayed in the spreadsheet view
+	 * @param      fieldsMap the record values. The fieldsMap is a map of field
+	 *             names and its Serializable values.
+	 * @param      mergeFields whether to merge the new fields with the existing
+	 *             ones; otherwise replace the existing fields
+	 * @param      serviceContext the service context to be applied. This can
+	 *             set the record modified date.
+	 * @return     the record
+	 * @throws     PortalException if a portal exception occurred
+	 */
+	@Override
+	public DDLRecord updateRecord(
+			long recordId, int displayIndex,
+			Map<String, Serializable> fieldsMap, boolean mergeFields,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		DDLRecord record = ddlRecordLocalService.getDDLRecord(recordId);
+
+		_ddlRecordSetModelResourcePermission.check(
+			getPermissionChecker(), record.getRecordSetId(), ActionKeys.UPDATE);
+
+		return ddlRecordLocalService.updateRecord(
+			getUserId(), recordId, displayIndex, fieldsMap, mergeFields,
+			serviceContext);
+	}
+
 	@Reference(
 		target = "(model.class.name=com.liferay.dynamic.data.lists.model.DDLRecordSet)"
 	)


### PR DESCRIPTION
Hi Team,

This fix is a sequel to: [LPS-166188](https://issues.liferay.com/browse/LPS-166188)
Previous PR: https://github.com/liferay-forms/liferay-portal/pull/2027

The customer was satisfied with the previous fix that re-introduced the add-record endpoint with fieldsMap in JSONWS API, but they also need the update-record method.

Solution:
Just like the first time, I (re)implemented the update endpoint with "fieldsMap" input.

Please review my PR!

Thank you and best regards,
Évi