### PR TITLE
LPS-186364 Keep localizedValue inside the verification block so the value is not lost during the rendering

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/ImagePicker/ImagePicker.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/ImagePicker/ImagePicker.es.js
@@ -266,7 +266,7 @@ const Main = ({
 	errorMessage,
 	id,
 	localizable,
-	localizedValue = {},
+	localizedValue,
 	inputValue,
 	itemSelectorURL,
 	message,
@@ -324,6 +324,7 @@ const Main = ({
 			errorMessage={getErrorMessages(errorMessage, isSignedIn)}
 			id={id}
 			name={name}
+			localizedValue={localizedValue}
 			readOnly={isSignedIn ? readOnly : true}
 			valid={isSignedIn ? valid : false}
 		>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/ImagePicker/ImagePicker.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/ImagePicker/ImagePicker.es.js
@@ -265,10 +265,10 @@ const Main = ({
 	editingLanguageId,
 	errorMessage,
 	id,
-	localizable,
-	localizedValue,
 	inputValue,
 	itemSelectorURL,
+	localizable,
+	localizedValue,
 	message,
 	name,
 	onBlur,
@@ -323,8 +323,8 @@ const Main = ({
 			displayErrors={isSignedIn ? displayErrors : true}
 			errorMessage={getErrorMessages(errorMessage, isSignedIn)}
 			id={id}
-			name={name}
 			localizedValue={localizedValue}
+			name={name}
 			readOnly={isSignedIn ? readOnly : true}
 			valid={isSignedIn ? valid : false}
 		>


### PR DESCRIPTION
### **Context:** [LPS-186364](https://issues.liferay.com/browse/LPS-186364)

### _Regressing bug caused by [LPS-184939](https://issues.liferay.com/browse/LPS-184939)_

### *Step to reproduce:*

-  Add a new site
- Upload an image as a document to Documents and Media
- Add a web content structure with an Image field
- Add a web content
- Select the document in Image field
- Publish
- Edit the web content

:heavy_check_mark: *Expected Results:*
The selected image should be shown on Image field.

:x: *Actual Results:*
The Image field is empty.