### PR TITLE
LPS-184939 Add remaining localizable parameters in Image Picker

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/ImagePicker/ImagePicker.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/ImagePicker/ImagePicker.es.js
@@ -15,6 +15,7 @@
 import ClayButton from '@clayui/button';
 import ClayForm, {ClayInput} from '@clayui/form';
 import ClayModal, {useModal} from '@clayui/modal';
+import {usePrevious} from '@liferay/frontend-js-react-web';
 import {addParams, openSelectionModal, sub} from 'frontend-js-web';
 import React, {useState} from 'react';
 
@@ -259,10 +260,13 @@ const ImagePicker = ({
 };
 
 const Main = ({
+	defaultLanguageId,
 	displayErrors,
 	editingLanguageId,
 	errorMessage,
 	id,
+	localizable,
+	localizedValue = {},
 	inputValue,
 	itemSelectorURL,
 	message,
@@ -276,6 +280,15 @@ const Main = ({
 	value,
 	...otherProps
 }) => {
+	const prevEditingLanguageId = usePrevious(editingLanguageId);
+
+	if (prevEditingLanguageId !== editingLanguageId && localizable) {
+		value =
+			localizedValue[editingLanguageId] !== undefined
+				? localizedValue[editingLanguageId]
+				: localizedValue[defaultLanguageId];
+	}
+
 	const getErrorMessages = (errorMessage, isSignedIn) => {
 		const errorMessages = [errorMessage];
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/ImagePicker/ImagePicker.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/ImagePicker/ImagePicker.es.js
@@ -284,9 +284,8 @@ const Main = ({
 
 	if (prevEditingLanguageId !== editingLanguageId && localizable) {
 		value =
-			localizedValue[editingLanguageId] !== undefined
-				? localizedValue[editingLanguageId]
-				: localizedValue[defaultLanguageId];
+			localizedValue[editingLanguageId] ??
+			localizedValue[defaultLanguageId];
 	}
 
 	const getErrorMessages = (errorMessage, isSignedIn) => {

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/FDSView.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/FDSView.d.ts
@@ -12,6 +12,8 @@
  * details.
  */
 
+/// <reference types="react" />
+
 import {IClientExtensionCellRenderer} from './api';
 import '../css/FDSView.scss';
 import {FDSViewType} from './FDSViews';

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/Details.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/Details.d.ts
@@ -12,6 +12,8 @@
  * details.
  */
 
+/// <reference types="react" />
+
 import {IFDSViewSectionInterface} from '../FDSView';
 declare const Details: ({
 	fdsView,

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/Fields.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/Fields.d.ts
@@ -12,6 +12,8 @@
  * details.
  */
 
+/// <reference types="react" />
+
 import {IFDSViewSectionInterface} from '../FDSView';
 import '../../css/FDSEntries.scss';
 declare const Fields: ({

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/Sorting.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/Sorting.d.ts
@@ -12,6 +12,8 @@
  * details.
  */
 
+/// <reference types="react" />
+
 import {IFDSViewSectionInterface} from '../FDSView';
 declare const Sorting: ({
 	fdsView,


### PR DESCRIPTION
### **Context:** https://issues.liferay.com/browse/LPS-184939

### **Steps to reproduce:**
1. From System Settings, enable Changeable Default Language option for Web Content. 
 2. Add a new structure 'test' with a text and image field.
 3. Create a new WC based on 'test' and define some values for the site's default locale (en_US):
 - Title: _title_
 - Text: _hello_
- Image: upload an image -- image1.
 4. Change the web content default language to es_ES in basic information.
 5. Define values for es_ES:
 - Title: _titulo_
 - Text: _hola_
 - Image: upload a different image -- image2.
 6. Change the language selector to ca-ES and observe the values set.

### _Expected result:_ 
Title: titulo; Text: hola Image: image2 ✅ 

### _Current result:_ 
Title: titulo; Text: hola; Image: image1 🚫 