### PR TITLE
LPS-189754 Cannot filter a date ddm field using Elasticsearch 'now' keyword because the information is stored as String instead of using the 'date' type 

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/META-INF/module-log4j.xml
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/META-INF/module-log4j.xml
@@ -6,6 +6,7 @@
 		<Logger level="WARN" name="com.liferay.dynamic.data.mapping.internal.storage.JSONDDMStorageAdapter" />
 		<Logger level="WARN" name="com.liferay.dynamic.data.mapping.internal.storage.JSONStorageAdapter" />
 		<Logger level="WARN" name="com.liferay.dynamic.data.mapping.internal.upgrade.v1_0_0.DynamicDataMappingUpgradeProcess" />
+		<Logger level="WARN" name="com.liferay.dynamic.data.mapping.internal.util" />
 		<Logger level="WARN" name="com.liferay.dynamic.data.mapping.verify.DDMServiceVerifyProcess" />
 	</Loggers>
 </Configuration>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/META-INF/module-log4j.xml
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/META-INF/module-log4j.xml
@@ -2,10 +2,9 @@
 
 <Configuration strict="true">
 	<Loggers>
-		<Logger level="WARN" name="com.liferay.dynamic.data.mapping.internal.io.exporter.DDMFormInstanceRecordXLSWriter" />
-		<Logger level="WARN" name="com.liferay.dynamic.data.mapping.internal.storage.JSONDDMStorageAdapter" />
-		<Logger level="WARN" name="com.liferay.dynamic.data.mapping.internal.storage.JSONStorageAdapter" />
-		<Logger level="WARN" name="com.liferay.dynamic.data.mapping.internal.upgrade.v1_0_0.DynamicDataMappingUpgradeProcess" />
+		<Logger level="WARN" name="com.liferay.dynamic.data.mapping.internal.io.exporter" />
+		<Logger level="WARN" name="com.liferay.dynamic.data.mapping.internal.storage" />
+		<Logger level="WARN" name="com.liferay.dynamic.data.mapping.internal.upgrade" />
 		<Logger level="WARN" name="com.liferay.dynamic.data.mapping.internal.util" />
 		<Logger level="WARN" name="com.liferay.dynamic.data.mapping.verify.DDMServiceVerifyProcess" />
 	</Loggers>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test-util/bnd.bnd
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test-util/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Dynamic Data Mapping Test Utilities
 Bundle-SymbolicName: com.liferay.dynamic.data.mapping.test.util
