### PR TITLE
LPS-186579 Nothing happens after clicking "View Fields" from a field set

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/css/main.scss
@@ -418,6 +418,10 @@ textarea.script {
 		display: inline;
 		margin-right: 5px;
 	}
+
+	.select-button {
+		margin-top: 1rem;
+	}
 }
 
 .form-builder-placeholder {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/main.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/main.js
@@ -523,14 +523,16 @@ AUI.add(
 					const documentsAndMediaField = document.querySelector(
 						'.ddm-documents-and-media-field'
 					);
-					const isHidden = documentsAndMediaField.classList.contains(
-						'hide'
-					);
-					if (hasDocumentLibrary && isHidden) {
-						documentsAndMediaField.classList.remove('hide');
-					}
-					else if (!hasDocumentLibrary) {
-						documentsAndMediaField.classList.add('hide');
+					if (documentsAndMediaField !== null) {
+						const isHidden = documentsAndMediaField.classList.contains(
+							'hide'
+						);
+						if (hasDocumentLibrary && isHidden) {
+							documentsAndMediaField.classList.remove('hide');
+						}
+						else if (!hasDocumentLibrary) {
+							documentsAndMediaField.classList.add('hide');
+						}
 					}
 				},
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/css/main.scss
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/css/main.scss
@@ -168,7 +168,7 @@ $multi-step-progress-bar-fixed-width: 100px !default;
 	.kaleo-process-preview-fields-dialog {
 		.modal-content {
 			.modal-body {
-				overflow-y: hidden;
+				overflow-y: auto;
 
 				.checkbox {
 					margin-bottom: 0;


### PR DESCRIPTION
Related Issue: https://issues.liferay.com/browse/LPS-186579

When creating a new Kaleo Workflow Forms, after adding a field set, it was not possible to access _View Fields_. 

I noticed that [there was a change in this component last year](https://github.com/ericthmoritsuka/liferay-portal/commit/aac7101da39a663b9be80d368bdc50d588660151) that added a message if someone was trying to add a Document and Media without the proper permission.

The problem was being caused because the code was trying to read _classList_ from _null_ (I think the function __handleAlertMessages_ was being called in other moments that were not the ones intended by the previous alteration).

So, I added a condition to check if _documentsAndMediaField_ was not  _null_ and, only then, we would proceed with the rest of the documents and media check from the previous alteration.

As requested by @alinedoleron, I also brought back the scroll bar to make all fields visible (we could only do that by resizing the modal as it was).

And, I added a margin top to the _select_ button in the _form-builder-field_ because it was right next to the field and it did not look nice.