### PR TITLE
LPS-167450 - DDL records is published to live when disabled Publish Displayed Content by Default

### DIFF
--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/internal/exportimport/test/DDLDisplayExportImportTest.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/internal/exportimport/test/DDLDisplayExportImportTest.java
@@ -85,6 +85,9 @@ public class DDLDisplayExportImportTest
 		PortletPreferences importedPortletPreferences =
 			getImportedPortletPreferences(
 				HashMapBuilder.put(
+					"groupId",
+					new String[] {String.valueOf(recordSet.getGroupId())}
+				).put(
 					"recordSetId",
 					new String[] {String.valueOf(recordSet.getRecordSetId())}
 				).build());

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/internal/exportimport/test/DDLDisplayExportImportTest.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-test/src/testIntegration/java/com/liferay/dynamic/data/lists/internal/exportimport/test/DDLDisplayExportImportTest.java
@@ -90,6 +90,9 @@ public class DDLDisplayExportImportTest
 				).put(
 					"recordSetId",
 					new String[] {String.valueOf(recordSet.getRecordSetId())}
+				).put(
+					"recordSetKey",
+					new String[] {String.valueOf(recordSet.getRecordSetKey())}
 				).build());
 
 		DDLRecord importedRecord =

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/java/com/liferay/dynamic/data/lists/web/internal/exportimport/portlet/preferences/processor/DDLDisplayExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/java/com/liferay/dynamic/data/lists/web/internal/exportimport/portlet/preferences/processor/DDLDisplayExportImportPortletPreferencesProcessor.java
@@ -21,6 +21,7 @@ import com.liferay.dynamic.data.lists.model.DDLRecordSet;
 import com.liferay.dynamic.data.lists.service.DDLRecordSetLocalService;
 import com.liferay.dynamic.data.mapping.model.DDMTemplate;
 import com.liferay.dynamic.data.mapping.service.DDMTemplateLocalService;
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.exportimport.kernel.lar.PortletDataException;
 import com.liferay.exportimport.kernel.lar.PortletDataHandlerKeys;
@@ -29,15 +30,20 @@ import com.liferay.exportimport.kernel.staging.MergeLayoutPrototypesThreadLocal;
 import com.liferay.exportimport.portlet.preferences.processor.Capability;
 import com.liferay.exportimport.portlet.preferences.processor.ExportImportPortletPreferencesProcessor;
 import com.liferay.exportimport.staged.model.repository.StagedModelRepository;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.Property;
 import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.Validator;
 
 import java.util.List;
 import java.util.Map;
@@ -98,37 +104,87 @@ public class DDLDisplayExportImportPortletPreferencesProcessor
 
 		String portletId = portletDataContext.getPortletId();
 
-		long recordSetId = GetterUtil.getLong(
-			portletPreferences.getValue("recordSetId", null));
+		String recordSetId = portletPreferences.getValue("recordSetId", null);
 
-		if (recordSetId == 0) {
-			if (_log.isWarnEnabled()) {
-				_log.warn(
-					"Record set ID is not set for preferences of portlet " +
+		if (recordSetId == null) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					"No recordSetId found in preferences of portlet " +
 						portletId);
 			}
 
 			return portletPreferences;
 		}
 
+		long recordSetGroupId = GetterUtil.getLong(
+			portletPreferences.getValue("groupId", StringPool.BLANK));
+
+		if (recordSetGroupId <= 0) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"No group ID found in preferences of portlet " + portletId);
+			}
+
+			return portletPreferences;
+		}
+
+		Group group = _groupLocalService.fetchGroup(recordSetGroupId);
+
+		if (group == null) {
+			if (_log.isDebugEnabled()) {
+				_log.debug("No group found with group ID " + recordSetGroupId);
+			}
+
+			return portletPreferences;
+		}
+
+		if (ExportImportThreadLocal.isStagingInProcess() &&
+			!group.isStagedPortlet(DDLPortletKeys.DYNAMIC_DATA_LISTS)) {
+
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					"Dynamic Data Lists are not staged in the site " +
+						group.getName());
+			}
+
+			return portletPreferences;
+		}
+
+		long previousScopeGroupId = portletDataContext.getScopeGroupId();
+
+		if (recordSetGroupId != previousScopeGroupId) {
+			portletDataContext.setScopeGroupId(recordSetGroupId);
+		}
+
 		DDLRecordSet recordSet = _ddlRecordSetLocalService.fetchRecordSet(
-			recordSetId);
+			GetterUtil.getLong(recordSetId));
 
