### PR TITLE
LPS-184158 Additional commit

### DIFF
--- a/modules/apps/data-engine/data-engine-service/src/main/java/com/liferay/data/engine/internal/exportimport/data/handler/DEDataDefinitionFieldLinkStagedModelDataHandler.java
+++ b/modules/apps/data-engine/data-engine-service/src/main/java/com/liferay/data/engine/internal/exportimport/data/handler/DEDataDefinitionFieldLinkStagedModelDataHandler.java
@@ -206,10 +206,10 @@ public class DEDataDefinitionFieldLinkStagedModelDataHandler
 			existingDEDataDefinitionFieldLink =
 				_deDataDefinitionFieldLinkLocalService.
 					fetchDEDataDefinitionFieldLinks(
-						deDataDefinitionFieldLink.getClassNameId(),
-						deDataDefinitionFieldLink.getClassPK(),
-						deDataDefinitionFieldLink.getDdmStructureId(),
-						deDataDefinitionFieldLink.getFieldName());
+						importedDEDataDefinitionFieldLink.getClassNameId(),
+						importedDEDataDefinitionFieldLink.getClassPK(),
+						importedDEDataDefinitionFieldLink.getDdmStructureId(),
+						importedDEDataDefinitionFieldLink.getFieldName());
 		}
 
 		if ((existingDEDataDefinitionFieldLink == null) ||


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-184158

Original fix of LPS-184158 was sent here https://github.com/liferay-forms/liferay-portal/pull/2214 and merged by Brian here https://github.com/brianchandotcom/liferay-portal/pull/134846

But the original fix has an minor bug, it is using `deDataDefinitionFieldLink` var instead of using `importedDEDataDefinitionFieldLink` that is a copy with modified classPk. 

The classPk of `importedDEDataDefinitionFieldLink` is modified with the information from Live side, so we should use it.

In this PR I am just sending an additional commit that changes the used var.

Let me know if you have any question.