### PR TITLE
[TS] LPS-177307 Performance issue with v4_3_4.DLFileEntryTypeDDMFieldAttributeUpgradeProcess

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/registry/DDMServiceUpgradeStepRegistrator.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/registry/DDMServiceUpgradeStepRegistrator.java
@@ -74,6 +74,7 @@ import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.security.permission.ResourceActions;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourceLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
@@ -427,7 +428,9 @@ public class DDMServiceUpgradeStepRegistrator
 			"4.0.0", "4.1.0",
 			new DDMFieldUpgradeProcess(
 				_jsonFactory, _jsonDDMFormDeserializer,
-				_jsonDDMFormValuesDeserializer));
+				_jsonDDMFormValuesDeserializer),
+			new com.liferay.dynamic.data.mapping.internal.upgrade.v4_1_0.
+				SchemaUpgradeProcess());
 
 		registry.register(
 			"4.1.0", "4.2.0",
@@ -460,7 +463,8 @@ public class DDMServiceUpgradeStepRegistrator
 			"4.3.3", "4.3.4",
 			new DDMStructureLinkDLFileEntryTypeUpgradeProcess(
 				_dlFileEntryTypeLocalService),
-			new DLFileEntryTypeDDMFieldAttributeUpgradeProcess());
+			new DLFileEntryTypeDDMFieldAttributeUpgradeProcess(
+				_companyLocalService));
 
 		registry.register(
 			"4.3.4", "4.3.5", new DDMTemplateVersionUpgradeProcess());
@@ -539,6 +543,9 @@ public class DDMServiceUpgradeStepRegistrator
 
 	@Reference
 	private ClassNameLocalService _classNameLocalService;
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
 
 	@Reference
 	private CounterLocalService _counterLocalService;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v4_1_0/SchemaUpgradeProcess.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v4_1_0/SchemaUpgradeProcess.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.dynamic.data.mapping.internal.upgrade.v4_1_0;
+
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.LoggingTimer;
+import com.liferay.portal.kernel.util.StringUtil;
+
+/**
+ * @author István András Dézsi
+ */
+public class SchemaUpgradeProcess extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		try (LoggingTimer loggingTimer = new LoggingTimer()) {
+			String template = StringUtil.read(
+				SchemaUpgradeProcess.class.getResourceAsStream(
+					"dependencies/update.sql"));
+
+			runSQLTemplateString(template, false);
+		}
+	}
+
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/com/liferay/dynamic/data/mapping/internal/upgrade/v4_1_0/dependencies/update.sql
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/com/liferay/dynamic/data/mapping/internal/upgrade/v4_1_0/dependencies/update.sql
@@ -1,0 +1,9 @@
+create index IX_5378BAAD on DDMField (companyId, fieldType[$COLUMN_LENGTH:255$], ctCollectionId);
+create index IX_582EBFF1 on DDMField (storageId, ctCollectionId);
+create unique index IX_1BB20E75 on DDMField (storageId, instanceId[$COLUMN_LENGTH:75$], ctCollectionId);
+create index IX_5C0B8AE5 on DDMField (structureVersionId, ctCollectionId);
+
+create index IX_52703248 on DDMFieldAttribute (attributeName[$COLUMN_LENGTH:255$], smallAttributeValue[$COLUMN_LENGTH:255$], ctCollectionId);
+create unique index IX_22EEBF0C on DDMFieldAttribute (fieldId, attributeName[$COLUMN_LENGTH:255$], languageId[$COLUMN_LENGTH:75$], ctCollectionId);
+create index IX_EC62446F on DDMFieldAttribute (storageId, ctCollectionId);
+create index IX_1E90C536 on DDMFieldAttribute (storageId, languageId[$COLUMN_LENGTH:75$], ctCollectionId);


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

Motivation
=======
When ~ 1000000 entries exist in the `DDMFieldAttribute` table, [DLFileEntryTypeDDMFieldAttributeUpgradeProcess](https://github.com/liferay/liferay-portal/blob/master/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v4_3_4/DLFileEntryTypeDDMFieldAttributeUpgradeProcess.java) will take a substantial amount of time to complete. This is because the SQL queries in the upgrade process don't use indexing, and perform full table scans instead.
When the `DDMField` and `DDMFieldAttribute` tables are created in [DDMFieldUpgradeProcess](https://github.com/liferay/liferay-portal/blob/master/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v4_1_0/DDMFieldUpgradeProcess.java), their indexes are not created along with them, leading to a suboptimal query time.

Proposed Solution
========
Adding the `DDMField` and `DDMFieldAttribute` table's indexes during the upgrade and restructuring the queries in `DLFileEntryTypeDDMFieldAttributeUpgradeProcess` to utilize the indexes of the `DDMStructureLink`, `DDMField` and `DDMFieldAttribute` tables (thanks to @fabian-bouche-liferay for the idea!).

Steps to Verify
========
Please see the linked LPS for the reproduction steps.
https://issues.liferay.com/browse/LPS-177307

Thank you and best regards,
István