### PR TITLE
[TS] LPS-174138 | master

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_10_2/DDMFormInstanceReportUpgradeProcess.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_10_2/DDMFormInstanceReportUpgradeProcess.java
@@ -127,10 +127,12 @@ public class DDMFormInstanceReportUpgradeProcess extends UpgradeProcess {
 
 		JSONObject normalizedValuesJSONObject = _jsonFactory.createJSONObject();
 
-		for (String key : valuesJSONObject.keySet()) {
-			normalizedValuesJSONObject.put(
-				DDMFormFieldUpgradeProcessUtil.getNormalizedName(key),
-				valuesJSONObject.getInt(key));
+		if (valuesJSONObject.length() > 0) {
+			for (String key : valuesJSONObject.keySet()) {
+				normalizedValuesJSONObject.put(
+					DDMFormFieldUpgradeProcessUtil.getNormalizedName(key),
+					valuesJSONObject.getInt(key));
+			}
 		}
 
 		return normalizedValuesJSONObject;


### PR DESCRIPTION
Hi team,
Continuing with PR #2117 we still got a NPE when normalizing JSON data because we can have a valid JSON data (fixed by PR #2117) but internally this data, in turn, contains JSON data with empty content for its 'values' property.

So I added a condition before normalizing this 'values' data.

Regards
 Sergio.

Reference:
https://issues.liferay.com/browse/LPS-174138