### PR TITLE
LPS-190801 The Image Selector was defaulting to the wrong site after being closed and reopened

### DIFF
--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/utils/evaluation.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/utils/evaluation.es.js
@@ -145,6 +145,8 @@ const doEvaluate = debounce((fieldName, evaluatorContext, callback) => {
 		body: convertToFormData({
 			languageId: editingLanguageId,
 			p_auth: Liferay.authToken,
+			p_l_id: themeDisplay.getPlid(),
+			p_v_l_s_g_id: themeDisplay.getSiteGroupId(),
 			portletNamespace,
 			serializedFormContext: JSON.stringify({
 				...evaluatorContext,


### PR DESCRIPTION
We need to set these parameters to ensure that the correct scopeGroupId is preserved for future requests.

Ticket: [LPS-190801](https://liferay.atlassian.net/browse/LPS-190801)