### PR TITLE
[TS] LPS-178838 Wrong fieldReference is set when translating DDMFormField

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMBeanTranslatorImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMBeanTranslatorImpl.java
@@ -23,6 +23,7 @@ import com.liferay.dynamic.data.mapping.model.Value;
 import com.liferay.dynamic.data.mapping.storage.DDMFormFieldValue;
 import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
 import com.liferay.dynamic.data.mapping.util.DDMBeanTranslator;
+import com.liferay.portal.kernel.util.Validator;
 
 import java.util.Locale;
 import java.util.Map;
@@ -101,6 +102,13 @@ public class DDMBeanTranslatorImpl implements DDMBeanTranslator {
 		translatedDDMFormField.setDataType(ddmFormField.getDataType());
 		translatedDDMFormField.setFieldNamespace(
 			ddmFormField.getFieldNamespace());
+
+		String fieldReference = ddmFormField.getFieldReference();
+
+		if (Validator.isNotNull(fieldReference)) {
+			translatedDDMFormField.setFieldReference(fieldReference);
+		}
+
 		translatedDDMFormField.setIndexType(ddmFormField.getIndexType());
 		translatedDDMFormField.setDDMFormFieldOptions(
 			translate(ddmFormField.getDDMFormFieldOptions()));


### PR DESCRIPTION
# Motivation
The wrong fieldReference gets set when translating a DDMFormField. It is set to name, which is not necessarily correct as the name can be different from the fieldReference.

This is causing an issue for our client who is trying to write a custom wrapper for the `DLFileEntryLocalServiceImpl#addFileEntry` API, but they cannot access the fields in the passed-in ddmFormValuesMap because the getFieldReference API is returning the wrong value.

# Proposed Solution
Set the fieldReference manually from the translator, if one already exists, rather than relying on the constructor to set it to name (which may be incorrect).

# Steps to Verify
Please see the linked LPS for the reproduction steps. https://issues.liferay.com/browse/LPS-178838

