### PR TITLE
[TS] LPS-178473 Fix getRelationshipValue method with base model check

### DIFF
--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/manager/v1_0/ObjectEntryManager.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/manager/v1_0/ObjectEntryManager.java
@@ -119,9 +119,18 @@ public interface ObjectEntryManager {
 			String objectRelationshipName, Pagination pagination)
 		throws Exception;
 
+	public ObjectDefinition getObjectRelationshipObjectDefinition1(
+			ObjectDefinition objectDefinition1, String objectField2Name)
+		throws Exception;
+
 	public Page<Object> getRelatedSystemObjectEntries(
 			ObjectDefinition objectDefinition, Long objectEntryId,
 			String objectRelationshipName, Pagination pagination)
+		throws Exception;
+
+	public Object getSystemBaseModel(
+			DTOConverterContext dtoConverterContext,
+			ObjectDefinition objectDefinition, long primaryKey)
 		throws Exception;
 
 	public ObjectEntry updateObjectEntry(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/graphql/dto/v1_0/ObjectDefinitionGraphQLDTOContributor.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/graphql/dto/v1_0/ObjectDefinitionGraphQLDTOContributor.java
@@ -255,22 +255,15 @@ public class ObjectDefinitionGraphQLDTOContributor
 			return null;
 		}
 
-		String relationshipIdName = null;
-
 		ObjectEntry objectEntry = _objectEntryManager.getObjectEntry(
 			dtoConverterContext, _objectDefinition, id);
 
 		Map<String, Object> properties = objectEntry.getProperties();
 
-		for (String key : properties.keySet()) {
-			if (key.contains(relationshipName)) {
-				relationshipIdName = key;
+		String objectField2Name = _getObjectField2Name(
+			properties, relationshipName);
 
-				break;
-			}
-		}
-
-		if (relationshipIdName == null) {
+		if (objectField2Name == null) {
 			Page<ObjectEntry> page =
 				_objectEntryManager.getObjectEntryRelatedObjectEntries(
 					dtoConverterContext, _objectDefinition, id,
@@ -281,16 +274,21 @@ public class ObjectDefinitionGraphQLDTOContributor
 				page.getItems(), itemObjectEntry -> _toMap(itemObjectEntry));
 		}
 
-		Object relationshipId = properties.get(relationshipIdName);
+		ObjectDefinition objectDefinition =
+			_objectEntryManager.getObjectRelationshipObjectDefinition1(
+				_objectDefinition, objectField2Name);
 
-		if (!(relationshipId instanceof Long)) {
-			return null;
+		long relatedObjectEntryId = (long)properties.get(objectField2Name);
+
+		if (objectDefinition.isSystem()) {
+			return (T)_objectEntryManager.getSystemBaseModel(
+				dtoConverterContext, objectDefinition, relatedObjectEntryId);
 		}
 
 		return (T)_toMap(
 			_objectEntryManager.fetchObjectEntry(
-				dtoConverterContext, null, (long)relationshipId),
-			relationshipIdName);
+				dtoConverterContext, objectDefinition, relatedObjectEntryId),
+			objectField2Name);
 	}
 
 	@Override
@@ -359,6 +357,22 @@ public class ObjectDefinitionGraphQLDTOContributor
 		_relationshipGraphQLDTOProperties = relationshipGraphQLDTOProperties;
 		_resourceName = resourceName;
 		_typeName = typeName;
+	}
+
+	private String _getObjectField2Name(
+		Map<String, Object> properties, String relationshipName) {
+
+		for (Map.Entry<String, Object> entry : properties.entrySet()) {
+			String key = entry.getKey();
+
+			if (key.contains(relationshipName) &&
+				(entry.getValue() instanceof Long)) {
+
+				return key;
+			}
+		}
+
+		return null;
 	}
 
 	private Map<String, Object> _toMap(ObjectEntry objectEntry) {

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -602,6 +602,23 @@ public class DefaultObjectEntryManagerImpl
 	}
 
 	@Override
