### PR TITLE
LPS-184600 | Master 

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-evaluator-impl/src/main/java/com/liferay/dynamic/data/mapping/form/evaluator/internal/helper/DDMFormEvaluatorRuleHelper.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-evaluator-impl/src/main/java/com/liferay/dynamic/data/mapping/form/evaluator/internal/helper/DDMFormEvaluatorRuleHelper.java
@@ -92,7 +92,7 @@ public class DDMFormEvaluatorRuleHelper {
 
 			UpdateFieldPropertyRequest.Builder builder =
 				UpdateFieldPropertyRequest.Builder.newBuilder(
-					ddmFormField.getName(), "visible", false);
+					ddmFormField.getName(), "visible", true);
 
 			_ddmFormEvaluatorExpressionObserver.updateFieldProperty(
 				builder.build());


### PR DESCRIPTION
[LPS-184600 - Form field with show rule is not displayed for user related to it](https://issues.liferay.com/browse/LPS-184600)

**Steps to reproduce:**
1. In Control Panel, create two new Roles and name them as Lite User and Quality
2. Create two new users and assign one as Lite User role (User1) and the other as Quality role (User2). Also assign the new users to the Site Liferay DXP
3. In Control Panel > Process Builder > Edit the Single Approver Workflow > Click on Review and edit its Assignment to "Quality Role", only
4. Go to Content & Data > Form > Import the attached .lar file ([here](https://issues.liferay.com/secure/attachment/499705/Forms-202305120146.portlet.lar)) > Open it
5. In the Form Rules > Edit the first Rule to "Quality" and the second one to "Lite User" > Save it and Publish
6. Click on Share and copy the link > Sign out
7. Open the link as User1 and fill out the form > Sign out
8. Sign in as User 2 > Go to My Workflow Tasks > Assigned to my Roles > Assign the role to myself
9. In the Preview of Form Record > Edit it > Upload a file > Reject the Workflow > Sign out
10. Sign in again as User 1 > Open the rejected Workflow in Notifications > Check the Preview of Form Record

  **Expected Result:**
The upload file field should be displayed, as set in the Forms Rules (step 5)

 **Actual Results:**
The upload file field is not displayed 