-		if (recordSet != null) {
-			StagedModelDataHandlerUtil.exportReferenceStagedModel(
-				portletDataContext, portletId, recordSet);
-
-			ActionableDynamicQuery recordActionableDynamicQuery =
-				_getRecordActionableDynamicQuery(
-					portletDataContext, recordSet, portletId);
-
-			try {
-				recordActionableDynamicQuery.performActions();
+		if (recordSet == null) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					StringBundler.concat(
+						"Portlet ", portletId,
+						" refers to an invalid recordSetId ", recordSetId));
 			}
-			catch (PortalException portalException) {
-				throw new PortletDataException(
-					"Unable to export referenced records", portalException);
-			}
+
+			portletDataContext.setScopeGroupId(previousScopeGroupId);
+
+			return portletPreferences;
+		}
+
+		StagedModelDataHandlerUtil.exportReferenceStagedModel(
+			portletDataContext, portletId, recordSet);
+
+		ActionableDynamicQuery recordActionableDynamicQuery =
+			_getRecordActionableDynamicQuery(
+				portletDataContext, recordSet, portletId);
+
+		try {
+			recordActionableDynamicQuery.performActions();
+		}
+		catch (PortalException portalException) {
+			throw new PortletDataException(
+				"Unable to export referenced records", portalException);
 		}
 
 		long displayDDMTemplateId = GetterUtil.getLong(
@@ -161,15 +217,75 @@ public class DDLDisplayExportImportPortletPreferencesProcessor
 				"Unable to export portlet permissions", portalException);
 		}
 
-		long importedRecordSetId = GetterUtil.getLong(
-			portletPreferences.getValue("recordSetId", null));
+		long previousScopeGroupId = portletDataContext.getScopeGroupId();
 
-		Map<Long, Long> recordSetIds =
+		Map<Long, Long> groupIds =
 			(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
-				DDLRecordSet.class);
+				Group.class);
 
-		long recordSetId = MapUtil.getLong(
-			recordSetIds, importedRecordSetId, importedRecordSetId);
+		long importGroupId = GetterUtil.getLong(
+			portletPreferences.getValue("groupId", null));
+
+		if ((importGroupId == portletDataContext.getCompanyGroupId()) &&
+			MergeLayoutPrototypesThreadLocal.isInProgress()) {
+
+			portletDataContext.setScopeType("company");
+		}
+
+		long groupId = MapUtil.getLong(groupIds, importGroupId, importGroupId);
+
+		Map<String, Long> recordSetGroupIds =
+			(Map<String, Long>)portletDataContext.getNewPrimaryKeysMap(
+				DDLRecordSet.class + ".groupId");
+
+		String importedRecordSetId = String.valueOf(
+			GetterUtil.getLong(
+				portletPreferences.getValue("recordSetId", null)));
+
+		if (recordSetGroupIds.containsKey(importedRecordSetId)) {
+			groupId = recordSetGroupIds.get(importedRecordSetId);
+		}
+
+		portletDataContext.setScopeGroupId(groupId);
+
+		if (Validator.isNotNull(importedRecordSetId) && (groupId != 0)) {
+			Group importedRecordSetGroup = _groupLocalService.fetchGroup(
+				groupId);
+
+			if (importedRecordSetGroup == null) {
+				if (_log.isDebugEnabled()) {
+					_log.debug("No group found with group ID " + groupId);
+				}
+
+				return portletPreferences;
+			}
+
+			if (!ExportImportThreadLocal.isStagingInProcess() ||
+				importedRecordSetGroup.isStagedPortlet(
+					DDLPortletKeys.DYNAMIC_DATA_LISTS)) {
+
+				Map<Long, Long> recordSetIds =
+					(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
+						DDLRecordSet.class);
+
+				long recordSetId = GetterUtil.getLong(importedRecordSetId);
+
+				recordSetId = MapUtil.getLong(recordSetIds, recordSetId, 0);
+
+				try {
+					portletPreferences.setValue(
+						"recordSetId", String.valueOf(recordSetId));
+
+					portletPreferences.setValue(
+						"groupId", String.valueOf(groupId));
+				}
+				catch (ReadOnlyException readOnlyException) {
+					throw new PortletDataException(
+						"Unable to update portlet preferences during import",
+						readOnlyException);
+				}
+			}
+		}
 
 		Map<Long, Long> templateIds =
 			(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
@@ -190,8 +306,6 @@ public class DDLDisplayExportImportPortletPreferencesProcessor
 
 		try {
 			portletPreferences.setValue(
-				"recordSetId", String.valueOf(recordSetId));
-			portletPreferences.setValue(
 				"displayDDMTemplateId", String.valueOf(displayDDMTemplateId));
 			portletPreferences.setValue(
 				"formDDMTemplateId", String.valueOf(formDDMTemplateId));
@@ -201,6 +315,8 @@ public class DDLDisplayExportImportPortletPreferencesProcessor
 				"Unable to update portlet preferences during import",
 				readOnlyException);
 		}
