### PR TITLE
LPS-172189 Add up and down arrow functionality for sidebar panel

### DIFF
--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/components/sidebar/MultiPanelSidebar.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/components/sidebar/MultiPanelSidebar.es.js
@@ -113,6 +113,41 @@ export default function MultiPanelSidebar({
 			sidebarPanelId,
 		});
 
+	const handleKeyDown = (event) => {
+		if (event.keyCode === 38) {
+			let arrayIndex = 0;
+			const panelArr = [...panels[0]];
+
+			panelArr.map((panelId, index) => {
+				if (panelId === event.target.id) {
+					arrayIndex = index - 1;
+
+					if (arrayIndex >= 0) {
+						const button = panels[0][arrayIndex];
+
+						document.querySelector('#' + button).focus();
+					}
+				}
+			});
+		}
+		else if (event.keyCode === 40) {
+			let arrayIndex = 0;
+			const panelArr = [...panels[0]];
+
+			panelArr.map((panelId, index) => {
+				if (panelId === event.target.id) {
+					arrayIndex = index + 1;
+
+					if (arrayIndex <= panels[0].length - 1) {
+						const button = panels[0][arrayIndex];
+
+						document.querySelector('#' + button).focus();
+					}
+				}
+			});
+		}
+	};
+
 	return (
 		<ClayTooltipProvider>
 			<div
@@ -188,6 +223,7 @@ export default function MultiPanelSidebar({
 													handlePanelClick(panel)
 												}
 												onFocus={prefetch}
+												onKeyDown={handleKeyDown}
 												onMouseEnter={prefetch}
 												symbol={icon}
 												tabIndex={


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-172189

Updated from https://github.com/liferay-forms/liferay-portal/pull/2092.

The sidebar panel buttons are not accessible when pressing tab or up and down arrows. In order to resolve this, I added listeners for up and down arrow key presses so that it will be possible to open the other panel buttons.
Made sure the focus is being changed when pressing up and down arrow as well as not updating until the user presses enter.

Please let me know if there are any questions or comments about this.
Thank you!