### PR TITLE
LPS-187024 Add AI-Creator button to web contents CKEditor when configuration is enabled

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/build.gradle
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/build.gradle
@@ -8,6 +8,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.annotation.versioning", version: "1.1.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
+	compileOnly project(":apps:ai-creator:ai-creator-openai-api")
 	compileOnly project(":apps:captcha:captcha-taglib")
 	compileOnly project(":apps:configuration-admin:configuration-admin-api")
 	compileOnly project(":apps:document-library:document-library-api")

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/rich/text/RichTextDDMFormFieldTemplateContextContributor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/rich/text/RichTextDDMFormFieldTemplateContextContributor.java
@@ -14,6 +14,7 @@
 
 package com.liferay.dynamic.data.mapping.form.field.type.internal.rich.text;
 
+import com.liferay.ai.creator.openai.manager.AICreatorOpenAIManager;
 import com.liferay.dynamic.data.mapping.form.field.type.DDMFormFieldTemplateContextContributor;
 import com.liferay.dynamic.data.mapping.form.field.type.constants.DDMFormFieldTypeConstants;
 import com.liferay.dynamic.data.mapping.form.field.type.internal.util.DDMFormFieldTypeUtil;
@@ -82,13 +83,21 @@ public class RichTextDDMFormFieldTemplateContextContributor
 				).put(
 					"liferay-ui:input-editor:name",
 					ddmFormFieldRenderingContext.getName()
+				).put(
+					"liferay-ui:input-editor:showAICreator",
+					_aiCreatorOpenAIManager.isAICreatorToolbarEnabled(
+						themeDisplay.getCompanyId(),
+						themeDisplay.getScopeGroupId(),
+						ddmFormFieldRenderingContext.getPortletNamespace())
 				).build(),
-				(ThemeDisplay)httpServletRequest.getAttribute(
-					WebKeys.THEME_DISPLAY),
+				themeDisplay,
 				RequestBackedPortletURLFactoryUtil.create(httpServletRequest));
 
 		return editorConfiguration.getData();
 	}
+
+	@Reference
+	private AICreatorOpenAIManager _aiCreatorOpenAIManager;
 
 	@Reference
 	private EditorConfigurationFactory _editorConfigurationFactory;


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-187024

Hi Team ✋ 

From the Echo Team, we are working on a story to [Provide a button to trigger AI in the web content editor.](https://issues.liferay.com/browse/LPS-181285) As part of that story, we need to add an attribute that indicates if the toolbar should be added or not. 

I needed to set the attribute in the point instead of determining it directly in the CKEditor configuration since it is necessary to know if it is JournalPortlet or not and the portlet information sometimes is missing in the editor configuration but in this point, we always have the portletNamespace so I decide to use it.

Could you please review it?

Thanks in advance! ❤️ 