### PR TITLE
[TS] LPS-190239 Heading from a from success page is causing accessibility problems

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/components/DefaultPage.tsx
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/components/DefaultPage.tsx
@@ -60,9 +60,9 @@ const DefaultPage: React.FC<IProps> = ({
 					/>
 				) : (
 					<div className="lfr-ddm__default-page-container">
-						<h2 className="lfr-ddm__default-page-title">
+						<div className="lfr-ddm__default-page-title">
 							{pageTitle}
-						</h2>
+						</div>
 
 						<p className="lfr-ddm__default-page-description">
 							{pageDescription}

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/forms/FormPortlet.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/forms/FormPortlet.path
@@ -77,7 +77,7 @@
 </tr>
 <tr>
 	<td>SUCCESS_PAGE_TITLE</td>
-	<td>//h2[contains(@class,'lfr-ddm__default-page-title') and contains(.,'${key_successPageTitle}')]</td>
+	<td>//div[contains(@class,'lfr-ddm__default-page-title') and contains(.,'${key_successPageTitle}')]</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
Hi @liferay-forms team!

This is a solution to [LPS-190239](https://liferay.atlassian.net/browse/LPS-190239) very much in the style of [LPS-183915](https://liferay.atlassian.net/browse/LPS-183915) but for the success page. 

I've only changed the title's `<h2>` to a `<div>` but not modified the description's `<p>` since I assume it's ok as it is.

Please let me know if you have any questions.

Thanks!