### PR TITLE
[TECHNICAL SUPPORT] LPS-170823 Web content's repeatable field's value is switched during localization

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
@@ -296,6 +296,7 @@ JournalEditArticleDisplayContext journalEditArticleDisplayContext = new JournalE
 					defaultLanguageId="<%= journalEditArticleDisplayContext.getDefaultArticleLanguageId() %>"
 					languageId="<%= journalEditArticleDisplayContext.getSelectedLanguageId() %>"
 					namespace="<%= liferayPortletResponse.getNamespace() %>"
+					persistDefaultValues="<%= true %>"
 					persisted="<%= article != null %>"
 					submittable="<%= false %>"
 				/>


### PR DESCRIPTION
Hey,

In order to not distrupt the order of repeated fields we have to store the default values as well. The solution was created based on the information I got from https://issues.liferay.com/browse/PTR-3567

Please review