### PR TITLE
[TS] LPP-47463 > LPS-171451 Cannot upload a file in a Select Document modal window inside a Form

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMUserPersonalFolderItemSelectorViewDisplayContext.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMUserPersonalFolderItemSelectorViewDisplayContext.java
@@ -74,6 +74,10 @@ public class DDMUserPersonalFolderItemSelectorViewDisplayContext {
 			_httpServletRequest);
 	}
 
+	public long getFolderId(){
+		return _ddmUserPersonalFolderItemSelectorCriterion.getFolderId();
+	}
+
 	public String getItemSelectedEventName() {
 		return _itemSelectedEventName;
 	}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/item_selector/user_personal_folder.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/item_selector/user_personal_folder.jsp
@@ -31,4 +31,5 @@ DDMUserPersonalFolderItemSelectorViewDisplayContext ddmUserPersonalFolderItemSel
 	showSearch="<%= false %>"
 	tabName="<%= ddmUserPersonalFolderItemSelectorViewDisplayContext.getTitle(locale) %>"
 	uploadURL="<%= ddmUserPersonalFolderItemSelectorViewDisplayContext.getUploadURL(liferayPortletResponse) %>"
+	folderId="<%= ddmUserPersonalFolderItemSelectorViewDisplayContext.getFolderId() %>"
 />

--- a/modules/apps/item-selector/item-selector-taglib/src/main/java/com/liferay/item/selector/taglib/internal/display/context/ItemSelectorRepositoryEntryManagementToolbarDisplayContext.java
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/java/com/liferay/item/selector/taglib/internal/display/context/ItemSelectorRepositoryEntryManagementToolbarDisplayContext.java
@@ -15,6 +15,7 @@
 package com.liferay.item.selector.taglib.internal.display.context;
 
 import com.liferay.document.library.display.context.DLUIItemKeys;
+import com.liferay.document.library.kernel.service.DLAppLocalServiceUtil;
 import com.liferay.document.library.portlet.toolbar.contributor.DLPortletToolbarContributor;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
@@ -27,7 +28,10 @@ import com.liferay.item.selector.taglib.internal.document.library.portlet.toolba
 import com.liferay.item.selector.taglib.servlet.taglib.RepositoryEntryBrowserTag;
 import com.liferay.item.selector.taglib.servlet.taglib.util.RepositoryEntryBrowserTagUtil;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
@@ -35,6 +39,7 @@ import com.liferay.portal.kernel.portlet.PortalPreferences;
 import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.portlet.PortletURLUtil;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
