### PR TITLE
LPS-184111 Check if it exists before adding to avoid duplicate key.

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMDataDefinitionConverterImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMDataDefinitionConverterImpl.java
@@ -239,11 +239,19 @@ public class DDMDataDefinitionConverterImpl
 			long fieldSetDDMStructureId = GetterUtil.getLong(
 				ddmFormField.getProperty("ddmStructureId"));
 
-			if (fieldSetDDMStructureId != 0) {
+			DEDataDefinitionFieldLink deDataDefinitionFieldLink =
 				_deDataDefinitionFieldLinkLocalService.
-					addDEDataDefinitionFieldLink(
-						groupId, classNameId, dataDefinitionId,
-						fieldSetDDMStructureId, ddmFormField.getName());
+					fetchDEDataDefinitionFieldLinks(
+						classNameId, dataDefinitionId, fieldSetDDMStructureId,
+						ddmFormField.getName());
+
+			if (fieldSetDDMStructureId != 0) {
+				if (deDataDefinitionFieldLink == null) {
+					_deDataDefinitionFieldLinkLocalService.
+						addDEDataDefinitionFieldLink(
+							groupId, classNameId, dataDefinitionId,
+							fieldSetDDMStructureId, ddmFormField.getName());
+				}
 
 				_addDataDefinitionFieldLinks(
 					classNameId, dataDefinitionId,

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMDataDefinitionConverterImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMDataDefinitionConverterImpl.java
@@ -239,24 +239,26 @@ public class DDMDataDefinitionConverterImpl
 			long fieldSetDDMStructureId = GetterUtil.getLong(
 				ddmFormField.getProperty("ddmStructureId"));
 
+			if (fieldSetDDMStructureId == 0) {
+				continue;
+			}
+
 			DEDataDefinitionFieldLink deDataDefinitionFieldLink =
 				_deDataDefinitionFieldLinkLocalService.
 					fetchDEDataDefinitionFieldLinks(
 						classNameId, dataDefinitionId, fieldSetDDMStructureId,
 						ddmFormField.getName());
 
-			if (fieldSetDDMStructureId != 0) {
-				if (deDataDefinitionFieldLink == null) {
-					_deDataDefinitionFieldLinkLocalService.
-						addDEDataDefinitionFieldLink(
-							groupId, classNameId, dataDefinitionId,
-							fieldSetDDMStructureId, ddmFormField.getName());
-				}
-
-				_addDataDefinitionFieldLinks(
-					classNameId, dataDefinitionId,
-					ddmFormField.getNestedDDMFormFields(), groupId);
+			if (deDataDefinitionFieldLink == null) {
+				_deDataDefinitionFieldLinkLocalService.
+					addDEDataDefinitionFieldLink(
+						groupId, classNameId, dataDefinitionId,
+						fieldSetDDMStructureId, ddmFormField.getName());
 			}
+
+			_addDataDefinitionFieldLinks(
+				classNameId, dataDefinitionId,
+				ddmFormField.getNestedDDMFormFields(), groupId);
 		}
 	}
 


### PR DESCRIPTION
**7.3 to 7.4 com.liferay.dynamic.data.mapping.service upgrade results in a Index duplicate entry**

The issue is the same as [LPS-144100](https://issues.liferay.com/browse/LPS-144100) but in the other add method.

The issue appears as a duplicate entry:

Caused by: com.liferay.portal.kernel.log.LogSanitizerException: java.sql.BatchUpdateException: ORA-00001: unique constraint (LIFERAYPROMG.IX_998C30ED) violated_ [Sanitized]