### PR TITLE
LPS-184158 ERROR: duplicate key value violates unique constraint "ix_998c30ed" when publishing a Webcontent structure in Remote Staging after upgrading from 7.2 to 7.4

### DIFF
--- a/modules/apps/data-engine/data-engine-service/src/main/java/com/liferay/data/engine/internal/exportimport/data/handler/DEDataDefinitionFieldLinkStagedModelDataHandler.java
+++ b/modules/apps/data-engine/data-engine-service/src/main/java/com/liferay/data/engine/internal/exportimport/data/handler/DEDataDefinitionFieldLinkStagedModelDataHandler.java
@@ -15,6 +15,7 @@
 package com.liferay.data.engine.internal.exportimport.data.handler;
 
 import com.liferay.data.engine.model.DEDataDefinitionFieldLink;
+import com.liferay.data.engine.service.DEDataDefinitionFieldLinkLocalService;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.model.DDMStructureLayout;
 import com.liferay.dynamic.data.mapping.model.DDMStructureVersion;
@@ -201,6 +202,16 @@ public class DEDataDefinitionFieldLinkStagedModelDataHandler
 				deDataDefinitionFieldLink.getUuid(),
 				portletDataContext.getScopeGroupId());
 
+		if (existingDEDataDefinitionFieldLink == null) {
+			existingDEDataDefinitionFieldLink =
+				_deDataDefinitionFieldLinkLocalService.
+					fetchDEDataDefinitionFieldLinks(
+						deDataDefinitionFieldLink.getClassNameId(),
+						deDataDefinitionFieldLink.getClassPK(),
+						deDataDefinitionFieldLink.getDdmStructureId(),
+						deDataDefinitionFieldLink.getFieldName());
+		}
+
 		if ((existingDEDataDefinitionFieldLink == null) ||
 			!portletDataContext.isDataStrategyMirror()) {
 
@@ -239,6 +250,10 @@ public class DEDataDefinitionFieldLinkStagedModelDataHandler
 
 	@Reference
 	private DDMStructureVersionLocalService _ddmStructureVersionLocalService;
+
+	@Reference
+	private DEDataDefinitionFieldLinkLocalService
+		_deDataDefinitionFieldLinkLocalService;
 
 	@Reference
 	private Portal _portal;


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-184158

**Root cause of the issue:**
 - The upgrade **com.liferay.dynamic.data.mapping.internal.upgrade.v4_0_0.DDMStructureUpgradeProcess** (added by LPS-103896) is creating new records in DEDataDefinitionFieldLink table with new generated UUIDs
 - But if you have a installation with remote staging configured and you upgrade both Staging and Live servers, the new generated UUIDs in each databases won't match
 - So after the upgrade from 7.2 to 7.4, If you publish from staging to live you can end having a duplicate key value violates unique constraint "ix_998c30ed"

The error is only reproduced when the records from Staging environments have the same ids than the Live, causing the unique constraint "ix_998c30ed" violation. (for example if the Staging environment in 7.2 was clone from the live environment)

*Solution:*

The solution is to apply a similar solution than LayoutClassedModelUsageStagedModelDataHandler, using both ids and UUID+groupId to find the existing record see:
 * https://github.com/liferay/liferay-portal/blob/29a3d384841d7b475347125aab460715b7175b84/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/exportimport/data/handler/LayoutClassedModelUsageStagedModelDataHandler.java#L229-L240
