### PR TITLE
[TS] LPS-190226 Success Page is not shown when form was not created in the default language

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/config/initialState.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/config/initialState.es.js
@@ -125,7 +125,7 @@ export function initState(
 		body: initialSuccessPageSettings?.body
 			? initialSuccessPageSettings?.body
 			: {
-					[themeDisplay.getDefaultLanguageId()]: Liferay.Language.get(
+					[themeDisplay.getLanguageId()]: Liferay.Language.get(
 						'your-information-was-successfully-received-thank-you-for-filling-out-the-form'
 					),
 			  },
@@ -136,7 +136,7 @@ export function initState(
 		title: initialSuccessPageSettings?.title
 			? initialSuccessPageSettings?.title
 			: {
-					[themeDisplay.getDefaultLanguageId()]: Liferay.Language.get(
+					[themeDisplay.getLanguageId()]: Liferay.Language.get(
 						'thank-you'
 					),
 			  },


### PR DESCRIPTION
Hi @liferay-forms team!

This is a solution for [LPS-190226](https://liferay.atlassian.net/browse/LPS-190226). 

The problem is that the success page is associated to the default language even when the form is created in a different language. 

The solution is to use the current page when initializing the state.

Please let me know if you have any questions.

Thanks!