### PR TITLE
[TS] LPS-189059 Structure considered modified even if its not after every restart

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/build.gradle
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/build.gradle
@@ -1,4 +1,7 @@
 dependencies {
+	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: "2.13.4"
+	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-core", version: "2.13.4"
+	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.13.4.2"
 	compileOnly group: "com.liferay", name: "biz.aQute.bnd.annotation", version: "4.2.0.LIFERAY-PATCHED-2"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/exportimport/data/handler/DDMStructureStagedModelDataHandler.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/exportimport/data/handler/DDMStructureStagedModelDataHandler.java
@@ -14,6 +14,9 @@
 
 package com.liferay.dynamic.data.mapping.web.internal.exportimport.data.handler;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import com.liferay.data.engine.model.DEDataDefinitionFieldLink;
 import com.liferay.data.engine.service.DEDataDefinitionFieldLinkLocalService;
 import com.liferay.dynamic.data.mapping.constants.DDMPortletKeys;
@@ -66,6 +69,8 @@ import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.xml.Element;
+
+import java.io.IOException;
 
 import java.util.HashSet;
 import java.util.List;
@@ -480,6 +485,20 @@ public class DDMStructureStagedModelDataHandler
 	@Reference
 	protected JSONFactory jsonFactory;
 
+	private boolean _equalsJSON(String stringInput1, String stringInput2) {
+		try {
+			JsonNode jsonNode1 = _objectMapper.readTree(stringInput1);
+			JsonNode jsonNode2 = _objectMapper.readTree(stringInput2);
+
+			return jsonNode1.equals(jsonNode2);
+		}
+		catch (IOException ioException) {
+			_log.error(ioException);
+
+			return false;
+		}
+	}
+
 	private void _exportDDMDataProviderInstances(
 			PortletDataContext portletDataContext, DDMStructure structure,
 			Element structureElement)
@@ -769,7 +788,7 @@ public class DDMStructureStagedModelDataHandler
 
 		// Check other attributes
 
-		if (!Objects.equals(
+		if (!_equalsJSON(
 				existingStructure.getDefinition(), structure.getDefinition()) ||
 			!Objects.equals(
 				existingStructure.getDescriptionMap(),
@@ -861,6 +880,8 @@ public class DDMStructureStagedModelDataHandler
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		DDMStructureStagedModelDataHandler.class);
+
+	private static final ObjectMapper _objectMapper = new ObjectMapper();
 
 	@Reference
 	private DDM _ddm;


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

Motivation
=======
A web content is published the portal [checks](https://github.com/liferay/liferay-portal/blob/master/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/exportimport/data/handler/DDMStructureStagedModelDataHandler.java#L426) its referenced structure and determines if the structure has been modified or not. If it has been modified, all of the DDMFields are updated that are referencing this structure.
The issue is that after every server restart, the structure is deemed as modified even if it's not. This is because when the code [compares](https://github.com/liferay/liferay-portal/blob/master/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/exportimport/data/handler/DDMStructureStagedModelDataHandler.java#L772) the existing structure to the one that is being imported, the field order in their definition JSON is different.
This is because the JSON structure is written and then read from the exported file and the field order is altered during the serialization/deserialization process.

Proposed Solution
========
When comparing the structure definitions, the comparison should be made on the structural level ignoring the field order.

Steps to Verify
========
Please see the linked LPS for the reproduction steps.
https://liferay.atlassian.net/browse/LPS-189059

Thank you and best regards,
István