### PR TITLE
[TS] LPS-171400 NullPointerException is thrown during Upgrade 7.2 to 7.4 when using specifics fields in Forms caused by JSONFactory being null - REGRESSION BUG

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/report/CheckboxMultipleDDMFormFieldTypeReportProcessor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/report/CheckboxMultipleDDMFormFieldTypeReportProcessor.java
@@ -39,6 +39,15 @@ import org.osgi.service.component.annotations.Reference;
 public class CheckboxMultipleDDMFormFieldTypeReportProcessor
 	implements DDMFormFieldTypeReportProcessor {
 
+	public CheckboxMultipleDDMFormFieldTypeReportProcessor() {
+	}
+
+	public CheckboxMultipleDDMFormFieldTypeReportProcessor(
+		JSONFactory jsonFactory) {
+
+		_jsonFactory = jsonFactory;
+	}
+
 	@Override
 	public JSONObject process(
 			DDMFormFieldValue ddmFormFieldValue, JSONObject fieldJSONObject,

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/report/NumericDDMFormFieldTypeReportProcessor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/report/NumericDDMFormFieldTypeReportProcessor.java
@@ -24,6 +24,7 @@ import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -53,6 +54,13 @@ import org.osgi.service.component.annotations.Component;
 )
 public class NumericDDMFormFieldTypeReportProcessor
 	extends TextDDMFormFieldTypeReportProcessor {
+
+	public NumericDDMFormFieldTypeReportProcessor() {
+	}
+
+	public NumericDDMFormFieldTypeReportProcessor(JSONFactory jsonFactory) {
+		super(jsonFactory);
+	}
 
 	@Override
 	public JSONObject process(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/report/TextDDMFormFieldTypeReportProcessor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/report/TextDDMFormFieldTypeReportProcessor.java
@@ -60,6 +60,13 @@ import org.osgi.service.component.annotations.Reference;
 public class TextDDMFormFieldTypeReportProcessor
 	implements DDMFormFieldTypeReportProcessor {
 
+	public TextDDMFormFieldTypeReportProcessor() {
+	}
+
+	public TextDDMFormFieldTypeReportProcessor(JSONFactory jsonFactory) {
+		this.jsonFactory = jsonFactory;
+	}
+
 	@Override
 	public JSONObject process(
 			DDMFormFieldValue ddmFormFieldValue, JSONObject fieldJSONObject,

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_7_3/DDMFormInstanceReportUpgradeProcess.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_7_3/DDMFormInstanceReportUpgradeProcess.java
@@ -153,19 +153,20 @@ public class DDMFormInstanceReportUpgradeProcess extends UpgradeProcess {
 		if (StringUtil.equals(type, "checkbox_multiple") ||
 			StringUtil.equals(type, "select")) {
 
-			return new CheckboxMultipleDDMFormFieldTypeReportProcessor();
+			return new CheckboxMultipleDDMFormFieldTypeReportProcessor(
+				_jsonFactory);
 		}
 		else if (StringUtil.equals(type, "color") ||
 				 StringUtil.equals(type, "date") ||
 				 StringUtil.equals(type, "text")) {
 
-			return new TextDDMFormFieldTypeReportProcessor();
+			return new TextDDMFormFieldTypeReportProcessor(_jsonFactory);
 		}
 		else if (StringUtil.equals(type, "grid")) {
 			return new UpgradeGridDDMFormFieldTypeReportProcessor(ddmFormField);
 		}
 		else if (StringUtil.equals(type, "numeric")) {
-			return new NumericDDMFormFieldTypeReportProcessor();
+			return new NumericDDMFormFieldTypeReportProcessor(_jsonFactory);
 		}
 		else if (StringUtil.equals(type, "radio")) {
 			return new RadioDDMFormFieldTypeReportProcessor();


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-171400

:warning: This is a regression caused by https://issues.liferay.com/browse/LPS-143631 :warning: 

During the upgrade, the DDMFormFieldTypeReportProcessor classes are created here calling the constructor:
 - https://github.com/liferay-forms/liferay-portal/blob/347d0d9e32ce975c2f9ac0cc6070b73ebb1a50c2/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_7_3/DDMFormInstanceReportUpgradeProcess.java#L150-L175

So the JSONFactory object is not correctly populated in the DDMFormFieldTypeReportProcessor classes.

We cannot load them as OSGI components because the module is not ready yet, so I am adding a new constructor in order to be able to set the JSONFactory.

Let me know if you think there are better alternatives.
