### PR TITLE
[TS] LPS-173034

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMDataDefinitionConverterImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMDataDefinitionConverterImpl.java
@@ -589,9 +589,11 @@ public class DDMDataDefinitionConverterImpl
 		List<DDMFormField> ddmFormFields, Locale defaultLocale,
 		DDMFormField parentFieldSetDDMFormField) {
 
+		List<DDMFormField> newDDMFormFields = new ArrayList<>();
+
 		for (DDMFormField ddmFormField : ddmFormFields) {
 			if (ListUtil.isEmpty(ddmFormField.getNestedDDMFormFields())) {
-				parentFieldSetDDMFormField.addNestedDDMFormField(ddmFormField);
+				newDDMFormFields.add(ddmFormField);
 
 				continue;
 			}
@@ -610,9 +612,17 @@ public class DDMDataDefinitionConverterImpl
 			ddmFormField.setNestedDDMFormFields(Collections.emptyList());
 			ddmFormField.setRepeatable(false);
 
-			parentFieldSetDDMFormField.addNestedDDMFormField(
-				fieldSetDDMFormField);
+			newDDMFormFields.add(fieldSetDDMFormField);
 		}
+
+		DDMFormField fieldSetDDMFormField = _createFieldSetDDMFormField(
+			defaultLocale, parentFieldSetDDMFormField.getName() + "FieldSet",
+			newDDMFormFields, false);
+
+		fieldSetDDMFormField.setProperty(
+			"rows", _getDDMFormFieldsRows(fieldSetDDMFormField));
+
+		parentFieldSetDDMFormField.addNestedDDMFormField(fieldSetDDMFormField);
 	}
 
 	private void _upgradeNumberField(DDMFormField ddmFormField) {


### PR DESCRIPTION
Motivation
=======
This fix tries to solve case described in [LPS-173034](https://issues.liferay.com/browse/LPS-173034)

Proposed Solution
========
With this change the [original fields](https://github.com/liferay/liferay-portal/blob/master/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/resources/com/liferay/dynamic/data/mapping/util/test/dependencies/ddm-form-data-definition-json-converter-nested-fields.json) after the upgrade would be converted to the following:

`{
  "availableLanguageIds": [
    "es_ES"
  ],
  "contentType": "journal",
  "dataDefinitionFields": [
    {
      "customProperties": {
        "ddmStructureLayoutId": "",
        "ddmStructureId": "",
        "upgradedStructure": false,
        "fieldReference": "TextecoyFieldSet",
        "rows": [
          {
            "columns": [
              {
                "size": 12,
                "fields": [
                  "Textecoy"
                ]
              }
            ]
          },
          {
            "columns": [
              {
                "size": 12,
                "fields": [
                  "Textj73rFieldSet"
                ]
              }
            ]
          }
        ],
        "collapsible": false
      },
      "defaultValue": {},
      "fieldType": "fieldset",
      "indexable": false,
      "label": {
        "es_ES": ""
      },
      "localizable": false,
      "name": "TextecoyFieldSet",
      "nestedDataDefinitionFields": [
        {
          "customProperties": {
            "displayStyle": "singleline",
            "visibilityExpression": "",
            "fieldNamespace": "",
            "autocomplete": false,
            "ddmDataProviderInstanceOutput": [],
            "ddmDataProviderInstanceId": [],
            "dataType": "string",
            "options": {
              "es_ES": [
                {
                  "reference": "",
                  "label": "Option",
                  "value": "Option"
                }
              ]
            },
            "tooltip": {
              "es_ES": ""
            },
            "fieldReference": "Textecoy",
            "placeholder": {
              "es_ES": ""
            },
            "dataSourceType": "manual"
          },
          "defaultValue": {
            "es_ES": ""
          },
          "fieldType": "text",
          "indexType": "keyword",
          "indexable": true,
          "label": {
            "es_ES": "Text"
          },
          "localizable": true,
          "name": "Textecoy",
          "nestedDataDefinitionFields": [],
          "readOnly": false,
          "repeatable": false,
          "required": false,
          "showLabel": true,
          "tip": {
            "es_ES": ""
          }
        },
        {
          "customProperties": {
            "ddmStructureLayoutId": "",
            "ddmStructureId": "",
            "upgradedStructure": false,
            "fieldReference": "Textj73rFieldSet",
            "rows": [
              {
                "columns": [
                  {
                    "size": 12,
                    "fields": [
                      "Textj73r"
                    ]
                  }
                ]
              }
            ],
            "collapsible": false
          },
          "defaultValue": {},
          "fieldType": "fieldset",
          "indexable": false,
          "label": {
            "es_ES": ""
          },
          "localizable": false,
          "name": "Textj73rFieldSet",
          "nestedDataDefinitionFields": [
            {
              "customProperties": {
                "displayStyle": "singleline",
                "visibilityExpression": "",
                "fieldNamespace": "",
                "autocomplete": false,
                "ddmDataProviderInstanceOutput": [],
                "ddmDataProviderInstanceId": [],
                "dataType": "string",
                "options": {
                  "es_ES": [
                    {
                      "reference": "",
                      "label": "Option",
                      "value": "Option"
                    }
                  ]
                },
                "tooltip": {
                  "es_ES": ""
                },
                "fieldReference": "Textj73r",
                "placeholder": {
                  "es_ES": ""
                },
                "dataSourceType": "manual"
              },
              "defaultValue": {
                "es_ES": ""
              },
              "fieldType": "text",
              "indexType": "keyword",
              "indexable": true,
              "label": {
                "es_ES": "Text"
              },
              "localizable": true,
              "name": "Textj73r",
              "nestedDataDefinitionFields": [],
              "readOnly": false,
              "repeatable": false,
              "required": false,
              "showLabel": true,
              "tip": {
                "es_ES": ""
              }
            }
          ],
          "readOnly": false,
          "repeatable": false,
          "required": false,
          "showLabel": false,
          "tip": {}
        }
      ],
      "readOnly": false,
      "repeatable": false,
      "required": false,
      "showLabel": false,
      "tip": {}
    },
    {
      "customProperties": {
        "ddmStructureLayoutId": "",
        "ddmStructureId": "",
        "upgradedStructure": false,
        "fieldReference": "Numberjj8sFieldSet",
        "rows": [
          {
            "columns": [
              {
                "size": 12,
                "fields": [
                  "Numberjj8s"
                ]
              }
            ]
          },
          {
            "columns": [
              {
                "size": 12,
                "fields": [
                  "Number9i3sFieldSet"
                ]
              }
            ]
          }
        ],
        "collapsible": false
      },
      "defaultValue": {},
      "fieldType": "fieldset",
      "indexable": false,
      "label": {
        "es_ES": ""
      },
      "localizable": false,
      "name": "Numberjj8sFieldSet",
      "nestedDataDefinitionFields": [
        {
          "customProperties": {
            "visibilityExpression": "",
            "fieldNamespace": "",
            "dataType": "double",
            "fieldReference": "Numberjj8s"
          },
          "defaultValue": {
            "es_ES": ""
          },
          "fieldType": "numeric",
          "indexType": "keyword",
          "indexable": true,
          "label": {
            "es_ES": "Number"
          },
          "localizable": true,
          "name": "Numberjj8s",
          "nestedDataDefinitionFields": [],
          "readOnly": false,
          "repeatable": false,
          "required": false,
          "showLabel": true,
          "tip": {
            "es_ES": ""
          }
        },
        {
          "customProperties": {
            "ddmStructureLayoutId": "",
            "ddmStructureId": "",
            "upgradedStructure": false,
            "fieldReference": "Number9i3sFieldSet",
            "rows": [
              {
                "columns": [
                  {
                    "size": 12,
                    "fields": [
                      "Number9i3s"
                    ]
                  }
                ]
              }
            ],
            "collapsible": false
          },
          "defaultValue": {},
          "fieldType": "fieldset",
          "indexable": false,
          "label": {
            "es_ES": ""
          },
          "localizable": false,
          "name": "Number9i3sFieldSet",
          "nestedDataDefinitionFields": [
            {
              "customProperties": {
                "visibilityExpression": "",
                "fieldNamespace": "",
                "dataType": "double",
                "fieldReference": "Number9i3s"
              },
              "defaultValue": {
                "es_ES": ""
              },
              "fieldType": "numeric",
              "indexType": "keyword",
              "indexable": true,
              "label": {
                "es_ES": "Number"
              },
              "localizable": true,
              "name": "Number9i3s",
              "nestedDataDefinitionFields": [],
              "readOnly": false,
              "repeatable": false,
              "required": false,
              "showLabel": true,
              "tip": {
                "es_ES": ""
              }
            }
          ],
          "readOnly": false,
          "repeatable": false,
          "required": false,
          "showLabel": false,
          "tip": {}
        }
      ],
      "readOnly": false,
      "repeatable": false,
      "required": false,
      "showLabel": false,
      "tip": {}
    }
  ],
  "defaultDataLayout": {
    "dataLayoutFields": {},
    "dataLayoutPages": [
      {
        "dataLayoutRows": [
          {
            "dataLayoutColumns": [
              {
                "columnSize": 12,
                "fieldNames": [
                  "TextecoyFieldSet"
                ]
              }
            ]
          },
          {
            "dataLayoutColumns": [
              {
                "columnSize": 12,
                "fieldNames": [
                  "Numberjj8sFieldSet"
                ]
              }
            ]
          }
        ],
        "description": {
          "es_ES": "Descripción"
        },
        "title": {
          "es_ES": "Página"
        }
      }
    ],
    "dataRules": [],
    "description": {},
    "name": {},
    "paginationMode": "single-page"
  },
  "defaultLanguageId": "es_ES",
  "description": {},
  "name": {
    "es_ES": "test_fix"
  },
  "storageType": "default"
}`


Steps to Verify
========
To be able to check if more than 2 levels of nested fields is working, you can follow the steps listed in the LPS:

1. In 7.0 create a new structure including the following hierarchy of nested fields (for example of ddm-text-html type):

     Parent 'A'
        Child 'B'
           GrandChild 'C'
2. Upgrade to master/7.4
3. Check how the structure looks like in master.

**Expected result**: the hierarchy of nested fields remains the same

**Current result:** GrandChild becomes a Child:

Parent 'A'
   Child 'B'
   Child 'C'

References to existing code (if applies)
========
I would like to verify with you if the expected result pointed in https://github.com/liferay/liferay-portal/blob/master/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/resources/com/liferay/dynamic/data/mapping/util/test/dependencies/ddm-form-data-definition-json-converter-nested-fields-expected-result.json should be changed accordingly, or this fix is actually producing [unexpected results.](https://github.com/crodriguezy/liferay-portal/pull/311)


