### PR TITLE
[TS] LPS-173557 Cannot Find global DDL with staging

### DIFF
--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -26,9 +26,16 @@ boolean editable = PrefsParamUtil.getBoolean(PortletPreferencesFactoryUtil.getPo
 boolean formView = PrefsParamUtil.getBoolean(PortletPreferencesFactoryUtil.getPortletSetup(renderRequest), renderRequest, "formView", false);
 long formDDMTemplateId = PrefsParamUtil.getLong(PortletPreferencesFactoryUtil.getPortletSetup(renderRequest), renderRequest, "formDDMTemplateId");
 long recordSetId = PrefsParamUtil.getLong(PortletPreferencesFactoryUtil.getPortletSetup(renderRequest), renderRequest, "recordSetId");
+String scopeType = PrefsParamUtil.getString(PortletPreferencesFactoryUtil.getPortletSetup(renderRequest), renderRequest, "lfrScopeType");
 boolean spreadsheet = PrefsParamUtil.getBoolean(PortletPreferencesFactoryUtil.getPortletSetup(renderRequest), renderRequest, "spreadsheet");
 
 Group scopeGroup = themeDisplay.getScopeGroup();
+
+if (scopeType.equals("company")) {
+	scopeGroup = GroupLocalServiceUtil.getGroup(themeDisplay.getCompanyGroupId());
+
+	scopeGroupId = scopeGroup.getGroupId();
+}
 
 if (scopeGroup.isStagingGroup() && !scopeGroup.isInStagingPortlet(DDLPortletKeys.DYNAMIC_DATA_LISTS)) {
 	scopeGroupId = scopeGroup.getLiveGroupId();


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

Motivation
=======
In a **staged** site, where the Dynamic Data Lists Display portlet is **not** staged, the DDLs created in the **Global** site won't be listed.
The issue is not present when the site is not staged or when **both** the site and DDL Display portlet are staged.

Proposed Solution
========
Explicitly checking if the portlet scope is set to company (Global). If that is the case, we should set `scopeGroupId` to the ID of the Global site.

Steps to Verify
========
Please check the linked LPS for reproduction steps.
https://issues.liferay.com/browse/LPS-173557

Alternative Solutions that were discarded
========
The [code that is directly responsible for the behavior](https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/util/PortalImpl.java#L4723-L4762) is in `PortalImpl`.
I am not sure whether is purposefully designed this way, therefore I refrained from modifying this core part of the code.

Thank you and best regards,
István