### PR TITLE
LPS-170726 Accessibility fix for invalid language, use a hyphen in the language attribute

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Text/Text.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Text/Text.es.js
@@ -164,7 +164,7 @@ const Text = ({
 				dir={Liferay.Language.direction[editingLanguageId]}
 				disabled={disabled}
 				id={id}
-				lang={editingLanguageId}
+				lang={editingLanguageId?.replace('_', '-')}
 				maxLength={showCounter ? '' : maxLength}
 				name={name}
 				onBlur={(event) => {
@@ -219,7 +219,7 @@ const Textarea = ({
 				dir={Liferay.Language.direction[editingLanguageId]}
 				disabled={disabled}
 				id={id}
-				lang={editingLanguageId}
+				lang={editingLanguageId?.replace('_', '-')}
 				name={name}
 				onBlur={onBlur}
 				onChange={(event) => {
@@ -330,7 +330,7 @@ const Autocomplete = ({
 				dir={Liferay.Language.direction[editingLanguageId]}
 				disabled={disabled}
 				id={id}
-				lang={editingLanguageId}
+				lang={editingLanguageId?.replace('_', '-')}
 				name={name}
 				onBlur={onBlur}
 				onChange={(event) => {


### PR DESCRIPTION
Hi @carolmariaabb @cgmonte ,

Previous PR: https://github.com/liferay-forms/liferay-portal/pull/2085
https://issues.liferay.com/browse/LPS-170726

Tests are passed on my local with these changes. Adding the change to 2 more places seemed to be required because the error was also detectable for example when the same reproduction steps are followed, but the form is set to Multiple Lines instead of Single Lines.

Could you please review it?