### PR TITLE
[TS] LPS-181705 Add fetchMissingReference for DDMDataProviderInstanceStagedModelRepository

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-web/src/main/java/com/liferay/dynamic/data/mapping/data/provider/web/internal/exportimport/staged/model/repository/DDMDataProviderInstanceStagedModelRepository.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-web/src/main/java/com/liferay/dynamic/data/mapping/data/provider/web/internal/exportimport/staged/model/repository/DDMDataProviderInstanceStagedModelRepository.java
@@ -28,6 +28,7 @@ import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.exportimport.kernel.lar.PortletDataException;
 import com.liferay.exportimport.kernel.lar.StagedModelModifiedDateComparator;
 import com.liferay.exportimport.staged.model.repository.StagedModelRepository;
+import com.liferay.exportimport.staged.model.repository.StagedModelRepositoryHelper;
 import com.liferay.portal.kernel.dao.orm.ExportActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -109,6 +110,13 @@ public class DDMDataProviderInstanceStagedModelRepository
 	}
 
 	@Override
+	public DDMDataProviderInstance fetchMissingReference(
+		String uuid, long groupId) {
+
+		return _stagedModelRepositoryHelper.fetchMissingReference(
+			uuid, groupId, this);
+	}
+
 	public DDMDataProviderInstance fetchStagedModelByUuidAndGroupId(
 		String uuid, long groupId) {
 
@@ -217,5 +225,8 @@ public class DDMDataProviderInstanceStagedModelRepository
 
 	@Reference(target = "(ddm.form.values.deserializer.type=json)")
 	private DDMFormValuesDeserializer _jsonDDMFormValuesDeserializer;
+
+	@Reference
+	private StagedModelRepositoryHelper _stagedModelRepositoryHelper;
 
 }


### PR DESCRIPTION
Hello @liferay-forms,
this pull fixes [LPS-181705](https://issues.liferay.com/browse/LPS-181705).
We used _DDMFormInstanceStagedModelRepository_ as pattern to add the [fetchMissingReference](https://github.com/danielmijarra/liferay-portal/blob/master/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/exportimport/staged/model/repository/DDMFormInstanceStagedModelRepository.java#L115-L119) method.

Please let me note if you have any questions.