### PR TITLE
[TECHNICAL SUPPORT] LPS-189593 Text in repeatable text field not mouse selectable

### DIFF
--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/components/FieldRepeatableDND.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/components/FieldRepeatableDND.js
@@ -14,6 +14,11 @@ const FieldRepeatableDND = ({children, field, index, nestedFieldIndex}) => {
 	const ref = useRef(null);
 
 	const [{isDragging}, dragRef, preview] = useDrag({
+		canDrag: () => {
+			return !['INPUT', 'TEXTAREA'].includes(
+				document.activeElement?.tagName
+			);
+		},
 		canDrop() {
 			return true;
 		},


### PR DESCRIPTION
Hey,
Ticket: [LPS-189593](https://liferay.atlassian.net/browse/LPS-189593)

I wanted to cancel the drag event if it is fired from the children of FieldRepeatableDND wrapper. This way all the input fields will be selectable and the drag'n'drop feature will be activated just when the user is draging the very top part of the repeated field.

Please review my change,

Thanks