### PR TITLE
LPS-188971 remove tabindex attributes from ddm role group divs

### DIFF
--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/components/Pages.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/components/Pages.es.js
@@ -67,7 +67,6 @@ const Pages = React.forwardRef(
 				className={classNames({sheet: view === 'fieldSets'})}
 				ref={containerElementRef}
 				role="group"
-				tabIndex={0}
 			>
 				<input
 					key={portletNamespace + 'persistDefaultValues'}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
@@ -254,7 +254,7 @@ export function FieldBase({
 	const hasFieldDetails = accessible && fieldDetails && readFieldDetails;
 
 	const accessiblePropsGroup = {
-		...(!renderLabel && {'aria-labelledby': fieldDetailsId, 'tabIndex': 0}),
+		...(!renderLabel && {'aria-labelledby': fieldDetailsId}),
 		...(type === 'fieldset' && {role: 'group'}),
 	};
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Checkbox/__snapshots__/Checkbox.es.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Checkbox/__snapshots__/Checkbox.es.js.snap
@@ -5,7 +5,6 @@ exports[`Field Checkbox has a helptext 1`] = `
   <div
     aria-labelledby="undefined_fieldDetails"
     class="form-group hide"
-    tabindex="0"
   >
     <label
       class="toggle-switch"
@@ -68,7 +67,6 @@ exports[`Field Checkbox has a key 1`] = `
   <div
     aria-labelledby="undefined_fieldDetails"
     class="form-group hide"
-    tabindex="0"
   >
     <label
       class="toggle-switch"
@@ -116,7 +114,6 @@ exports[`Field Checkbox has a label 1`] = `
   <div
     aria-labelledby="undefined_fieldDetails"
     class="form-group hide"
-    tabindex="0"
   >
     <label
       class="toggle-switch"
@@ -164,7 +161,6 @@ exports[`Field Checkbox has a predefined Value 1`] = `
   <div
     aria-labelledby="undefined_fieldDetails"
     class="form-group hide"
-    tabindex="0"
   >
     <label
       class="toggle-switch"
@@ -211,7 +207,6 @@ exports[`Field Checkbox has a value 1`] = `
   <div
     aria-labelledby="undefined_fieldDetails"
     class="form-group hide"
-    tabindex="0"
   >
     <label
       class="toggle-switch"
@@ -259,7 +254,6 @@ exports[`Field Checkbox has an id 1`] = `
   <div
     aria-labelledby="ID_fieldDetails"
     class="form-group hide"
-    tabindex="0"
   >
     <label
       class="toggle-switch"
@@ -306,7 +300,6 @@ exports[`Field Checkbox is not editable 1`] = `
   <div
     aria-labelledby="undefined_fieldDetails"
     class="form-group hide"
-    tabindex="0"
   >
     <label
       class="toggle-switch"
@@ -354,7 +347,6 @@ exports[`Field Checkbox is not required 1`] = `
   <div
     aria-labelledby="undefined_fieldDetails"
     class="form-group hide"
-    tabindex="0"
   >
     <label
       class="toggle-switch"
@@ -401,7 +393,6 @@ exports[`Field Checkbox is shown as a switcher 1`] = `
   <div
     aria-labelledby="undefined_fieldDetails"
     class="form-group hide"
-    tabindex="0"
   >
     <label
       class="toggle-switch"
@@ -448,7 +439,6 @@ exports[`Field Checkbox is shown as checkbox 1`] = `
   <div
     aria-labelledby="undefined_fieldDetails"
     class="form-group hide"
-    tabindex="0"
   >
     <div
       class="custom-control custom-checkbox"
@@ -482,7 +472,6 @@ exports[`Field Checkbox renders Label if showLabel is true 1`] = `
   <div
     aria-labelledby="undefined_fieldDetails"
     class="form-group hide"
-    tabindex="0"
   >
     <label
       class="toggle-switch"

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/CheckboxMultiple/__snapshots__/CheckboxMultiple.es.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/CheckboxMultiple/__snapshots__/CheckboxMultiple.es.js.snap
@@ -5,7 +5,6 @@ exports[`Field Checkbox Multiple has a helptext 1`] = `
   <div
     aria-labelledby="undefined_fieldDetails"
     class="form-group hide"
-    tabindex="0"
   >
     <div
       class="lfr-ddm-checkbox-multiple"
@@ -99,7 +98,6 @@ exports[`Field Checkbox Multiple has a key 1`] = `
   <div
     aria-labelledby="undefined_fieldDetails"
     class="form-group hide"
-    tabindex="0"
   >
     <div
       class="lfr-ddm-checkbox-multiple"
@@ -266,7 +264,6 @@ exports[`Field Checkbox Multiple has a predefined Value 1`] = `
   <div
     aria-labelledby="undefined_fieldDetails"
     class="form-group hide"
-    tabindex="0"
   >
     <div
       class="lfr-ddm-checkbox-multiple"
@@ -344,7 +341,6 @@ exports[`Field Checkbox Multiple has a spritemap 1`] = `
   <div
     aria-labelledby="undefined_fieldDetails"
     class="form-group hide"
-    tabindex="0"
   >
     <div
       class="lfr-ddm-checkbox-multiple"
@@ -422,7 +418,6 @@ exports[`Field Checkbox Multiple has a value 1`] = `
   <div
     aria-labelledby="undefined_fieldDetails"
     class="form-group hide"
-    tabindex="0"
   >
     <div
       class="lfr-ddm-checkbox-multiple"
@@ -500,7 +495,6 @@ exports[`Field Checkbox Multiple has an id 1`] = `
   <div
     aria-labelledby="ID_fieldDetails"
     class="form-group hide"
-    tabindex="0"
   >
     <div
       class="lfr-ddm-checkbox-multiple"
@@ -578,7 +572,6 @@ exports[`Field Checkbox Multiple is not editable 1`] = `
   <div
     aria-labelledby="undefined_fieldDetails"
     class="form-group hide"
-    tabindex="0"
   >
     <div
       class="lfr-ddm-checkbox-multiple"
@@ -658,7 +651,6 @@ exports[`Field Checkbox Multiple is not required 1`] = `
   <div
     aria-labelledby="undefined_fieldDetails"
     class="form-group hide"
-    tabindex="0"
   >
     <div
       class="lfr-ddm-checkbox-multiple"
@@ -736,7 +728,6 @@ exports[`Field Checkbox Multiple is shown as a switcher 1`] = `
   <div
     aria-labelledby="undefined_fieldDetails"
     class="form-group hide"
-    tabindex="0"
   >
     <div
       class="lfr-ddm-checkbox-multiple"
@@ -814,7 +805,6 @@ exports[`Field Checkbox Multiple is shown as checkbox 1`] = `
   <div
     aria-labelledby="undefined_fieldDetails"
     class="form-group hide"
-    tabindex="0"
   >
     <div
       class="lfr-ddm-checkbox-multiple"

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/ColorPicker/__snapshots__/ColorPicker.es.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/ColorPicker/__snapshots__/ColorPicker.es.js.snap
@@ -6,7 +6,6 @@ exports[`Field Color Picker renders field disabled 1`] = `
     aria-labelledby="colorPicker_fieldDetails"
     class="form-group hide"
     data-field-name="colorPicker"
-    tabindex="0"
   >
     <input
       name="colorPicker"
@@ -68,7 +67,6 @@ exports[`Field Color Picker renders field with helptext 1`] = `
     aria-labelledby="colorPicker_fieldDetails"
     class="form-group hide"
     data-field-name="colorPicker"
-    tabindex="0"
   >
     <input
       name="colorPicker"

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/DocumentLibrary/__snapshots__/DocumentLibrary.es.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/DocumentLibrary/__snapshots__/DocumentLibrary.es.js.snap
@@ -6,7 +6,6 @@ exports[`Field DocumentLibrary has a helptext 1`] = `
     aria-labelledby="uploadField_fieldDetails"
     class="form-group has-error hide"
     data-field-name="uploadField"
-    tabindex="0"
   >
     <div
       class="liferay-ddm-form-field-document-library"
@@ -194,7 +193,6 @@ exports[`Field DocumentLibrary has a placeholder 1`] = `
     aria-labelledby="uploadField_fieldDetails"
     class="form-group has-error hide"
     data-field-name="uploadField"
-    tabindex="0"
   >
     <div
       class="liferay-ddm-form-field-document-library"
@@ -282,7 +280,6 @@ exports[`Field DocumentLibrary has a spritemap 1`] = `
     aria-labelledby="uploadField_fieldDetails"
     class="form-group has-error hide"
     data-field-name="uploadField"
-    tabindex="0"
   >
     <div
       class="liferay-ddm-form-field-document-library"
@@ -369,7 +366,6 @@ exports[`Field DocumentLibrary has a value 1`] = `
     aria-labelledby="uploadField_fieldDetails"
     class="form-group has-error hide"
     data-field-name="uploadField"
-    tabindex="0"
   >
     <div
       class="liferay-ddm-form-field-document-library"
@@ -456,7 +452,6 @@ exports[`Field DocumentLibrary has an id 1`] = `
     aria-labelledby="ID_fieldDetails"
     class="form-group has-error hide"
     data-field-name="uploadField"
-    tabindex="0"
   >
     <div
       class="liferay-ddm-form-field-document-library"
@@ -544,7 +539,6 @@ exports[`Field DocumentLibrary is not readOnly 1`] = `
     aria-labelledby="uploadField_fieldDetails"
     class="form-group hide"
     data-field-name="uploadField"
-    tabindex="0"
   >
     <div
       class="liferay-ddm-form-field-document-library"
@@ -599,7 +593,6 @@ exports[`Field DocumentLibrary is not required 1`] = `
     aria-labelledby="uploadField_fieldDetails"
     class="form-group has-error hide"
     data-field-name="uploadField"
-    tabindex="0"
   >
     <div
       class="liferay-ddm-form-field-document-library"

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/FieldBase/__snapshots__/ReactFieldBase.es.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/FieldBase/__snapshots__/ReactFieldBase.es.js.snap
@@ -49,7 +49,6 @@ exports[`ReactFieldBase does not render the label if showLabel is false 1`] = `
   <div
     aria-labelledby="undefined_fieldDetails"
     class="form-group hide"
-    tabindex="0"
   >
     <input
       name="undefined_edited"
@@ -71,7 +70,6 @@ exports[`ReactFieldBase renders the FieldBase with contentRenderer 1`] = `
   <div
     aria-labelledby="undefined_fieldDetails"
     class="form-group hide"
-    tabindex="0"
   >
     <div>
       <h1>
@@ -92,7 +90,6 @@ exports[`ReactFieldBase renders the FieldBase with help text 1`] = `
   <div
     aria-labelledby="undefined_fieldDetails"
     class="form-group hide"
-    tabindex="0"
   >
     <input
       name="undefined_edited"
@@ -124,7 +121,6 @@ exports[`ReactFieldBase renders the FieldBase with id 1`] = `
   <div
     aria-labelledby="Id_fieldDetails"
     class="form-group hide"
-    tabindex="0"
   >
     <input
       name="undefined_edited"
@@ -249,7 +245,6 @@ exports[`ReactFieldBase renders the default markup 1`] = `
   <div
     aria-labelledby="undefined_fieldDetails"
     class="form-group hide"
-    tabindex="0"
   >
     <input
       name="undefined_edited"

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Grid/__snapshots__/Grid.es.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Grid/__snapshots__/Grid.es.js.snap
@@ -96,7 +96,6 @@ exports[`Grid has a tip 1`] = `
   <div
     aria-labelledby="undefined_fieldDetails"
     class="form-group hide"
-    tabindex="0"
   >
     <div
       class="table-responsive"
@@ -192,7 +191,6 @@ exports[`Grid has an id 1`] = `
   <div
     aria-labelledby="Id_fieldDetails"
     class="form-group hide"
-    tabindex="0"
   >
     <div
       class="table-responsive"
@@ -272,7 +270,6 @@ exports[`Grid is not editable 1`] = `
   <div
     aria-labelledby="undefined_fieldDetails"
     class="form-group hide"
-    tabindex="0"
   >
     <div
       class="table-responsive"
@@ -349,7 +346,6 @@ exports[`Grid is not required 1`] = `
   <div
     aria-labelledby="undefined_fieldDetails"
     class="form-group hide"
-    tabindex="0"
   >
     <div
       class="table-responsive"
@@ -520,7 +516,6 @@ exports[`Grid renders columns 1`] = `
   <div
     aria-labelledby="undefined_fieldDetails"
     class="form-group hide"
-    tabindex="0"
   >
     <div
       class="table-responsive"
@@ -627,7 +622,6 @@ exports[`Grid renders no columns when columns comes empty 1`] = `
   <div
     aria-labelledby="undefined_fieldDetails"
     class="form-group hide"
-    tabindex="0"
   >
     <div
       class="table-responsive"
@@ -680,7 +674,6 @@ exports[`Grid renders no rows when row comes empty 1`] = `
   <div
     aria-labelledby="undefined_fieldDetails"
     class="form-group hide"
-    tabindex="0"
   >
     <div
       class="table-responsive"
@@ -723,7 +716,6 @@ exports[`Grid renders rows 1`] = `
   <div
     aria-labelledby="undefined_fieldDetails"
     class="form-group hide"
-    tabindex="0"
   >
     <div
       class="table-responsive"

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/KeyValue/__snapshots__/KeyValue.es.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/KeyValue/__snapshots__/KeyValue.es.js.snap
@@ -6,13 +6,11 @@ exports[`KeyValue has a helptext 1`] = `
     aria-labelledby="keyValue_fieldDetails"
     class="form-group hide"
     data-field-name="keyValue"
-    tabindex="0"
   >
     <div
       aria-labelledby="keyValueLabelkeyValue_fieldDetails"
       class="form-group hide"
       data-field-name="keyValueLabelkeyValue"
-      tabindex="0"
     >
       <div
         data-tooltip-align="top"
@@ -90,7 +88,6 @@ exports[`KeyValue has a label 1`] = `
       aria-labelledby="keyValueLabelkeyValue_fieldDetails"
       class="form-group hide"
       data-field-name="keyValueLabelkeyValue"
-      tabindex="0"
     >
       <div
         data-tooltip-align="top"
@@ -147,13 +144,11 @@ exports[`KeyValue has a predefined Value 1`] = `
     aria-labelledby="keyValue_fieldDetails"
     class="form-group hide"
     data-field-name="keyValue"
-    tabindex="0"
   >
     <div
       aria-labelledby="keyValueLabelkeyValue_fieldDetails"
       class="form-group hide"
       data-field-name="keyValueLabelkeyValue"
-      tabindex="0"
     >
       <div
         data-tooltip-align="top"
@@ -206,13 +201,11 @@ exports[`KeyValue has a value 1`] = `
     aria-labelledby="keyValue_fieldDetails"
     class="form-group hide"
     data-field-name="keyValue"
-    tabindex="0"
   >
     <div
       aria-labelledby="keyValueLabelkeyValue_fieldDetails"
       class="form-group hide"
       data-field-name="keyValueLabelkeyValue"
-      tabindex="0"
     >
       <div
         data-tooltip-align="top"
@@ -264,13 +257,11 @@ exports[`KeyValue has an id 1`] = `
     aria-labelledby="Id_fieldDetails"
     class="form-group hide"
     data-field-name="keyValue"
-    tabindex="0"
   >
     <div
       aria-labelledby="keyValueLabelkeyValue_fieldDetails"
       class="form-group hide"
       data-field-name="keyValueLabelkeyValue"
-      tabindex="0"
     >
       <div
         data-tooltip-align="top"
@@ -321,13 +312,11 @@ exports[`KeyValue is not editable 1`] = `
     aria-labelledby="keyValue_fieldDetails"
     class="form-group hide"
     data-field-name="keyValue"
-    tabindex="0"
   >
     <div
       aria-labelledby="keyValueLabelkeyValue_fieldDetails"
       class="form-group hide"
       data-field-name="keyValueLabelkeyValue"
-      tabindex="0"
     >
       <div
         data-tooltip-align="top"
@@ -379,13 +368,11 @@ exports[`KeyValue is not required 1`] = `
     aria-labelledby="keyValue_fieldDetails"
     class="form-group hide"
     data-field-name="keyValue"
-    tabindex="0"
   >
     <div
       aria-labelledby="keyValueLabelkeyValue_fieldDetails"
       class="form-group hide"
       data-field-name="keyValueLabelkeyValue"
-      tabindex="0"
     >
       <div
         data-tooltip-align="top"
@@ -448,7 +435,6 @@ exports[`KeyValue renders Label if showLabel is true 1`] = `
       aria-labelledby="keyValueLabelkeyValue_fieldDetails"
       class="form-group hide"
       data-field-name="keyValueLabelkeyValue"
-      tabindex="0"
     >
       <div
         data-tooltip-align="top"
@@ -505,13 +491,11 @@ exports[`KeyValue renders component with a key 1`] = `
     aria-labelledby="keyValue_fieldDetails"
     class="form-group hide"
     data-field-name="keyValue"
-    tabindex="0"
   >
     <div
       aria-labelledby="keyValueLabelkeyValue_fieldDetails"
       class="form-group hide"
       data-field-name="keyValueLabelkeyValue"
-      tabindex="0"
     >
       <div
         data-tooltip-align="top"

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/LocalizableText/__snapshots__/LocalizableText.es.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/LocalizableText/__snapshots__/LocalizableText.es.js.snap
@@ -6,7 +6,6 @@ exports[`Field LocalizableText adds a new translation for an untranslated item 1
     aria-labelledby="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US_fieldDetails"
     class="form-group hide"
     data-field-name="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US"
-    tabindex="0"
   >
     <div
       class="input-group"
@@ -728,7 +727,6 @@ exports[`Field LocalizableText emits field edit event on field change 1`] = `
     aria-labelledby="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US_fieldDetails"
     class="form-group hide"
     data-field-name="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US"
-    tabindex="0"
   >
     <div
       class="input-group"
@@ -1448,7 +1446,6 @@ exports[`Field LocalizableText fills with the default language value when the se
     aria-labelledby="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US_fieldDetails"
     class="form-group hide"
     data-field-name="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US"
-    tabindex="0"
   >
     <div
       class="input-group"
@@ -2170,7 +2167,6 @@ exports[`Field LocalizableText fills with the selected language value when the s
     aria-labelledby="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US_fieldDetails"
     class="form-group hide"
     data-field-name="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US"
-    tabindex="0"
   >
     <div
       class="input-group"
@@ -3623,7 +3619,6 @@ exports[`Field LocalizableText has a placeholder 1`] = `
     aria-labelledby="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US_fieldDetails"
     class="form-group hide"
     data-field-name="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US"
-    tabindex="0"
   >
     <div
       class="input-group"
@@ -4343,7 +4338,6 @@ exports[`Field LocalizableText is not readOnly 1`] = `
     aria-labelledby="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US_fieldDetails"
     class="form-group hide"
     data-field-name="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US"
-    tabindex="0"
   >
     <div
       class="input-group"
@@ -5063,7 +5057,6 @@ exports[`Field LocalizableText is not required 1`] = `
     aria-labelledby="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US_fieldDetails"
     class="form-group hide"
     data-field-name="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US"
-    tabindex="0"
   >
     <div
       class="input-group"
@@ -5783,7 +5776,6 @@ exports[`Field LocalizableText removes the translation of an item already transl
     aria-labelledby="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US_fieldDetails"
     class="form-group hide"
     data-field-name="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US"
-    tabindex="0"
   >
     <div
       class="input-group"
@@ -6505,7 +6497,6 @@ exports[`Field LocalizableText renders no values when values come empty 1`] = `
     aria-labelledby="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US_fieldDetails"
     class="form-group hide"
     data-field-name="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US"
-    tabindex="0"
   >
     <div
       class="input-group"
@@ -7225,7 +7216,6 @@ exports[`Field LocalizableText renders values 1`] = `
     aria-labelledby="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US_fieldDetails"
     class="form-group hide"
     data-field-name="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US"
-    tabindex="0"
   >
     <div
       class="input-group"
@@ -7945,7 +7935,6 @@ exports[`Field LocalizableText shows default language value when no other langua
     aria-labelledby="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US_fieldDetails"
     class="form-group hide"
     data-field-name="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US"
-    tabindex="0"
   >
     <div
       class="input-group"

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Numeric/__snapshots__/Numeric.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Numeric/__snapshots__/Numeric.js.snap
@@ -6,7 +6,6 @@ exports[`Field Numeric Integer Input Mask toggle has an inputMaskFormat 1`] = `
     aria-labelledby="numericField_fieldDetails"
     class="form-group hide"
     data-field-name="numericField"
-    tabindex="0"
   >
     <div
       data-tooltip-align="top"
@@ -41,7 +40,6 @@ exports[`Field Numeric renders the default markup 1`] = `
   <div
     aria-labelledby="undefined_fieldDetails"
     class="form-group hide"
-    tabindex="0"
   >
     <div
       data-tooltip-align="top"

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Options/__snapshots__/Options.es.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Options/__snapshots__/Options.es.js.snap
@@ -6,7 +6,6 @@ exports[`Options shows the options 1`] = `
     aria-labelledby="options_fieldDetails"
     class="form-group hide"
     data-field-name="options"
-    tabindex="0"
   >
     <div
       class="ddm-field-options-container"
@@ -37,13 +36,11 @@ exports[`Options shows the options 1`] = `
             aria-labelledby="option0_fieldDetails"
             class="form-group hide"
             data-field-name="option0"
-            tabindex="0"
           >
             <div
               aria-labelledby="keyValueLabeloption0_fieldDetails"
               class="form-group hide"
               data-field-name="keyValueLabeloption0"
-              tabindex="0"
             >
               <div
                 data-tooltip-align="top"
@@ -145,13 +142,11 @@ exports[`Options shows the options 1`] = `
             aria-labelledby="option1_fieldDetails"
             class="form-group hide"
             data-field-name="option1"
-            tabindex="0"
           >
             <div
               aria-labelledby="keyValueLabeloption1_fieldDetails"
               class="form-group hide"
               data-field-name="keyValueLabeloption1"
-              tabindex="0"
             >
               <div
                 data-tooltip-align="top"
@@ -253,13 +248,11 @@ exports[`Options shows the options 1`] = `
             aria-labelledby="option2_fieldDetails"
             class="form-group hide"
             data-field-name="option2"
-            tabindex="0"
           >
             <div
               aria-labelledby="keyValueLabeloption2_fieldDetails"
               class="form-group hide"
               data-field-name="keyValueLabeloption2"
-              tabindex="0"
             >
               <div
                 data-tooltip-align="top"

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Paragraph/__snapshots__/Paragraph.es.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Paragraph/__snapshots__/Paragraph.es.js.snap
@@ -6,7 +6,6 @@ exports[`Field Paragraph has a key 1`] = `
     aria-labelledby="textField_fieldDetails"
     class="form-group hide"
     data-field-name="textField"
-    tabindex="0"
   >
     <div
       class="form-group liferay-ddm-form-field-paragraph"
@@ -67,7 +66,6 @@ exports[`Field Paragraph has a placeholder 1`] = `
     aria-labelledby="textField_fieldDetails"
     class="form-group hide"
     data-field-name="textField"
-    tabindex="0"
   >
     <div
       class="form-group liferay-ddm-form-field-paragraph"
@@ -92,7 +90,6 @@ exports[`Field Paragraph has a value 1`] = `
     aria-labelledby="textField_fieldDetails"
     class="form-group hide"
     data-field-name="textField"
-    tabindex="0"
   >
     <div
       class="form-group liferay-ddm-form-field-paragraph"
@@ -117,7 +114,6 @@ exports[`Field Paragraph has an id 1`] = `
     aria-labelledby="Id_fieldDetails"
     class="form-group hide"
     data-field-name="textField"
-    tabindex="0"
   >
     <div
       class="form-group liferay-ddm-form-field-paragraph"
@@ -142,7 +138,6 @@ exports[`Field Paragraph is not required 1`] = `
     aria-labelledby="textField_fieldDetails"
     class="form-group hide"
     data-field-name="textField"
-    tabindex="0"
   >
     <div
       class="form-group liferay-ddm-form-field-paragraph"
@@ -167,7 +162,6 @@ exports[`Field Paragraph is readOnly 1`] = `
     aria-labelledby="textField_fieldDetails"
     class="form-group hide"
     data-field-name="textField"
-    tabindex="0"
   >
     <div
       class="form-group liferay-ddm-form-field-paragraph"

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Radio/__snapshots__/Radio.es.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Radio/__snapshots__/Radio.es.js.snap
@@ -6,7 +6,6 @@ exports[`Field Radio has a helptext 1`] = `
     aria-labelledby="radioField_fieldDetails"
     class="form-group hide"
     data-field-name="radioField"
-    tabindex="0"
   >
     <div
       class="ddm__radio"
@@ -173,7 +172,6 @@ exports[`Field Radio has a placeholder 1`] = `
     aria-labelledby="radioField_fieldDetails"
     class="form-group hide"
     data-field-name="radioField"
-    tabindex="0"
   >
     <div
       class="ddm__radio"
@@ -243,7 +241,6 @@ exports[`Field Radio has a value 1`] = `
     aria-labelledby="radioField_fieldDetails"
     class="form-group hide"
     data-field-name="radioField"
-    tabindex="0"
   >
     <div
       class="ddm__radio"
@@ -313,7 +310,6 @@ exports[`Field Radio has an id 1`] = `
     aria-labelledby="Id_fieldDetails"
     class="form-group hide"
     data-field-name="radioField"
-    tabindex="0"
   >
     <div
       class="ddm__radio"
@@ -383,7 +379,6 @@ exports[`Field Radio is not editable 1`] = `
     aria-labelledby="radioField_fieldDetails"
     class="form-group hide"
     data-field-name="radioField"
-    tabindex="0"
   >
     <div
       class="ddm__radio"
@@ -455,7 +450,6 @@ exports[`Field Radio is not required 1`] = `
     aria-labelledby="radioField_fieldDetails"
     class="form-group hide"
     data-field-name="radioField"
-    tabindex="0"
   >
     <div
       class="ddm__radio"
@@ -606,7 +600,6 @@ exports[`Field Radio renders no options when options is empty 1`] = `
     aria-labelledby="radioField_fieldDetails"
     class="form-group hide"
     data-field-name="radioField"
-    tabindex="0"
   >
     <div
       class="ddm__radio"
@@ -631,7 +624,6 @@ exports[`Field Radio renders options 1`] = `
     aria-labelledby="radioField_fieldDetails"
     class="form-group hide"
     data-field-name="radioField"
-    tabindex="0"
   >
     <div
       class="ddm__radio"

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Select/__snapshots__/Select.es.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Select/__snapshots__/Select.es.js.snap
@@ -5,7 +5,6 @@ exports[`Select calls onChange callback when an item is selected using multisele
   <div
     aria-labelledby="undefined_fieldDetails"
     class="form-group hide"
-    tabindex="0"
   >
     <div
       data-tooltip-align="top"
@@ -362,7 +361,6 @@ exports[`Select filters according to the input and calls onChange callback when 
   <div
     aria-labelledby="undefined_fieldDetails"
     class="form-group hide"
-    tabindex="0"
   >
     <div
       data-tooltip-align="top"
@@ -633,7 +631,6 @@ exports[`Select has a help text 1`] = `
   <div
     aria-labelledby="undefined_fieldDetails"
     class="form-group hide"
-    tabindex="0"
   >
     <div
       data-tooltip-align="top"
@@ -754,7 +751,6 @@ exports[`Select has a key 1`] = `
   <div
     aria-labelledby="undefined_fieldDetails"
     class="form-group hide"
-    tabindex="0"
   >
     <div
       data-tooltip-align="top"
@@ -983,7 +979,6 @@ exports[`Select has a placeholder 1`] = `
   <div
     aria-labelledby="undefined_fieldDetails"
     class="form-group hide"
-    tabindex="0"
   >
     <div
       data-tooltip-align="top"
@@ -1088,7 +1083,6 @@ exports[`Select has a predefinedValue 1`] = `
   <div
     aria-labelledby="undefined_fieldDetails"
     class="form-group hide"
-    tabindex="0"
   >
     <div
       data-tooltip-align="top"
@@ -1193,7 +1187,6 @@ exports[`Select has a value 1`] = `
   <div
     aria-labelledby="undefined_fieldDetails"
     class="form-group hide"
-    tabindex="0"
   >
     <div
       data-tooltip-align="top"
@@ -1298,7 +1291,6 @@ exports[`Select has an id 1`] = `
   <div
     aria-labelledby="Id_fieldDetails"
     class="form-group hide"
-    tabindex="0"
   >
     <div
       data-tooltip-align="top"
@@ -1404,7 +1396,6 @@ exports[`Select has class dropdown-opened when it's opened 1`] = `
   <div
     aria-labelledby="undefined_fieldDetails"
     class="form-group hide"
-    tabindex="0"
   >
     <div
       data-tooltip-align="top"
@@ -1509,7 +1500,6 @@ exports[`Select is closed by default 1`] = `
   <div
     aria-labelledby="undefined_fieldDetails"
     class="form-group hide"
-    tabindex="0"
   >
     <div
       data-tooltip-align="top"
@@ -1614,7 +1604,6 @@ exports[`Select is not required 1`] = `
   <div
     aria-labelledby="undefined_fieldDetails"
     class="form-group hide"
-    tabindex="0"
   >
     <div
       data-tooltip-align="top"
@@ -1981,7 +1970,6 @@ exports[`Select renders no options when options come empty 1`] = `
   <div
     aria-labelledby="undefined_fieldDetails"
     class="form-group hide"
-    tabindex="0"
   >
     <div
       data-tooltip-align="top"
@@ -2086,7 +2074,6 @@ exports[`Select renders options 1`] = `
   <div
     aria-labelledby="undefined_fieldDetails"
     class="form-group hide"
-    tabindex="0"
   >
     <div
       data-tooltip-align="top"
@@ -2204,7 +2191,6 @@ exports[`Select shows a search input when the number of options is more than the
   <div
     aria-labelledby="undefined_fieldDetails"
     class="form-group hide"
-    tabindex="0"
   >
     <div
       data-tooltip-align="top"

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Text/__snapshots__/Text.es.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Text/__snapshots__/Text.es.js.snap
@@ -6,7 +6,6 @@ exports[`Field Text has a helptext 1`] = `
     aria-labelledby="textField_fieldDetails"
     class="form-group hide"
     data-field-name="textField"
-    tabindex="0"
   >
     <div
       data-tooltip-align="top"
@@ -92,7 +91,6 @@ exports[`Field Text has a placeholder 1`] = `
     aria-labelledby="textField_fieldDetails"
     class="form-group hide"
     data-field-name="textField"
-    tabindex="0"
   >
     <div
       data-tooltip-align="top"
@@ -123,7 +121,6 @@ exports[`Field Text has a value 1`] = `
     aria-labelledby="textField_fieldDetails"
     class="form-group hide"
     data-field-name="textField"
-    tabindex="0"
   >
     <div
       data-tooltip-align="top"
@@ -153,7 +150,6 @@ exports[`Field Text has an id 1`] = `
     aria-labelledby="Id_fieldDetails"
     class="form-group hide"
     data-field-name="textField"
-    tabindex="0"
   >
     <div
       data-tooltip-align="top"
@@ -182,7 +178,6 @@ exports[`Field Text is not readOnly 1`] = `
     aria-labelledby="textField_fieldDetails"
     class="form-group hide"
     data-field-name="textField"
-    tabindex="0"
   >
     <div
       data-tooltip-align="top"
@@ -211,7 +206,6 @@ exports[`Field Text is not required 1`] = `
     aria-labelledby="textField_fieldDetails"
     class="form-group hide"
     data-field-name="textField"
-    tabindex="0"
   >
     <div
       data-tooltip-align="top"
@@ -241,7 +235,6 @@ exports[`Field Text is readOnly 1`] = `
     aria-labelledby="textField_fieldDetails"
     class="form-group hide"
     data-field-name="textField"
-    tabindex="0"
   >
     <div
       data-tooltip-align="top"

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Validation/__snapshots__/Validation.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Validation/__snapshots__/Validation.js.snap
@@ -9,7 +9,6 @@ exports[`Validation renders checkbox to enable Validation 1`] = `
       aria-labelledby="enableValidation_fieldDetails"
       class="form-group hide"
       data-field-name="enableValidation"
-      tabindex="0"
     >
       <label
         class="toggle-switch"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-188971

Forwarding from https://github.com/liferay-peds/liferay-portal/pull/156.

I removed the `tabindex` attributes from

https://github.com/liferay/liferay-portal/blame/8a8ccf6182cddaa04da6992d2426014dea057cfb/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js#L254

and 

https://github.com/liferay/liferay-portal/blame/master/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/components/Pages.es.js#L70.

It includes the div that groups a set of form elements in the tab order. We only need to use `role="group"` for a screen readers. It will announce it properly when navigating with it.

