### PR TITLE
[TS] LPS-180854 DDL Display Spreadsheet view in non-Editable mode - remove empty lines at the bottom

### DIFF
--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/view_spreadsheet_records.jsp
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/view_spreadsheet_records.jsp
@@ -129,10 +129,14 @@ DDMStructure ddmStructure = recordSet.getDDMStructure();
 		return a.displayIndex - b.displayIndex;
 	});
 
-	var data = Liferay.SpreadSheet.buildEmptyRecords(
-		<%= Math.max(recordSet.getMinDisplayRows() - records.size(), 0) %>,
-		keys
-	);
+	var data = [];
+
+	<c:if test="<%= editable %>">
+		data = Liferay.SpreadSheet.buildEmptyRecords(
+			<%= Math.max(recordSet.getMinDisplayRows() - records.size(), 0) %>,
+			keys
+		);
+	</c:if>
 
 	records.forEach((item, index) => {
 		data.splice(item.displayIndex, 0, item);


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

Motivation
=======
Some end users use non-editable DDL Display widgets on pages, in Spreadsheet View.
They noticed that they always see an additional empty line at the bottom of the lists, which is annoying and provides a poor end-user experience. They would not like to see any empty lines at the bottom of the lists in such widgets (especially when they are non-editable, so only for viewing)

Proposed Solution
========
Not displaying the empty lines in the Spreadsheet View. This is applied only to lines that contain no data at all. Lines that hold fields whose value has been set to empty or blank are still being displayed, perhaps to be edited at a later time.

Steps to Verify
========
Please see the linked LPS for the reproduction steps.
https://issues.liferay.com/browse/LPS-180854

Thank you and best regards,
István