### PR TITLE
LPS-118032 Fix accessibility errors pagination Lexicon

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
@@ -103,7 +103,7 @@ const LabelProperty = ({hideField, label}) => {
 
 const RequiredProperty = () => {
 	return (
-		<span className="ddm-label-required reference-mark">
+		<span aria-hidden="true" className="ddm-label-required reference-mark">
 			<ClayIcon symbol="asterisk" />
 		</span>
 	);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/FieldBase/__snapshots__/ReactFieldBase.es.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/FieldBase/__snapshots__/ReactFieldBase.es.js.snap
@@ -169,6 +169,7 @@ exports[`ReactFieldBase renders the FieldBase with required 1`] = `
       tabindex="0"
     >
       <span
+        aria-hidden="true"
         class="ddm-label-required reference-mark"
       >
         <svg

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Select/__snapshots__/Select.es.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Select/__snapshots__/Select.es.js.snap
@@ -1715,6 +1715,7 @@ exports[`Select puts an asterisk when field is required 1`] = `
     >
       This is the label
       <span
+        aria-hidden="true"
         class="ddm-label-required reference-mark"
       >
         <svg


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-118032

Hi team, I'm submitting this fix based in an old LPS as with the change from Clay to React the correction was missed. The request is to remove the icon information during the screenreader reading. As I can't  directly update the Clay Icon (see [markup element rendered here ](https://clayui.com/docs/components/icon/markup.html)), I'm adding in the parent tag the aria-hidden attribute. 

As in the past we're creating the tags in a jsp writer, older fixes removed the role="presentation" from the creation and overwrote with the aria-hidden. To overpass an external library update, I'm proposing this fix and intending to maintain both info.

The aria-hidden="true" will remove the entire element from the accessibility tool, so the existing role="presentation" won't impact the results.

Let me know if it is the best approach to this case and if I have to open a new LPS ticket.

Solution tested and results were satisfactory.

![sd](https://github.com/liferay-forms/liferay-portal/assets/41641596/c655dc00-398d-4bb8-b235-1d2881e26df8)


