### PR TITLE
LPS-189754 Cannot filter a date ddm field using Elasticsearch 'now' keyword because the information is stored as String instead of using the 'date' type

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMIndexerImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMIndexerImpl.java
@@ -713,8 +713,12 @@ public class DDMIndexerImpl implements DDMIndexer {
 			else {
 				if (type.equals(DDMFormFieldTypeConstants.DATE)) {
 					try {
-						Date date = DateUtil.parseDate(
-							"yyyy-MM-dd", valueString, locale);
+						Date date = null;
+
+						if (!Validator.isBlank(valueString)) {
+							date = DateUtil.parseDate(
+								"yyyy-MM-dd", valueString, locale);
+						}
 
 						document.addDate(name.concat("_date"), date);
 					}
@@ -724,8 +728,12 @@ public class DDMIndexerImpl implements DDMIndexer {
 				}
 				else if (type.equals(DDMFormFieldTypeConstants.DATE_TIME)) {
 					try {
-						Date date = DateUtil.parseDate(
-							"yyyy-MM-dd hh:mm", valueString, locale);
+						Date date = null;
+
+						if (!Validator.isBlank(valueString)) {
+							date = DateUtil.parseDate(
+								"yyyy-MM-dd hh:mm", valueString, locale);
+						}
 
 						document.addDate(name.concat("_date"), date);
 					}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMIndexerImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMIndexerImpl.java
@@ -48,6 +48,7 @@ import com.liferay.portal.kernel.search.filter.QueryFilter;
 import com.liferay.portal.kernel.search.generic.BooleanQueryImpl;
 import com.liferay.portal.kernel.search.generic.NestedQuery;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.DateUtil;
 import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HtmlParser;
@@ -72,6 +73,7 @@ import java.io.Serializable;
 import java.math.BigDecimal;
 
 import java.text.Format;
+import java.text.ParseException;
 
 import java.util.Comparator;
 import java.util.Date;
@@ -141,7 +143,8 @@ public class DDMIndexerImpl implements DDMIndexer {
 
 						if (legacyDDMIndexFieldsEnabled) {
 							_addToDocument(
-								document, field, indexType, name, value);
+								document, field, indexType, locale, name,
+								value);
 						}
 						else if (value != null) {
 							fieldArray.addField(
@@ -158,13 +161,15 @@ public class DDMIndexerImpl implements DDMIndexer {
 					value = field.getValue(ddmFormValues.getDefaultLocale());
 
 					if (legacyDDMIndexFieldsEnabled) {
-						_addToDocument(document, field, indexType, name, value);
+						_addToDocument(
+							document, field, indexType,
+							ddmFormValues.getDefaultLocale(), name, value);
 					}
 					else if (value != null) {
 						fieldArray.addField(
 							createField(
-								ddmFormField, field, indexType, null, name,
-								value));
+								ddmFormField, field, indexType,
+								ddmFormValues.getDefaultLocale(), name, value));
 					}
 				}
 			}
@@ -428,7 +433,7 @@ public class DDMIndexerImpl implements DDMIndexer {
 		String valueFieldName = getValueFieldName(indexType, locale);
 
 		_addToDocument(
-			document, ddmStructureField, indexType, valueFieldName,
+			document, ddmStructureField, indexType, locale, valueFieldName,
 			_getSortableValue(ddmFormField, locale, value), value);
 
 		Map<String, com.liferay.portal.kernel.search.Field> documentFields =
@@ -601,16 +606,16 @@ public class DDMIndexerImpl implements DDMIndexer {
 	}
 
 	private void _addToDocument(
-			Document document, Field field, String indexType, String name,
-			Serializable value)
+			Document document, Field field, String indexType, Locale locale,
+			String name, Serializable value)
 		throws PortalException {
 
-		_addToDocument(document, field, indexType, name, value, value);
+		_addToDocument(document, field, indexType, locale, name, value, value);
 	}
 
 	private void _addToDocument(
-			Document document, Field field, String indexType, String name,
-			Serializable sortableValue, Serializable value)
+			Document document, Field field, String indexType, Locale locale,
+			String name, Serializable sortableValue, Serializable value)
 		throws PortalException {
 
 		if (value == null) {
@@ -706,7 +711,29 @@ public class DDMIndexerImpl implements DDMIndexer {
 						_jsonFactory.createJSONArray(valueString)));
 			}
 			else {
-				if (type.equals(DDMFormFieldTypeConstants.RICH_TEXT)) {
+				if (type.equals(DDMFormFieldTypeConstants.DATE)) {
+					try {
+						Date date = DateUtil.parseDate(
+							"yyyy-MM-dd", valueString, locale);
+
+						document.addDate(name.concat("_date"), date);
+					}
+					catch (ParseException parseException) {
+						throw new PortalException(parseException);
+					}
+				}
+				else if (type.equals(DDMFormFieldTypeConstants.DATE_TIME)) {
+					try {
+						Date date = DateUtil.parseDate(
+							"yyyy-MM-dd hh:mm", valueString, locale);
+
+						document.addDate(name.concat("_date"), date);
+					}
+					catch (ParseException parseException) {
+						throw new PortalException(parseException);
+					}
+				}
+				else if (type.equals(DDMFormFieldTypeConstants.RICH_TEXT)) {
 					valueString = _htmlParser.extractText(valueString);
 					sortableValueString = _htmlParser.extractText(
 						sortableValueString);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/META-INF/module-log4j.xml
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/META-INF/module-log4j.xml
@@ -6,6 +6,7 @@
 		<Logger level="WARN" name="com.liferay.dynamic.data.mapping.internal.storage.JSONDDMStorageAdapter" />
 		<Logger level="WARN" name="com.liferay.dynamic.data.mapping.internal.storage.JSONStorageAdapter" />
 		<Logger level="WARN" name="com.liferay.dynamic.data.mapping.internal.upgrade.v1_0_0.DynamicDataMappingUpgradeProcess" />
+		<Logger level="WARN" name="com.liferay.dynamic.data.mapping.internal.util" />
 		<Logger level="WARN" name="com.liferay.dynamic.data.mapping.verify.DDMServiceVerifyProcess" />
 	</Loggers>
 </Configuration>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/META-INF/module-log4j.xml
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/META-INF/module-log4j.xml
@@ -2,10 +2,9 @@
 
 <Configuration strict="true">
 	<Loggers>
-		<Logger level="WARN" name="com.liferay.dynamic.data.mapping.internal.io.exporter.DDMFormInstanceRecordXLSWriter" />
-		<Logger level="WARN" name="com.liferay.dynamic.data.mapping.internal.storage.JSONDDMStorageAdapter" />
-		<Logger level="WARN" name="com.liferay.dynamic.data.mapping.internal.storage.JSONStorageAdapter" />
-		<Logger level="WARN" name="com.liferay.dynamic.data.mapping.internal.upgrade.v1_0_0.DynamicDataMappingUpgradeProcess" />
+		<Logger level="WARN" name="com.liferay.dynamic.data.mapping.internal.io.exporter" />
+		<Logger level="WARN" name="com.liferay.dynamic.data.mapping.internal.storage" />
+		<Logger level="WARN" name="com.liferay.dynamic.data.mapping.internal.upgrade" />
 		<Logger level="WARN" name="com.liferay.dynamic.data.mapping.internal.util" />
 		<Logger level="WARN" name="com.liferay.dynamic.data.mapping.verify.DDMServiceVerifyProcess" />
 	</Loggers>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test-util/src/main/java/com/liferay/dynamic/data/mapping/test/util/search/TestOrderHelper.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test-util/src/main/java/com/liferay/dynamic/data/mapping/test/util/search/TestOrderHelper.java
@@ -90,9 +90,20 @@ public abstract class TestOrderHelper {
 
 	public void testOrderByDDMDateField() throws Exception {
 		testOrderByDDMField(
-			new String[] {"20160417192501", "20160417192510", "20160417192503"},
-			new String[] {"20160417192501", "20160417192503", "20160417192510"},
+			new String[] {"2016-04-17", "2016-04-20", "2016-04-18"},
+			new String[] {"2016-04-17", "2016-04-18", "2016-04-20"},
 			FieldConstants.DATE, DDMFormFieldTypeConstants.DATE);
+	}
+
+	public void testOrderByDDMDateTimeField() throws Exception {
+		testOrderByDDMField(
+			new String[] {
+				"2016-04-17 19:25", "2016-04-17 19:30", "2016-04-17 19:27"
+			},
+			new String[] {
+				"2016-04-17 19:25", "2016-04-17 19:27", "2016-04-17 19:30"
+			},
+			FieldConstants.DATE, DDMFormFieldTypeConstants.DATE_TIME);
 	}
 
 	public void testOrderByDDMIntegerField() throws Exception {

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleSearchTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleSearchTest.java
@@ -235,6 +235,14 @@ public class JournalArticleSearchTest extends BaseSearchTestCase {
 	}
 
 	@Test
+	public void testOrderByDDMDateTimeField() throws Exception {
+		TestOrderHelper testOrderHelper =
+			new JournalArticleSearchTestOrderHelper(_ddmIndexer, group);
+
+		testOrderHelper.testOrderByDDMDateTimeField();
+	}
+
+	@Test
 	public void testOrderByDDMIntegerField() throws Exception {
 		TestOrderHelper testOrderHelper =
 			new JournalArticleSearchTestOrderHelper(_ddmIndexer, group);

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
@@ -1080,6 +1080,16 @@
 			}
 		},
 		{
+			"template_date": {
+				"mapping": {
+					"format": "yyyyMMddHHmmss",
+					"store": true,
+					"type": "date"
+				},
+				"match": "*_date"
+			}
+		},
+		{
 			"template_ddmFieldArray_ddmFieldValueText": {
 				"mapping": {
 					"store": true,

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/resources/com/liferay/portal/search/elasticsearch7/internal/index/ElasticsearchIndexInformationTest-testGetFieldMappings.json
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/resources/com/liferay/portal/search/elasticsearch7/internal/index/ElasticsearchIndexInformationTest-testGetFieldMappings.json
@@ -1082,6 +1082,16 @@
 					}
 				},
 				{
+					"template_date": {
+						"mapping": {
+							"format": "yyyyMMddHHmmss",
+							"store": true,
+							"type": "date"
+						},
+						"match": "*_date"
+					}
+				},
+				{
 					"template_ddmFieldArray_ddmFieldValueText": {
 						"mapping": {
 							"store": true,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-189754

Hi all,

Our customer is trying to filter the webcontent results using Custom Filters and the Elasticsearch special keyword `now` to display only the contents of today:
 - **Custom fields:** For more information about Custom Filters, see following documentation: https://help.liferay.com/hc/en-us/articles/4408343859341-Perform-a-date-range-query-using-Custom-Filter-Widgets-over-two-fields-of-a-structure
and https://learn.liferay.com/w/dxp/using-search/search-pages-and-widgets/search-results/custom-filter-examples#boosting-matches-to-nested-fields
 - **Date calculation in Elasticsearch:** For more infomation about the Elasticsearch special keyword 'now' see following documentation: https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#date-math

This is not working because now the Date and Date-Time fields are indexed in Elasticsearch as Strings.

For more information see the reproduction steps on ticket description https://liferay.atlassian.net/browse/LPS-189754

Other indexed web content fields such as 'createDate', 'displayDate', 'expirationDate', 'modified' or the field `nestedFieldArray.value_date` in Objects functionality are indexed as date and it is possible to apply the Custom Filters with the 'now' Elasticsearch keyword without any problem.

**Implemented solution**

To solve the customer problem, we have to parse the DDM field information and index them in Elasticsearch using the 'date' type, this will allow the customer to use Elasticsearch date calculations.

Instead of replacing current indexed field type, I am adding a new field with the "_date" suffix. Replacing current configuration would break all our customers installations until they execute a full reindex. Adding a separate _date field would save everybody to reindex after this LPS is commited.

The new "_date" field follows the similar approach of "_geolocation" fields, see https://github.com/liferay-forms/liferay-portal/blob/master/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMIndexerImpl.java#L688-L697

**Commits:**

- 9a8f667a34ce2ad040696f3ec8d9ee59b3e1d1da => If the DDM field type is DATE or DATE_TIME, we parse them and index an additional xxx_date field with date format.
- 2a85e6a15bd1cc0f177feb03b07a12db9197ad07 => Avoid parse error if the DDM field value is empty because it was not filled in on the user interface.
- 2637bb23ee1af76da177df93482f18e71c78d6fa => Add Elasticsearch mappings so all fields with *_date name will indexed with the 'date' format.
- 30b6435ba27aaba958d1bfd8e71f41e90cc6f5e9 and 99b82c90789f6e77a46a738f7b50ac812b34b353 => I enabled some WARN traces as they weren't activated and I wasn't able to see why the JournalArticleSearchTest test was failing.
- 10ebf5fd3cb969515337ac2589c3f81df7745383 => Fix TestOrderHelper date formats as they weren't correct (_20160417192501 instead of 2016-04-17 17:19_). That caused the new parse code to fail in test JournalArticleSearchTest.

Let me know if you have any question
