### PR TITLE
LPS-190908 Can't remove duplicated rich text if the Field Reference was edited

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
@@ -270,7 +270,7 @@ export function FieldBase({
 		visitor.mapFields(
 			(field) => {
 				if (
-					newFieldName === field.fieldName &&
+					newFieldName === field.fieldReference &&
 					newParentInstanceId === field.parentInstanceId
 				) {
 					repetitionsCounter++;


### PR DESCRIPTION
Related Issue: [LPS-190908](https://liferay.atlassian.net/browse/LPS-190908)

I've observed that unless you change it, the fieldReference is equal to the fieldName, and you if you do change it,the comparison is now being made to the fieldReference, making it work for both cases.