### PR TITLE
[TS] LPS-178852 Comparing web content versions of the same structure does not work

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/templateparser/TemplateNode.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/templateparser/TemplateNode.java
@@ -225,7 +225,13 @@ public class TemplateNode extends LinkedHashMap<String, Object> {
 	}
 
 	public String getType() {
-		return (String)get("type");
+		Object type = get("type");
+
+		if ((type == null) || (type instanceof String)) {
+			return (String)type;
+		}
+
+		return StringPool.BLANK;
 	}
 
 	public String getUrl() {


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

Motivation
=======
In a structure, a custom field named "type" might be used as a field reference. During the parsing of the structure, when a default template is created (in the absence of an already existing template), a [TemplateNode](https://github.com/liferay/liferay-portal/blob/master/portal-kernel/src/com/liferay/portal/kernel/templateparser/TemplateNode.java) like this will be generated, with a `type` field whose value is not a string but an object:

`[null, null, optionsMap={}, null, data=, null, null, null, name=FieldsGroup77008454, null, attributes={}, label={attributes={language-id=en_US}, name=label, data=, type=text, options=[], optionsMap={}}, type={attributes={language-id=en_US}, name=type, data=, type=select, options=[], optionsMap={video=video, player=player, button=button}}, null, null, target={attributes={language-id=en_US}, name=target, data=, type=select, options=[], optionsMap={_self=_self, _blank=_blank}}]`

The [getType()](https://github.com/liferay/liferay-portal/blob/master/portal-kernel/src/com/liferay/portal/kernel/templateparser/TemplateNode.java#L227-L229) method will fail to cast the Object to a String.

Proposed Solution
========
Changing `getType()` so that it handles this case properly. I'm using the pattern of [getName()](https://github.com/liferay/liferay-portal/blob/master/portal-kernel/src/com/liferay/portal/kernel/templateparser/TemplateNode.java#L205-L213).

Steps to Verify
========
Please see the linked LPS for the reproduction steps, including a sample structure.
https://issues.liferay.com/browse/LPS-178852

Thank you and best regards,
István