### PR TITLE
LPS-193860 The geolocation field information of the web contents are lost if you click on "Save as Draft"

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Geolocation/useGeolocation.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Geolocation/useGeolocation.es.js
@@ -159,7 +159,7 @@ export function useGeolocation({
 	}, [onChange]);
 
 	useEffect(() => {
-		if (value && mapRef.current) {
+		if (value) {
 			let _value = value;
 
 			if (typeof _value !== 'string') {
@@ -170,7 +170,9 @@ export function useGeolocation({
 				.getElementById(`input_value_${instanceId}`)
 				.setAttribute('value', _value);
 
-			mapRef.current.setCenter(parseJSONValue(value));
+			if (mapRef.current) {
+				mapRef.current.setCenter(parseJSONValue(value));
+			}
 		}
 	}, [instanceId, value]);
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Geolocation/useGeolocation.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Geolocation/useGeolocation.es.js
@@ -122,6 +122,14 @@ export function useGeolocation({
 					mapRef.current,
 					`#map_${instanceId}`
 				);
+
+				mapRef.current.removeAllListeners('positionChange');
+
+				mapRef.current.on('positionChange', onChange);
+
+				if (value) {
+					mapRef.current.setCenter(parseJSONValue(value));
+				}
 			};
 
 			switch (mapProviderKey) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-193860

The “geolocation” field information of the web contents is lost if you click on "Save as Draft".

The root cause of the issue is on the way google maps is configured here: [useGeolocation.es.js#L59-L88](https://github.com/liferay/liferay-portal/blob/0ed1888646ef54af34ae0c49eff5f6841588f3bf/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Geolocation/useGeolocation.es.js#L59-L88)

1. The first time you open the webcontent, window.google && window.google.maps && Liferay.Maps && Liferay.Maps.gmapsReady is true, so the callback is executed immediately and after that, the position change listener is registered here: [useGeolocation.es.js#L157](https://github.com/liferay/liferay-portal/blob/0ed1888646ef54af34ae0c49eff5f6841588f3bf/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Geolocation/useGeolocation.es.js#L157)
2. If you click on "Save Draft", window.google && window.google.maps && Liferay.Maps && Liferay.Maps.gmapsReady is false, so Google Maps functionality must be initialized and the callback is executed later [useGeolocation.es.js#L73](https://github.com/liferay/liferay-portal/blob/0ed1888646ef54af34ae0c49eff5f6841588f3bf/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Geolocation/useGeolocation.es.js#L73)

As the callback is executed later, the position change listener is not registered here [useGeolocation.es.js#L157](https://github.com/liferay/liferay-portal/blob/0ed1888646ef54af34ae0c49eff5f6841588f3bf/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Geolocation/useGeolocation.es.js#L157) because mapRef.current is null when that code is executed.

To solve the issue:

1. 46748ea0b20caa126feb8978744548746431fba9 => I am removing the `mapRef.current` condition, to always set the value to the hidden input field to avoid losing the value if the customer clicks on save even if the map component is not loaded
2. 5b1bdc570f723014ea1713d543628a1cb6f69033 => I am setting the positionChange listener and the map center in the `registerMapBase` function as its execution can be delayed if 'window.google && window.google.maps && Liferay.Maps && Liferay.Maps.gmapsReady' is false and the current place [useGeolocation.es.js#L157](https://github.com/liferay/liferay-portal/blob/0ed1888646ef54af34ae0c49eff5f6841588f3bf/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Geolocation/useGeolocation.es.js#L157)  where the listener is added is not executed as mapRef.current is null as the callback execution was delayed due to Google Map initialization

Let me know if you need more information.