+	public ObjectDefinition getObjectRelationshipObjectDefinition1(
+			ObjectDefinition objectDefinition1, String objectField2Name)
+		throws Exception {
+
+		ObjectField objectField = _objectFieldLocalService.getObjectField(
+			objectDefinition1.getObjectDefinitionId(), objectField2Name);
+
+		ObjectRelationship objectRelationship =
+			_objectRelationshipLocalService.
+				fetchObjectRelationshipByObjectFieldId2(
+					objectField.getObjectFieldId());
+
+		return _objectDefinitionLocalService.getObjectDefinition(
+			objectRelationship.getObjectDefinitionId1());
+	}
+
+	@Override
 	public Page<Object> getRelatedSystemObjectEntries(
 			ObjectDefinition objectDefinition, Long objectEntryId,
 			String objectRelationshipName, Pagination pagination)
@@ -638,6 +655,32 @@ public class DefaultObjectEntryManagerImpl
 					_systemObjectDefinitionMetadataRegistry.
 						getSystemObjectDefinitionMetadata(
 							relatedObjectDefinition.getName()))));
+	}
+
+	@Override
+	public Object getSystemBaseModel(
+			DTOConverterContext dtoConverterContext,
+			ObjectDefinition objectDefinition, long primaryKey)
+		throws Exception {
+
+		if (FeatureFlagManagerUtil.isEnabled("LPS-172094")) {
+			SystemObjectDefinitionMetadata systemObjectDefinitionMetadata =
+				_systemObjectDefinitionMetadataRegistry.
+					getSystemObjectDefinitionMetadata(
+						objectDefinition.getName());
+
+			return DTOConverterUtil.toDTO(
+				systemObjectDefinitionMetadata.
+					getBaseModelByExternalReferenceCode(
+						systemObjectDefinitionMetadata.getExternalReferenceCode(
+							primaryKey),
+						objectDefinition.getCompanyId()),
+				_dtoConverterRegistry, systemObjectDefinitionMetadata,
+				dtoConverterContext.getUser());
+		}
+
+		return _objectEntryLocalService.getSystemModelAttributes(
+			objectDefinition, primaryKey);
 	}
 
 	@Override

--- a/modules/apps/object/object-storage-salesforce/src/main/java/com/liferay/object/storage/salesforce/internal/rest/manager/v1_0/SalesforceObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-storage-salesforce/src/main/java/com/liferay/object/storage/salesforce/internal/rest/manager/v1_0/SalesforceObjectEntryManagerImpl.java
@@ -259,9 +259,26 @@ public class SalesforceObjectEntryManagerImpl
 	}
 
 	@Override
+	public ObjectDefinition getObjectRelationshipObjectDefinition1(
+			ObjectDefinition objectDefinition1, String objectField2Name)
+		throws Exception {
+
+		return null;
+	}
+
+	@Override
 	public Page<Object> getRelatedSystemObjectEntries(
 			ObjectDefinition objectDefinition, Long objectEntryId,
 			String objectRelationshipName, Pagination pagination)
+		throws Exception {
+
+		return null;
+	}
+
+	@Override
+	public Object getSystemBaseModel(
+			DTOConverterContext dtoConverterContext,
+			ObjectDefinition objectDefinition, long primaryKey)
 		throws Exception {
 
 		return null;


### PR DESCRIPTION
Hi Team,

https://issues.liferay.com/browse/LPS-178473

Issue:
If a System object had a one to many relationship to a Custom object, then graphQL couldn't fetch the right data.

Solution:
There was a fix for Custom object - Custom object relationship graphQL issue, but if there is a System object in the relationship then we need to use a different manager. Checking if the base model is a System one and using the right manager according to this fixed the issue. The PTR also helped fixing the issue (https://issues.liferay.com/browse/PTR-3786).

I tested it in my local environment and the solution worked as expected.

Please review my PR!

Best regards,
Dani