### PR TITLE
[TS] LPS-175744 Cannot Import a Form when a Workflow that no longer exists is set.

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMFormInstanceLocalServiceImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMFormInstanceLocalServiceImpl.java
@@ -693,12 +693,14 @@ public class DDMFormInstanceLocalServiceImpl
 			!workflowDefinition.equals("no-workflow")) {
 
 			KaleoDefinition kaleoDefinition =
-				_kaleoDefinitionLocalService.getKaleoDefinition(
+				_kaleoDefinitionLocalService.fetchKaleoDefinition(
 					workflowDefinition, serviceContext);
 
-			latestWorkflowDefinition =
-				workflowDefinition + StringPool.AT +
-					kaleoDefinition.getVersion();
+			if (kaleoDefinition != null) {
+				latestWorkflowDefinition =
+					workflowDefinition + StringPool.AT +
+						kaleoDefinition.getVersion();
+			}
 		}
 
 		_workflowDefinitionLinkLocalService.updateWorkflowDefinitionLink(


### PR DESCRIPTION
Notes from @javalosjr96:

> Ticket:
> [LPS-175744](https://issues.liferay.com/browse/LPS-175744)
> 
> Issue:
> If a Workflow Process no longer exists, then it is not possible to import a Form that had it assigned.  
> 
> Solution:
> Fetch the Kaleo Workflow instead of get and assign the definition only if it exists; ignore if otherwise.