### PR TITLE
LPS-175293 FileItemSelectorCriterion is not found

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/custom_fields.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/custom_fields.js
@@ -358,8 +358,7 @@ AUI.add(
 						'0_json': JSON.stringify(criterionJSON),
 						'1_json': JSON.stringify(criterionJSON),
 						'2_json': JSON.stringify(uploadCriterionJSON),
-						'criteria':
-							'com.liferay.item.selector.criteria.file.criterion.FileItemSelectorCriterion',
+						'criteria': 'file',
 						'itemSelectedEventName':
 							portletNamespace + 'selectDocumentLibrary',
 						'p_p_id': Liferay.PortletKeys.ITEM_SELECTOR,

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -1659,9 +1659,7 @@ AUI.add(
 						'documentLibrarySelectorURL'
 					);
 
-					let retVal = instance.getDocumentLibraryURL(
-						'com.liferay.item.selector.criteria.file.criterion.FileItemSelectorCriterion'
-					);
+					let retVal = instance.getDocumentLibraryURL('file');
 
 					if (documentLibrarySelectorURL) {
 						retVal = documentLibrarySelectorURL;


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

Motivation
=======
Since [LPS-171236](https://issues.liferay.com/browse/LPS-171236), a ServiceTrackerMap is holding the ItemSelectorCriterionHandler. They are registered by item selector criterion keys instead of class names.
In [ddm_form.js](https://github.com/liferay/liferay-portal/blob/master/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js#L1663) and [custom_fields.js](https://github.com/liferay/liferay-portal/blob/master/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/custom_fields.js#L362) the parameters are still passed as class names.
Therefore, `ItemSelectorImpl._getItemSelectorCriterionClasses` won't be able to find `FileItemSelectorCriterion`.

Proposed Solution
========
Passing the 'file' item selector criterion key instead of the 'com.liferay.item.selector.criteria.file.criterion.FileItemSelectorCriterion' class name.

Steps to Verify
========
Please consult the linked LPS for reproduction steps.
https://issues.liferay.com/browse/LPS-175293

Thank you and best regards,
István