### PR TITLE
[TS] LPS-185807 Only up to 21 Fieldsets are listed in the Form Builder

### DIFF
--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/FormBuilder.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/FormBuilder.js
@@ -71,7 +71,7 @@ export function FormBuilder() {
 
 			if (groupId) {
 				globalFieldSetsPromise = getItem(
-					`/o/data-engine/v2.0/sites/${groupId}/data-definitions/by-content-type/${contentType}`
+					`/o/data-engine/v2.0/sites/${groupId}/data-definitions/by-content-type/${contentType}?page=-1&pageSize=-1`
 				);
 			}
 
@@ -79,7 +79,7 @@ export function FormBuilder() {
 				groupId === themeDisplay.getCompanyGroupId()
 					? Promise.resolve({})
 					: getItem(
-							`/o/data-engine/v2.0/data-definitions/by-content-type/${contentType}`
+							`/o/data-engine/v2.0/data-definitions/by-content-type/${contentType}?page=-1&pageSize=-1`
 					  );
 
 			const fetchFieldSets = async () => {


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

Motivation
=======
Only up to 21 Fieldsets are listed in the Form Builder due to the default pagination settings.
Those are set in [PaginationContextProvider](https://github.com/liferay/liferay-portal/blob/master/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/context/provider/PaginationContextProvider.java#L47-L48)

Proposed Solution
========
By setting the page and pageSize parameters to -1, the [start](https://github.com/liferay/liferay-portal/blob/master/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/pagination/Pagination.java#L45) and [end](https://github.com/liferay/liferay-portal/blob/master/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/pagination/Pagination.java#L29) position will be -1 as well, thus all entries will be returned by the query.

Steps to Verify
========
Please see the linked LPS for the reproduction steps.
https://issues.liferay.com/browse/LPS-185807

Thank you and best regards,
István