### PR TITLE
[TS] LPS-174138 | master

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_10_2/DDMFormInstanceReportUpgradeProcess.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_10_2/DDMFormInstanceReportUpgradeProcess.java
@@ -127,7 +127,7 @@ public class DDMFormInstanceReportUpgradeProcess extends UpgradeProcess {
 
 		JSONObject normalizedValuesJSONObject = _jsonFactory.createJSONObject();
 
-		if (valuesJSONObject.length() > 0) {
+		if ((valuesJSONObject != null) && (valuesJSONObject.length() > 0)) {
 			for (String key : valuesJSONObject.keySet()) {
 				normalizedValuesJSONObject.put(
 					DDMFormFieldUpgradeProcessUtil.getNormalizedName(key),


### PR DESCRIPTION
Hi team,

This is an additional commit for PR #2120

Customer data showed us that '_valuesJSONObject_' can be null when it is recovered from fields like radio buttons.

So I added a check of null object (and thus avoid, again, a NPE)

cc/ @carolmariaabb 

Reference: 
https://issues.liferay.com/browse/LPS-174138