### PR TITLE
LPS-191691

### DIFF
--- a/modules/apps/data-engine/data-engine-api/bnd.bnd
+++ b/modules/apps/data-engine/data-engine-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Data Engine API
 Bundle-SymbolicName: com.liferay.data.engine.api
-Bundle-Version: 6.5.2
+Bundle-Version: 6.6.0
 Export-Package:\
 	com.liferay.data.engine.constants,\
 	com.liferay.data.engine.content.type,\

--- a/modules/apps/data-engine/data-engine-api/src/main/java/com/liferay/data/engine/renderer/DataLayoutRenderer.java
+++ b/modules/apps/data-engine/data-engine-api/src/main/java/com/liferay/data/engine/renderer/DataLayoutRenderer.java
@@ -23,6 +23,12 @@ public interface DataLayoutRenderer {
 			DataLayoutRendererContext dataLayoutRendererContext)
 		throws Exception;
 
+	public String render(
+			Long dataLayoutId,
+			DataLayoutRendererContext dataLayoutRendererContext,
+			boolean checkPermission)
+		throws Exception;
+
 	/**
 	 * @deprecated As of Mueller (7.2.x), see {@link
 	 *             DataLayoutRenderer#render(Long, DataLayoutRendererContext)}

--- a/modules/apps/data-engine/data-engine-api/src/main/resources/com/liferay/data/engine/renderer/packageinfo
+++ b/modules/apps/data-engine/data-engine-api/src/main/resources/com/liferay/data/engine/renderer/packageinfo
@@ -1,1 +1,1 @@
-version 1.5.0
+version 1.6.0

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/renderer/v2_0/DataLayoutRendererImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/renderer/v2_0/DataLayoutRendererImpl.java
@@ -41,6 +41,16 @@ public class DataLayoutRendererImpl implements DataLayoutRenderer {
 			DataLayoutRendererContext dataLayoutRendererContext)
 		throws Exception {
 
+		return render(dataLayoutId, dataLayoutRendererContext, true);
+	}
+
+	@Override
+	public String render(
+			Long dataLayoutId,
+			DataLayoutRendererContext dataLayoutRendererContext,
+			boolean checkPermission)
+		throws Exception {
+
 		DDMStructureLayout ddmStructureLayout =
 			_ddmStructureLayoutLocalService.getStructureLayout(dataLayoutId);
 
@@ -50,9 +60,11 @@ public class DataLayoutRendererImpl implements DataLayoutRenderer {
 
 		DDMStructure ddmStructure = ddmStructureVersion.getStructure();
 
-		_ddmStructureModelResourcePermission.check(
-			GuestOrUserUtil.getPermissionChecker(),
-			ddmStructure.getPrimaryKey(), ActionKeys.VIEW);
+		if (checkPermission) {
+			_ddmStructureModelResourcePermission.check(
+				GuestOrUserUtil.getPermissionChecker(),
+				ddmStructure.getPrimaryKey(), ActionKeys.VIEW);
+		}
 
 		DDMForm ddmForm = ddmStructure.getDDMForm();
 

--- a/modules/apps/data-engine/data-engine-taglib/src/main/java/com/liferay/data/engine/taglib/internal/servlet/taglib/util/DataLayoutTaglibUtil.java
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/java/com/liferay/data/engine/taglib/internal/servlet/taglib/util/DataLayoutTaglibUtil.java
@@ -95,7 +95,9 @@ public class DataLayoutTaglibUtil {
 		DataDefinitionResource.Builder dataDefinitionResourceBuilder =
 			dataDefinitionResourceFactory.create();
 
-		return dataDefinitionResourceBuilder.httpServletRequest(
+		return dataDefinitionResourceBuilder.checkPermissions(
+			false
+		).httpServletRequest(
 			httpServletRequest
 		).user(
 			PortalUtil.getUser(httpServletRequest)

--- a/modules/apps/data-engine/data-engine-taglib/src/main/java/com/liferay/data/engine/taglib/servlet/taglib/DataLayoutRendererTag.java
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/java/com/liferay/data/engine/taglib/servlet/taglib/DataLayoutRendererTag.java
@@ -154,7 +154,7 @@ public class DataLayoutRendererTag extends BaseDataLayoutRendererTag {
 			_dataLayoutRendererSnapshot.get();
 
 		return dataLayoutRenderer.render(
-			dataLayoutId, dataLayoutRendererContext);
+			dataLayoutId, dataLayoutRendererContext, false);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/data-engine/data-engine-taglib/src/test/java/com/liferay/data/engine/taglib/internal/servlet/taglib/util/DataLayoutTaglibUtilTest.java
+++ b/modules/apps/data-engine/data-engine-taglib/src/test/java/com/liferay/data/engine/taglib/internal/servlet/taglib/util/DataLayoutTaglibUtilTest.java
@@ -139,6 +139,12 @@ public class DataLayoutTaglibUtilTest {
 		);
 
 		Mockito.when(
+			dataDefinitionResourceBuilder.checkPermissions(Mockito.anyBoolean())
+		).thenReturn(
+			dataDefinitionResourceBuilder
+		);
+
+		Mockito.when(
 			dataDefinitionResourceBuilder.httpServletRequest(
 				_httpServletRequest)
 		).thenReturn(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-191691

Based on the feedback from https://github.com/liferay-echo/liferay-portal/pull/13014 and the discussion on https://liferay.atlassian.net/browse/PTR-4147 it was decided to not check for VIEW permission when utilizing the `DataLayoutRendererTag`.

There were two places this permission was being checked - during the fetch of the structure as well as during the render process. Both have been addressed in the changes here.

Please let me know your thoughts on the changes and if there would be a better way to implement this functionality. Thank you.