-Bundle-Version: 13.0.2
+Bundle-Version: 13.1.0
 Export-Package:\
 	com.liferay.dynamic.data.mapping.test.util,\
 	com.liferay.dynamic.data.mapping.test.util.search,\

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test-util/src/main/java/com/liferay/dynamic/data/mapping/test/util/search/TestOrderHelper.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test-util/src/main/java/com/liferay/dynamic/data/mapping/test/util/search/TestOrderHelper.java
@@ -90,9 +90,20 @@ public abstract class TestOrderHelper {
 
 	public void testOrderByDDMDateField() throws Exception {
 		testOrderByDDMField(
-			new String[] {"20160417192501", "20160417192510", "20160417192503"},
-			new String[] {"20160417192501", "20160417192503", "20160417192510"},
+			new String[] {"2016-04-17", "2016-04-20", "2016-04-18"},
+			new String[] {"2016-04-17", "2016-04-18", "2016-04-20"},
 			FieldConstants.DATE, DDMFormFieldTypeConstants.DATE);
+	}
+
+	public void testOrderByDDMDateTimeField() throws Exception {
+		testOrderByDDMField(
+			new String[] {
+				"2016-04-17 19:25", "2016-04-17 19:30", "2016-04-17 19:27"
+			},
+			new String[] {
+				"2016-04-17 19:25", "2016-04-17 19:27", "2016-04-17 19:30"
+			},
+			FieldConstants.DATE, DDMFormFieldTypeConstants.DATE_TIME);
 	}
 
 	public void testOrderByDDMIntegerField() throws Exception {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test-util/src/main/resources/com/liferay/dynamic/data/mapping/test/util/search/packageinfo
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test-util/src/main/resources/com/liferay/dynamic/data/mapping/test/util/search/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 1.2.0

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleSearchTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/search/test/JournalArticleSearchTest.java
@@ -235,6 +235,14 @@ public class JournalArticleSearchTest extends BaseSearchTestCase {
 	}
 
 	@Test
+	public void testOrderByDDMDateTimeField() throws Exception {
+		TestOrderHelper testOrderHelper =
+			new JournalArticleSearchTestOrderHelper(_ddmIndexer, group);
+
+		testOrderHelper.testOrderByDDMDateTimeField();
+	}
+
+	@Test
 	public void testOrderByDDMIntegerField() throws Exception {
 		TestOrderHelper testOrderHelper =
 			new JournalArticleSearchTestOrderHelper(_ddmIndexer, group);

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/resources/META-INF/mappings/liferay-type-mappings.json
@@ -601,6 +601,16 @@
 			}
 		},
 		{
+			"template_date": {
+				"mapping": {
+					"format": "yyyyMMddHHmmss",
+					"store": true,
+					"type": "date"
+				},
+				"match": "*_date"
+			}
+		},
+		{
 			"template_ddmFieldArray_ddmFieldValueKeyword": {
 				"mapping": {
 					"store": true,

--- a/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/resources/com/liferay/portal/search/elasticsearch7/internal/index/ElasticsearchIndexInformationTest-testGetFieldMappings.json
+++ b/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/test/resources/com/liferay/portal/search/elasticsearch7/internal/index/ElasticsearchIndexInformationTest-testGetFieldMappings.json
@@ -603,6 +603,16 @@
 					}
 				},
 				{
+					"template_date": {
+						"mapping": {
+							"format": "yyyyMMddHHmmss",
+							"store": true,
+							"type": "date"
+						},
+						"match": "*_date"
+					}
+				},
+				{
 					"template_ddmFieldArray_ddmFieldValueKeyword": {
 						"mapping": {
 							"store": true,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-189754

Similar PR than previous https://github.com/liferay-forms/liferay-portal/pull/2263 but I am using `_dateFormatFactory.getSimpleDateFormat(pattern)` instead of `DateUtil.parseDate` to avoid having to add the locale parameter to several methods. I have also modified the logic to avoid repeating some logic as requested here: https://github.com/liferay-forms/liferay-portal/pull/2263#discussion_r1253372583

----

Hi all,

Our customer is trying to filter the webcontent results using Custom Filters and the Elasticsearch special keyword `now` to display only the contents of today:
 - **Custom fields:** For more information about Custom Filters, see following documentation: https://help.liferay.com/hc/en-us/articles/4408343859341-Perform-a-date-range-query-using-Custom-Filter-Widgets-over-two-fields-of-a-structure
and https://learn.liferay.com/w/dxp/using-search/search-pages-and-widgets/search-results/custom-filter-examples#boosting-matches-to-nested-fields
 - **Date calculation in Elasticsearch:** For more infomation about the Elasticsearch special keyword 'now' see following documentation: https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#date-math

This is not working because now the Date and Date-Time fields are indexed in Elasticsearch as Strings.

For more information see the reproduction steps on ticket description https://liferay.atlassian.net/browse/LPS-189754

Other indexed web content fields such as 'createDate', 'displayDate', 'expirationDate', 'modified' or the field `nestedFieldArray.value_date` in Objects functionality are indexed as date and it is possible to apply the Custom Filters with the 'now' Elasticsearch keyword without any problem.

**Implemented solution**

To solve the customer problem, we have to parse the DDM field information and index them in Elasticsearch using the 'date' type, this will allow the customer to use Elasticsearch date calculations.

Instead of replacing current indexed field type, I am adding a new field with the "_date" suffix. Replacing current configuration would break all our customers installations until they execute a full reindex. Adding a separate _date field would save everybody to reindex after this LPS is commited.

The new "_date" field follows the similar approach of "_geolocation" fields, see https://github.com/liferay-forms/liferay-portal/blob/master/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMIndexerImpl.java#L688-L697

**Commits:**

- ac6ecee8021321d0c1a9e038a7219dbfad9c3418 => If the DDM field type is DATE or DATE_TIME, we parse and index them as an additional xxx_date field with date format.
- eb0a473d1c3124db3c564b91dfb2935dcb4c5dc6 => Add Elasticsearch mappings so all fields with *_date name will indexed with the 'date' format.
- 61877f94c7b75b8e92ee3281c184d3b1327d6770 and aec6bc68c13bacdb47dc1cf070ef51ec932cf207 => I am enabling some WARN traces as they weren't activated and I wasn't able to see why the JournalArticleSearchTest test was failing.
- 472c9579e153992e9a753adf6a886123ae2f44c0 => Fix TestOrderHelper date formats as they weren't correct (_20160417192501 instead of 2016-04-17 17:19_). That caused the new parse code to fail in test JournalArticleSearchTest.

Let me know if you have any question