### PR TITLE
LPS-174219 Set masked value to be fixed with decimal places as parameter

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Numeric/Numeric.tsx
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Numeric/Numeric.tsx
@@ -102,7 +102,10 @@ const getMaskedValue = ({
 	);
 
 	return {
-		masked,
+		masked:
+			dataType === 'double'
+				? Number(masked).toFixed(decimalPlaces)
+				: masked,
 		placeholder:
 			dataType === 'double'
 				? `0${symbols.decimalSymbol}${'0'.repeat(decimalPlaces)}`

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Numeric/Numeric.tsx
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Numeric/Numeric.tsx
@@ -101,10 +101,15 @@ const getMaskedValue = ({
 		'g'
 	);
 
+	const splitNumbers = masked.split(symbols.decimalSymbol);
+
+	const decimalDigitsLength =
+		splitNumbers.length > 1 ? splitNumbers.pop().length : 0;
+
 	return {
 		masked:
-			dataType === 'double'
-				? Number(masked).toFixed(decimalPlaces)
+			dataType === 'double' && decimalDigitsLength
+				? masked + '0'.repeat(decimalPlaces - decimalDigitsLength)
 				: masked,
 		placeholder:
 			dataType === 'double'
@@ -112,6 +117,7 @@ const getMaskedValue = ({
 				: inputMaskFormat.replace(/\d/g, '_'),
 		raw: masked.replace(regex, ''),
 	};
+	
 };
 
 const getFormattedValue = ({


### PR DESCRIPTION
**Scenario:**

1. Create a form with two numeric fields (cost and tax).
2. Set both fields to decimal, with an input mask of 2 decimal places, and a currency prefix (e.g. £).
3. Add a rule to calculate the value of the tax field as cost * 0.2 when cost is not empty.
4. Save and publish the form, and open the form URL.
5. Enter '1' in the cost field.

**Expected:** £1.00 displayed in cost and £0.20 displayed in tax.
**Actual:** £1 displayed in cost and £0.2 displayed in tax.

https://issues.liferay.com/browse/LPS-174219