### PR TITLE
LPS-183803 - Select file pop-up window from upload field does not have any context when editing a form entry 

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/document/library/DocumentLibraryDDMFormFieldTemplateContextContributor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/document/library/DocumentLibraryDDMFormFieldTemplateContextContributor.java
@@ -105,6 +105,12 @@ public class DocumentLibraryDDMFormFieldTemplateContextContributor
 		DDMFormField ddmFormField,
 		DDMFormFieldRenderingContext ddmFormFieldRenderingContext) {
 
+		ThemeDisplay themeDisplay = getThemeDisplay(
+			ddmFormFieldRenderingContext.getHttpServletRequest());
+
+		ddmFormFieldRenderingContext.setProperty(
+			"groupId", themeDisplay.getScopeGroupId());
+
 		return HashMapBuilder.<String, Object>put(
 			"allowGuestUsers",
 			GetterUtil.getBoolean(ddmFormField.getProperty("allowGuestUsers"))

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/document/library/DocumentLibraryDDMFormFieldTemplateContextContributor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/document/library/DocumentLibraryDDMFormFieldTemplateContextContributor.java
@@ -105,12 +105,6 @@ public class DocumentLibraryDDMFormFieldTemplateContextContributor
 		DDMFormField ddmFormField,
 		DDMFormFieldRenderingContext ddmFormFieldRenderingContext) {
 
-		ThemeDisplay themeDisplay = getThemeDisplay(
-			ddmFormFieldRenderingContext.getHttpServletRequest());
-
-		ddmFormFieldRenderingContext.setProperty(
-			"groupId", themeDisplay.getScopeGroupId());
-
 		return HashMapBuilder.<String, Object>put(
 			"allowGuestUsers",
 			GetterUtil.getBoolean(ddmFormField.getProperty("allowGuestUsers"))

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/java/com/liferay/dynamic/data/mapping/form/renderer/internal/DDMFormFieldTemplateContextFactory.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/java/com/liferay/dynamic/data/mapping/form/renderer/internal/DDMFormFieldTemplateContextFactory.java
@@ -115,13 +115,6 @@ public class DDMFormFieldTemplateContextFactory {
 			_ddmFormFieldValues, StringPool.BLANK);
 	}
 
-	protected ThemeDisplay getThemeDisplay(
-		HttpServletRequest httpServletRequest) {
-
-		return (ThemeDisplay)httpServletRequest.getAttribute(
-			WebKeys.THEME_DISPLAY);
-	}
-
 	protected void setDDMFormFieldTypeServicesRegistry(
 		DDMFormFieldTypeServicesRegistry ddmFormFieldTypeServicesRegistry) {
 
@@ -170,19 +163,20 @@ public class DDMFormFieldTemplateContextFactory {
 				"ddmFormInstanceRecordId", ddmFormInstanceRecordId);
 		}
 
-		ddmFormFieldRenderingContext.setProperty(
-			"groupId", _ddmFormRenderingContext.getGroupId());
-
-		long groupId = GetterUtil.getLong(
-			ddmFormFieldRenderingContext.getProperty("groupId"));
+		long groupId = _ddmFormRenderingContext.getGroupId();
 
 		if (groupId == 0) {
-			ThemeDisplay themeDisplay = getThemeDisplay(
-				ddmFormFieldRenderingContext.getHttpServletRequest());
+			HttpServletRequest httpServletRequest =
+				ddmFormFieldRenderingContext.getHttpServletRequest();
 
-			ddmFormFieldRenderingContext.setProperty(
-				"groupId", themeDisplay.getScopeGroupId());
+			ThemeDisplay themeDisplay =
+				(ThemeDisplay)httpServletRequest.getAttribute(
+					WebKeys.THEME_DISPLAY);
+
+			groupId = themeDisplay.getScopeGroupId();
 		}
+
+		ddmFormFieldRenderingContext.setProperty("groupId", groupId);
 
 		ddmFormFieldRenderingContext.setReturnFullContext(
 			_ddmFormRenderingContext.isReturnFullContext());

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/java/com/liferay/dynamic/data/mapping/form/renderer/internal/DDMFormFieldTemplateContextFactory.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/java/com/liferay/dynamic/data/mapping/form/renderer/internal/DDMFormFieldTemplateContextFactory.java
@@ -50,6 +50,7 @@ import com.liferay.portal.kernel.language.constants.LanguageConstants;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HtmlParser;
@@ -59,6 +60,7 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.util.WebKeys;
 
 import java.math.BigDecimal;
 
@@ -70,6 +72,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+
+import javax.servlet.http.HttpServletRequest;
 
 /**
  * @author Marcellus Tavares
@@ -109,6 +113,13 @@ public class DDMFormFieldTemplateContextFactory {
 	public List<Object> create() {
 		return _createDDMFormFieldTemplateContexts(
 			_ddmFormFieldValues, StringPool.BLANK);
+	}
+
+	protected ThemeDisplay getThemeDisplay(
+		HttpServletRequest httpServletRequest) {
+
+		return (ThemeDisplay)httpServletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
 	}
 
 	protected void setDDMFormFieldTypeServicesRegistry(
@@ -161,6 +172,18 @@ public class DDMFormFieldTemplateContextFactory {
 
 		ddmFormFieldRenderingContext.setProperty(
 			"groupId", _ddmFormRenderingContext.getGroupId());
+
+		long groupId = GetterUtil.getLong(
+			ddmFormFieldRenderingContext.getProperty("groupId"));
+
+		if (groupId == 0) {
+			ThemeDisplay themeDisplay = getThemeDisplay(
+				ddmFormFieldRenderingContext.getHttpServletRequest());
+
+			ddmFormFieldRenderingContext.setProperty(
+				"groupId", themeDisplay.getScopeGroupId());
+		}
+
 		ddmFormFieldRenderingContext.setReturnFullContext(
 			_ddmFormRenderingContext.isReturnFullContext());
 		ddmFormFieldRenderingContext.setViewMode(


### PR DESCRIPTION
_**Steps to reproduce:**_
1. Log in as Admin
2. Create a new form with an upload field in it
3. Drag this form on any page
4. Fill the form with a dummy file and submit
5. Navigate to Site Menu > Content and Data > Forms > Options for the test form > View Entries > Options for the entry > Edit > Click on one of the Upload Field Select button
6. See the pop-up window without options


Expected Result: The user can choose and upload a new file successfully.

Actual Results: The pop-up window comes up but does not have nay options only the title is visible. 

_**Solution proposed:**_

I did some investigation and discovered that there is no request being made after we click the upload file selection button. This happened because the variable responsible for storing the request URL (itemSelectorURL) was null, so the request could not be made at all.

This variable is created in a back-end class, and depends on the field's context having a valid **groupId**. After debugging I found that the groupId was not being set correctly in the field context.
