### PR TITLE
[TS] LPS-177122 | master

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/util/comparator/DDMTemplateNameComparator.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/util/comparator/DDMTemplateNameComparator.java
@@ -29,9 +29,11 @@ import java.util.Locale;
  */
 public class DDMTemplateNameComparator extends OrderByComparator<DDMTemplate> {
 
-	public static final String ORDER_BY_ASC = "DDMTemplate.name ASC";
+	public static final String ORDER_BY_ASC =
+		"CAST_CLOB_TEXT(DDMTemplate.name) ASC";
 
-	public static final String ORDER_BY_DESC = "DDMTemplate.name DESC";
+	public static final String ORDER_BY_DESC =
+		"CAST_CLOB_TEXT(DDMTemplate.name) DESC";
 
 	public static final String[] ORDER_BY_FIELDS = {"name"};
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/resources/com/liferay/dynamic/data/mapping/util/comparator/packageinfo
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/resources/com/liferay/dynamic/data/mapping/util/comparator/packageinfo
@@ -1,1 +1,1 @@
-version 2.2.0
+version 2.2.1


### PR DESCRIPTION
Hi team,

Some DXP compatible databases (i.e. Oracle) restrict columns type to be used in 'order by' clauses. In this case, Oracle does not allow to use a LOB type.
Entity 'DDMTemplate' defines column 'name' as LOB (for Oracle). Thus, DXP functionality to order by template name crashes when the system uses an Oracle database.

Proposed solution in this PR consists in doing a cast to 'varchar' (string) to avoid the ORA-00932 error.

Reference: https://issues.liferay.com/browse/LPS-177122

Regards