### PR TITLE
LPS-175528 Editing web content structures upgraded to 7.4 can result in a blank screen and an error in the browser console

### DIFF
--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/utils/settingsContext.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/utils/settingsContext.js
@@ -281,6 +281,10 @@ const getValueLocalized = (
 	defaultLanguageId,
 	editingLanguageId
 ) => {
+	if (value === null) {
+		return value;
+	}
+
 	if (
 		isLocalizedObjectValue({localizable, value}) &&
 		value[editingLanguageId] !== undefined


### PR DESCRIPTION
Hello @liferay-forms,

This is PR is a solution for [LPS-175528](https://issues.liferay.com/browse/LPS-175528). This issue happens for web content structures upgraded to 7.4. In this version there are several extra fields that are useful for Forms but not for web contents (as far as I can tell). The relevant ones are `"confirmationLabel"` and `"confirmationErrorMessage"`. 

For a newly created web content structure in 7.4, the value of these fields is set to
```
{"en_US": ""}
```
thanks to the class `DDMFormTemplateContextProcessor` (see [these methods](https://github.com/liferay/liferay-portal/blob/master/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/java/com/liferay/dynamic/data/mapping/form/renderer/internal/servlet/DDMFormTemplateContextProcessor.java#L271-L285)). The locale is obtained from the parameter `"languageId"` in the request. (See class `DDMFormContextProviderSet`.)

For already existing web content structures, none of this is done. Instead the value of  `"confirmationLabel"` and `"confirmationErrorMessage"` is obtained for the existing JSON definition. Since those element don't exist, the value set is an empty object `{}`. 

This might not be a problem per se since web content structures don't really need those attributes. However, when editing the structure, the JS function `updateFieldProperty` in `settingsContext.es.js` (inside module _data-enginge-components-web_) can be called, invoking in turn `getValueLocalized`. There, `value` can be `null` for `"confirmationLabel"` and `"confirmationErrorMessage"` producing the error shown in the description for LPS-175528 and making the edit view blank.

To avoid the problem, I've chosen to check for a possible `null` value of `value` and skip the rest of the code that throws the error. 

An alternative might be to ensure that `"confirmationLabel"` and `"confirmationErrorMessage"` have a value, like newly created structures do, but I'm not sure if that's a good idea or where exactly to set that value. 

Please let me know if you have any questions. 
Thanks!