### PR TITLE
[TS] LPS-173068

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMIndexerImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMIndexerImpl.java
@@ -372,7 +372,7 @@ public class DDMIndexerImpl implements DDMIndexer {
 
 				Serializable value = field.getValue(locale);
 
-				if (Validator.isNull(value)) {
+				if (value == null) {
 					continue;
 				}
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMIndexerImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMIndexerImpl.java
@@ -810,7 +810,7 @@ public class DDMIndexerImpl implements DDMIndexer {
 	private String _getSortableValue(
 		DDMFormField ddmFormField, Locale locale, Serializable value) {
 
-		if (Validator.isNull(value)) {
+		if (value == null) {
 			return null;
 		}
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMIndexerImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMIndexerImpl.java
@@ -372,7 +372,9 @@ public class DDMIndexerImpl implements DDMIndexer {
 
 				Serializable value = field.getValue(locale);
 
-				if (value == null) {
+				if ((value == null) ||
+					Objects.equals(value, StringPool.BLANK)) {
+
 					continue;
 				}
 
@@ -400,6 +402,10 @@ public class DDMIndexerImpl implements DDMIndexer {
 						String valueString = _getSortableValue(
 							ddmStructure.getDDMFormField(field.getName()),
 							locale, values[i].toString());
+
+						if (Validator.isBlank(valueString)) {
+							continue;
+						}
 
 						_addFieldValue(sb, field.getType(), valueString);
 


### PR DESCRIPTION
Hi Team,

Can you help review this PR? If this is not the right team for this review, please help advise which team to send to.

Notes from @noornajj: 

> https://issues.liferay.com/browse/LPS-173068
> 
> The issue here is that a null literal is added to a search summary when a repeatable field is empty and there is at least one other field that is not empty. This occurs because repeatable fields are returned as arrays and when the field is empty, an empty string is added to the array --> [""] 
> _getSortableValue will return the empty string as null and then null is added to the string bundler as a literal. 
> 
> To fix the issue, I had _getSortableValue return an empty string instead of null.

Please let us know if you have any questions.
Thanks!