### PR TITLE
LPS-180758 Performance issue when nesting fieldsets

### DIFF
--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/strategy/NestedFieldsSupportMapToDDMFormValuesConverterStrategy.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/strategy/NestedFieldsSupportMapToDDMFormValuesConverterStrategy.java
@@ -19,12 +19,8 @@ import com.liferay.dynamic.data.mapping.model.DDMFormField;
 import com.liferay.dynamic.data.mapping.storage.DDMFormFieldValue;
 import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
 import com.liferay.dynamic.data.mapping.util.DDM;
-import com.liferay.petra.string.StringBundler;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
-import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -67,47 +63,6 @@ public class NestedFieldsSupportMapToDDMFormValuesConverterStrategy
 	private NestedFieldsSupportMapToDDMFormValuesConverterStrategy() {
 	}
 
-	private void _addMissingValues(
-		Map<String, DDMFormField> ddmFormFieldsMap, Locale locale,
-		Map<String, Object> values) {
-
-		for (Map.Entry<String, DDMFormField> entry :
-				ddmFormFieldsMap.entrySet()) {
-
-			boolean match = false;
-
-			for (String key : values.keySet()) {
-				if (StringUtil.startsWith(key, entry.getKey())) {
-					match = true;
-
-					break;
-				}
-			}
-
-			if (match) {
-				continue;
-			}
-
-			Object value = StringPool.BLANK;
-
-			DDMFormField ddmFormField = entry.getValue();
-
-			if (ddmFormField.isLocalizable()) {
-				value = HashMapBuilder.<String, Object>put(
-					LocaleUtil.toLanguageId(locale), StringPool.BLANK
-				).build();
-			}
-
-			values.put(
-				StringBundler.concat(
-					entry.getKey(), DDM.INSTANCE_SEPARATOR,
-					StringUtil.randomString()),
-				HashMapBuilder.<String, Object>put(
-					"value", value
-				).build());
-		}
-	}
-
 	private DDMFormFieldValue _createDDMFormFieldValue(
 		DDMFormField ddmFormField, Map<String, DDMFormField> ddmFormFields,
 		Map<String, Object> fieldInstanceValue, String instanceId,
@@ -134,9 +89,6 @@ public class NestedFieldsSupportMapToDDMFormValuesConverterStrategy
 				(Map<String, Object>)GetterUtil.getObject(
 					fieldInstanceValue.get("nestedValues"),
 					new HashMap<String, Object>());
-
-			_addMissingValues(
-				ddmFormField.getNestedDDMFormFieldsMap(), locale, nestedValues);
 
 			if (MapUtil.isEmpty(nestedValues)) {
 				return ddmFormFieldValue;


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

Motivation
=======
[NestedFieldsSupportMapToDDMFormValuesConverterStrategy._addMissingValues](https://github.com/liferay/liferay-portal/blob/master/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/strategy/NestedFieldsSupportMapToDDMFormValuesConverterStrategy.java#L70) adds the nested fields to `DDMFormFieldValue` in a flat manner, meaning that in the exported structure (like in a template context) they will appear beside the parent structure in addition to being embedded in the parent structure.
This bloats the exported structure with incorrect redundant data that may lead to performance issues with verbose fields, for example, Rich Text.

Proposed Solution
========
Removing the `_addMissingValues` method as it is not needed to solve [LPS-130056](https://issues.liferay.com/browse/LPS-130056) and it also fills the exported structure with redundant data. 

Steps to Verify
========
Please see the linked LPS for the reproduction steps.
https://issues.liferay.com/browse/LPS-180758

Thank you and best regards,
István