### PR TITLE
[TS] LPS-174851 - multiple wc structure fields are missing in information templates

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/info/field/converter/DDMFormFieldInfoFieldConverterImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/info/field/converter/DDMFormFieldInfoFieldConverterImpl.java
@@ -24,6 +24,7 @@ import com.liferay.dynamic.data.mapping.storage.constants.FieldConstants;
 import com.liferay.info.field.InfoField;
 import com.liferay.info.field.type.BooleanInfoFieldType;
 import com.liferay.info.field.type.DateInfoFieldType;
+import com.liferay.info.field.type.FileInfoFieldType;
 import com.liferay.info.field.type.GridInfoFieldType;
 import com.liferay.info.field.type.ImageInfoFieldType;
 import com.liferay.info.field.type.InfoFieldType;
@@ -194,6 +195,12 @@ public class DDMFormFieldInfoFieldConverterImpl
 					ddmFormFieldType, DDMFormFieldTypeConstants.GRID)) {
 
 			return GridInfoFieldType.INSTANCE;
+		}
+		else if (Objects.equals(
+					ddmFormFieldType,
+					DDMFormFieldTypeConstants.DOCUMENT_LIBRARY)) {
+
+			return FileInfoFieldType.INSTANCE;
 		}
 
 		return TextInfoFieldType.INSTANCE;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/info/item/provider/DDMStructureInfoItemFieldSetProviderImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/info/item/provider/DDMStructureInfoItemFieldSetProviderImpl.java
@@ -99,7 +99,10 @@ public class DDMStructureInfoItemFieldSetProviderImpl
 		DDMFormFieldTypeConstants.DATE, DDMFormFieldTypeConstants.NUMERIC,
 		DDMFormFieldTypeConstants.IMAGE, DDMFormFieldTypeConstants.TEXT,
 		DDMFormFieldTypeConstants.RADIO, DDMFormFieldTypeConstants.RICH_TEXT,
-		DDMFormFieldTypeConstants.SELECT
+		DDMFormFieldTypeConstants.SELECT, DDMFormFieldTypeConstants.GRID,
+		DDMFormFieldTypeConstants.DOCUMENT_LIBRARY,
+		DDMFormFieldTypeConstants.COLOR, DDMFormFieldTypeConstants.GEOLOCATION,
+		DDMFormFieldTypeConstants.JOURNAL_ARTICLE
 	};
 
 	@Reference


### PR DESCRIPTION
Hi @liferay-forms!

I'm sending this PR to address a client reported issue here: https://issues.liferay.com/browse/LPP-47761

In it they reported that they were unable to map the upload field in an information template, despite it being available for use in web content templates. I've added therefore the fields available for WC structures. Looking through the documentation available, I didn't find any reason for these fields to be excluded, but please let me know if this is something that is intentional and I'll pass it on to the client. Thanks!