### PR TITLE
LPS-176503 IllegalArgumentException when adding a translation to a language with variant (ca_ES_VALENCIA or sr_RS_latin)

### DIFF
--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/thunks/pageLanguageUpdate.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/thunks/pageLanguageUpdate.es.js
@@ -97,7 +97,10 @@ export default function pageLanguageUpdate({
 					siteGroupId: themeDisplay.getSiteGroupId(),
 				}),
 				headers: {
-					'Accept-Language': nextEditingLanguageId.replace('_', '-'),
+					'Accept-Language': nextEditingLanguageId.replaceAll(
+						'_',
+						'-'
+					),
 					'Content-Type': 'application/json',
 				},
 				method: 'POST',

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/components/translation-manager/TranslationManager.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/components/translation-manager/TranslationManager.es.js
@@ -19,7 +19,7 @@ import classNames from 'classnames';
 import React, {useEffect, useState} from 'react';
 
 export function formatLabel(label) {
-	return label.replace('_', '-');
+	return label.replaceAll('_', '-');
 }
 
 export function formatIcon(label) {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/LocalizableText/transform.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/LocalizableText/transform.es.js
@@ -82,7 +82,7 @@ export function normalizeLocaleId(localeId) {
 		throw new Error(`localeId ${localeId} is invalid`);
 	}
 
-	return localeId.replace('_', '-').toLowerCase();
+	return localeId.replaceAll('_', '-').toLowerCase();
 }
 
 export function transformAvailableLocales(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Text/Text.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Text/Text.es.js
@@ -172,7 +172,7 @@ const Text = ({
 						dir={Liferay.Language.direction[editingLanguageId]}
 						disabled={disabled}
 						id={id}
-						lang={editingLanguageId?.replace('_', '-')}
+						lang={editingLanguageId?.replaceAll('_', '-')}
 						maxLength={showCounter ? '' : maxLength}
 						name={name}
 						onBlur={(event) => {
@@ -235,7 +235,7 @@ const Textarea = ({
 						dir={Liferay.Language.direction[editingLanguageId]}
 						disabled={disabled}
 						id={id}
-						lang={editingLanguageId?.replace('_', '-')}
+						lang={editingLanguageId?.replaceAll('_', '-')}
 						name={name}
 						onBlur={onBlur}
 						onChange={(event) => {
@@ -348,7 +348,7 @@ const Autocomplete = ({
 				dir={Liferay.Language.direction[editingLanguageId]}
 				disabled={disabled}
 				id={id}
-				lang={editingLanguageId?.replace('_', '-')}
+				lang={editingLanguageId?.replaceAll('_', '-')}
 				name={name}
 				onBlur={onBlur}
 				onChange={(event) => {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/html/start.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/html/start.jsp
@@ -232,7 +232,7 @@
 					}
 				});
 
-				languageId = languageId.replace('_', '-');
+				languageId = languageId.replaceAll('_', '-');
 
 				const triggerContent = Lang.sub(
 					'<span class="inline-item">{flag}</span><span class="btn-section">{languageId}</span>',

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -672,10 +672,10 @@ AUI.add(
 					if (sourceLocale !== targetLocale) {
 						const test = 1.1;
 						const sourceDecimalSeparator = test
-							.toLocaleString(sourceLocale.replace('_', '-'))
+							.toLocaleString(sourceLocale.replaceAll('_', '-'))
 							.charAt(1);
 						const targetDecimalSeparator = test
-							.toLocaleString(targetLocale.replace('_', '-'))
+							.toLocaleString(targetLocale.replaceAll('_', '-'))
 							.charAt(1);
 
 						if (sourceDecimalSeparator !== targetDecimalSeparator) {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-176503

This issue is produced when adding a webcontent translation but the root cause of the issue is produced in data engine code.

Root cause of the issue:

 - Java Locale code uses underscore character in the locale code to separate language, country and variant, for example: `ca_ES_VALENCIA`
 - But in the frontend side, we have to replace the underscore character with the dash, for example: `ca-ES-VALENCIA`
 - The problem here is we don't usually consider there could be two underscore characters, so only the first one is replaced: `ca_ES_VALENCIA` => `ca-ES_VALENCIA`, this language is considered invalid by Locale java class.


In my first commit b32ce8afe8557b90131b8afcfd32f8917d7e0d49  I have changed `replace('_', '-')` with `replaceAll('_', '-')` in all ocurrences inside data engine and dynamic data mapping.
In my second commit 2ee257395ba65626bf5616b505216a582b6a5fa3 I have applied the same change everywhere in the Liferay code.

Let me know if you prefer to only modify the code in data engine and dynamic data mapping.

Regards,
Jorge