+
+		portletDataContext.setScopeGroupId(previousScopeGroupId);
 
 		return portletPreferences;
 	}
@@ -275,5 +391,8 @@ public class DDLDisplayExportImportPortletPreferencesProcessor
 
 	@Reference
 	private DDMTemplateLocalService _ddmTemplateLocalService;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
 
 }

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/java/com/liferay/dynamic/data/lists/web/internal/exportimport/portlet/preferences/processor/DDLDisplayExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/java/com/liferay/dynamic/data/lists/web/internal/exportimport/portlet/preferences/processor/DDLDisplayExportImportPortletPreferencesProcessor.java
@@ -156,8 +156,18 @@ public class DDLDisplayExportImportPortletPreferencesProcessor
 			portletDataContext.setScopeGroupId(recordSetGroupId);
 		}
 
-		DDLRecordSet recordSet = _ddlRecordSetLocalService.fetchRecordSet(
-			GetterUtil.getLong(recordSetId));
+		String recordSetKey = portletPreferences.getValue("recordSetKey", null);
+
+		DDLRecordSet recordSet = null;
+
+		try {
+			recordSet = _ddlRecordSetLocalService.getRecordSet(
+				recordSetGroupId, recordSetKey);
+		}
+		catch (PortalException portalException) {
+			throw new PortletDataException(
+				"Unable to export referenced records", portalException);
+		}
 
 		if (recordSet == null) {
 			if (_log.isWarnEnabled()) {
@@ -199,6 +209,8 @@ public class DDLDisplayExportImportPortletPreferencesProcessor
 		_exportReferenceDDMTemplate(
 			portletDataContext, portletId, formDDMTemplateId);
 
+		portletDataContext.setScopeGroupId(previousScopeGroupId);
+
 		return portletPreferences;
 	}
 
@@ -238,9 +250,8 @@ public class DDLDisplayExportImportPortletPreferencesProcessor
 			(Map<String, Long>)portletDataContext.getNewPrimaryKeysMap(
 				DDLRecordSet.class + ".groupId");
 
-		String importedRecordSetId = String.valueOf(
-			GetterUtil.getLong(
-				portletPreferences.getValue("recordSetId", null)));
+		String importedRecordSetId = portletPreferences.getValue(
+			"recordSetId", null);
 
 		if (recordSetGroupIds.containsKey(importedRecordSetId)) {
 			groupId = recordSetGroupIds.get(importedRecordSetId);
@@ -268,9 +279,8 @@ public class DDLDisplayExportImportPortletPreferencesProcessor
 					(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
 						DDLRecordSet.class);
 
-				long recordSetId = GetterUtil.getLong(importedRecordSetId);
-
-				recordSetId = MapUtil.getLong(recordSetIds, recordSetId, 0);
+				long recordSetId = MapUtil.getLong(
+					recordSetIds, GetterUtil.getLong(importedRecordSetId), 0);
 
 				try {
 					portletPreferences.setValue(

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/java/com/liferay/dynamic/data/lists/web/internal/portlet/action/DDLDisplayConfigurationAction.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/java/com/liferay/dynamic/data/lists/web/internal/portlet/action/DDLDisplayConfigurationAction.java
@@ -15,12 +15,20 @@
 package com.liferay.dynamic.data.lists.web.internal.portlet.action;
 
 import com.liferay.dynamic.data.lists.constants.DDLPortletKeys;
+import com.liferay.dynamic.data.lists.model.DDLRecordSet;
+import com.liferay.dynamic.data.lists.service.DDLRecordSetLocalService;
 import com.liferay.portal.kernel.portlet.ConfigurationAction;
 import com.liferay.portal.kernel.portlet.DefaultConfigurationAction;
+import com.liferay.portal.kernel.util.GetterUtil;
+
+import javax.portlet.ActionRequest;
+import javax.portlet.ActionResponse;
+import javax.portlet.PortletConfig;
 
 import javax.servlet.http.HttpServletRequest;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Marcellus Tavares
@@ -35,5 +43,31 @@ public class DDLDisplayConfigurationAction extends DefaultConfigurationAction {
 	public String getJspPath(HttpServletRequest httpServletRequest) {
 		return "/configuration.jsp";
 	}
+
+	@Override
+	public void processAction(
+			PortletConfig portletConfig, ActionRequest actionRequest,
+			ActionResponse actionResponse)
+		throws Exception {
+
+		String recordSetId = getParameter(actionRequest, "recordSetId");
+
+		DDLRecordSet recordSet = _ddlRecordSetLocalService.getRecordSet(
+			GetterUtil.getLong(recordSetId));
+
+		setPreference(
+			actionRequest, "groupId", _getRecordSetGroupId(recordSet));
+		setPreference(
+			actionRequest, "recordSetKey", recordSet.getRecordSetKey());
+
+		super.processAction(portletConfig, actionRequest, actionResponse);
+	}
+
+	private String _getRecordSetGroupId(DDLRecordSet recordSet) {
+		return String.valueOf(recordSet.getGroupId());
+	}
+
+	@Reference
+	private DDLRecordSetLocalService _ddlRecordSetLocalService;
 
 }

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/java/com/liferay/dynamic/data/lists/web/internal/portlet/action/DDLDisplayConfigurationAction.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/java/com/liferay/dynamic/data/lists/web/internal/portlet/action/DDLDisplayConfigurationAction.java
@@ -50,21 +50,18 @@ public class DDLDisplayConfigurationAction extends DefaultConfigurationAction {
 			ActionResponse actionResponse)
 		throws Exception {
 
-		String recordSetId = getParameter(actionRequest, "recordSetId");
-
 		DDLRecordSet recordSet = _ddlRecordSetLocalService.getRecordSet(
-			GetterUtil.getLong(recordSetId));
+			GetterUtil.getLong(getParameter(actionRequest, "recordSetId")));
 
 		setPreference(
-			actionRequest, "groupId", _getRecordSetGroupId(recordSet));
+			actionRequest, "recordSetId",
+			String.valueOf(recordSet.getRecordSetId()));
+		setPreference(
+			actionRequest, "groupId", String.valueOf(recordSet.getGroupId()));
 		setPreference(
 			actionRequest, "recordSetKey", recordSet.getRecordSetKey());
 
 		super.processAction(portletConfig, actionRequest, actionResponse);
-	}
-
-	private String _getRecordSetGroupId(DDLRecordSet recordSet) {
-		return String.valueOf(recordSet.getGroupId());
 	}
 
 	@Reference


### PR DESCRIPTION
[LPS-167450](https://liferay.atlassian.net/browse/LPS-167450) - modified the DDLDisplay portlet to fetch the records based on groupId and recordSetKey instead of recordSetId

Hello team,

I would like to request a review of this PR, as it changes the behavior of the DDL Display Portlet. I have made modifications to the **DDLDisplayExportImportPortletPreferencesProcessor** class to align its behavior with that of the **JournalContentExportImportPortletPreferencesProcessor**. Additionally, I've included the **groupId** and **recordSetKey** in the portlet preferences within the **DDLDisplayConfigurationAction** class.

The issue with the **DDLDisplayPortlet** was that it only worked with the **recordSetId**, without considering the **groupId**. Consequently, it couldn't differentiate between staging and live **recordSets**. When we published the page containing the **DDLDisplayPortlet** without the **recordSet**, the display portlet still pointed to the single existing **recordSet**, even though it should have been exclusive to the staging site. Now you can publish the **recordSet** and the **records** individually.

Update :
**Expected** **Behavior**: The portlets are present (you can see the divs in the inspector) on Live but not the contents from them.
**Actual** **Behavior**: The web content doesn't present but the DDL record does.