### PR TITLE
[TECHNICAL SUPPORT] LPS-188749 DDM's repeatable field loses localized data when created on non default locale

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -1333,7 +1333,9 @@ AUI.add(
 							locale === defaultLocale ||
 							(localizationMap[defaultLocale] !== undefined &&
 								value !== localizationMap[defaultLocale]) ||
-							localizationMap[locale] !== undefined
+							localizationMap[locale] !== undefined ||
+							(instance.get('repeatable') &&
+								localizationMap[locale] === undefined)
 						) {
 							localizationMap[locale] = value;
 						}


### PR DESCRIPTION
Hey,

[LPS-188749](https://liferay.atlassian.net/browse/LPS-188749)

We can have empty transaltions and we can repeat a field on a non default locale. Currently the updateLocalizationMap method did not take this into account, so I had to update it.
This issue is reproducible on master due to dynamic data list that still uses DDM under the hood.

Please review my changes

Thanks,