+import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.servlet.taglib.ui.Menu;
 import com.liferay.portal.kernel.servlet.taglib.ui.URLMenuItem;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -94,6 +99,9 @@ public class ItemSelectorRepositoryEntryManagementToolbarDisplayContext {
 		DLPortletToolbarContributor dlPortletToolbarContributor =
 			DLPortletToolbarContributorRegistryUtil.
 				getDLPortletToolbarContributor();
+
+		_liferayPortletRequest.setAttribute(
+			WebKeys.DOCUMENT_LIBRARY_FOLDER, _getFolder());
 
 		List<Menu> menus = dlPortletToolbarContributor.getPortletTitleMenus(
 			_liferayPortletRequest, _liferayPortletResponse);
@@ -342,6 +350,23 @@ public class ItemSelectorRepositoryEntryManagementToolbarDisplayContext {
 		return RepositoryEntryBrowserTag.DISPLAY_STYLES;
 	}
 
+	private Folder _getFolder() {
+		long folderId = GetterUtil.getLong(
+			_httpServletRequest.getAttribute(
+				"liferay-item-selector:repository-entry-browser:folderId"));
+
+		Folder folder = null;
+
+		try {
+			folder = DLAppLocalServiceUtil.getFolder(folderId);
+		}
+		catch (PortalException portalException) {
+			_log.error(portalException);
+		}
+
+		return folder;
+	}
+
 	private String _getOrderByCol() {
 		if (_orderByCol != null) {
 			return _orderByCol;
@@ -412,6 +437,9 @@ public class ItemSelectorRepositoryEntryManagementToolbarDisplayContext {
 
 		return _showScopeFilter;
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		ItemSelectorRepositoryEntryManagementToolbarDisplayContext.class);
 
 	private final PortletURL _currentURLObj;
 	private final HttpServletRequest _httpServletRequest;

--- a/modules/apps/item-selector/item-selector-taglib/src/main/java/com/liferay/item/selector/taglib/servlet/taglib/RepositoryEntryBrowserTag.java
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/java/com/liferay/item/selector/taglib/servlet/taglib/RepositoryEntryBrowserTag.java
@@ -68,6 +68,10 @@ public class RepositoryEntryBrowserTag extends IncludeTag {
 		return _extensions;
 	}
 
+	public long getFolderId() {
+		return _folderId;
+	}
+
 	public String getItemSelectedEventName() {
 		return _itemSelectedEventName;
 	}
@@ -160,6 +164,10 @@ public class RepositoryEntryBrowserTag extends IncludeTag {
 		_extensions = extensions;
 	}
 
+	public void setFolderId(long folderId) {
+		_folderId = folderId;
+	}
+
 	public void setItemSelectedEventName(String itemSelectedEventName) {
 		_itemSelectedEventName = itemSelectedEventName;
 	}
@@ -228,6 +236,7 @@ public class RepositoryEntryBrowserTag extends IncludeTag {
 		_editImageURL = null;
 		_emptyResultsMessage = null;
 		_extensions = new ArrayList<>();
+		_folderId = 0;
 		_itemSelectedEventName = null;
 		_itemSelectorReturnTypeResolver = null;
 		_maxFileSize = UploadServletRequestConfigurationHelperUtil.getMaxSize();
@@ -326,6 +335,9 @@ public class RepositoryEntryBrowserTag extends IncludeTag {
 		}
 
 		httpServletRequest.setAttribute(
+			"liferay-item-selector:repository-entry-browser:folderId",
+			_folderId);
+		httpServletRequest.setAttribute(
 			"liferay-item-selector:repository-entry-browser:" +
 				"itemSelectedEventName",
 			_itemSelectedEventName);
@@ -388,6 +400,7 @@ public class RepositoryEntryBrowserTag extends IncludeTag {
 	private PortletURL _editImageURL;
 	private String _emptyResultsMessage;
 	private List<String> _extensions = new ArrayList<>();
+	private long _folderId;
 	private String _itemSelectedEventName;
 	private ItemSelectorReturnTypeResolver<?, ?>
 		_itemSelectorReturnTypeResolver;

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/liferay-item-selector.tld
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/liferay-item-selector.tld
@@ -137,6 +137,12 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
+			<description>The target folder for the new files that are uploaded.</description>
+			<name>folderId</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
 			<description>The name of the event to be thrown once an image is selected.</description>
 			<name>itemSelectedEventName</name>
 			<required>true</required>

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/page.jsp
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/page.jsp
@@ -24,6 +24,7 @@ PortletURL editImageURL = (PortletURL)request.getAttribute("liferay-item-selecto
 String emptyResultsMessage = GetterUtil.getString(request.getAttribute("liferay-item-selector:repository-entry-browser:emptyResultsMessage"));
 ItemSelectorReturnType existingFileEntryReturnType = (ItemSelectorReturnType)request.getAttribute("liferay-item-selector:repository-entry-browser:existingFileEntryReturnType");
 List<String> extensions = (List)request.getAttribute("liferay-item-selector:repository-entry-browser:extensions");
+long folderId = GetterUtil.getLong(request.getAttribute("liferay-item-selector:repository-entry-browser:folderId"));
 String itemSelectedEventName = GetterUtil.getString(request.getAttribute("liferay-item-selector:repository-entry-browser:itemSelectedEventName"));
 ItemSelectorReturnTypeResolver<?, FileEntry> itemSelectorReturnTypeResolver = (ItemSelectorReturnTypeResolver<?, FileEntry>)request.getAttribute("liferay-item-selector:repository-entry-browser:itemSelectorReturnTypeResolver");
 long maxFileSize = GetterUtil.getLong(request.getAttribute("liferay-item-selector:repository-entry-browser:maxFileSize"));
@@ -98,10 +99,6 @@ SearchContainer<?> searchContainer = new SearchContainer(renderRequest, itemSele
 	</c:if>
 
 	<div class="message-container"></div>
-
-	<%
-	long folderId = ParamUtil.getLong(request, "folderId");
-	%>
 
 	<c:if test="<%= showBreadcrumb && !showSearchInfo %>">
 


### PR DESCRIPTION
Motivation
============
This work solves the problem reported in the [LPS-171451](https://issues.liferay.com/browse/LPS-171451) ticket.
cc: @quanhuynhces 

**1. Cause:** The upload files are stored in the default folder for Document and Media upload files. So they are not listed in the Form-field-upload-folder. The folder was null so it return to the default `folderId` (https://github.com/liferay/liferay-portal-ee/blob/470587ce0ffccb77ff770cb15bb88e486cd0f447/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/toolbar/contributor/helper/MenuItemProvider.java#L98) 
**2. What we did to solve this problem:**
We should create an attribute to store `folderId` for Form-field-upload-folder and set it to the request. So when it gets the `folderId` of the request, it can get the right folder for Form-field-upload-folder (https://github.com/liferay/liferay-portal-ee/blob/470587ce0ffccb77ff770cb15bb88e486cd0f447/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/toolbar/contributor/helper/DLPortletToolbarContributorHelper.java#L46)

Steps to reproduce
=============
1. Go to default site > Contents & Data > Forms > + (New Form)
2. Drag Upload fields from the sidebar and publish
3. Go to Site Builder > Pages > + > Page > Blank
4. Create New Page and add Form Widget
5. Click (⋮)Options on right side > Configuration
6. Select Form name in Step1 and Save
7. Close Form-Configuration window and Publish
8. Go to page in step3
9. Click Select button upload a new file
10. Click +(New) > File Upload
(Don't Use "Drag & Drop Your Files or Browse to Upload" function)
11. Select File and Publish
12. Note the uploaded file is not listed
- Actual result: No file is uploaded. 
- Expected result : File is uploaded successfully and can be selected for the form.