### PR TITLE
[TS] LPS-193762 Reloading the edit view for web contents changes theme used in CKEditor from admin theme to one used for public pages

### DIFF
--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/thunks/pageLanguageUpdate.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/thunks/pageLanguageUpdate.es.js
@@ -77,7 +77,7 @@ export default function pageLanguageUpdate({
 		fetch(
 			`/o/data-engine/v2.0/data-layouts/${ddmStructureLayoutId}/context?p_p_id=${getPortletId(
 				portletNamespace
-			)}`,
+			)}&p_l_id=${themeDisplay.getPlid()}`,
 			{
 				body: JSON.stringify({
 					dataRecordValues,


### PR DESCRIPTION
Hi @liferay-form team,

This is a solution for [LPS-193762](https://liferay.atlassian.net/browse/LPS-193762). The issue appears when reloading the edit view of a web content with a CKEditor. The problem is that the theme for the editor is taken from the default page of the site, instead of from the control panel site (by default, admin theme).

Although I'm not quite sure why the issue is only reproduced when reloading the edit view, I've seen that the call to `/o/data-engine/v2.0/data-layouts` didn't have any reference to the current layout. So it's the default layout for the current site (i.e., /guest, not /control_panel) that it's taken when creating the `themeDisplay` that is later used in `JournalArticleContentEditorConfigContributor`. 

My proposed solution is to add a query parameter with the current `plid`. This is similar to what was done in [LPS-167709](https://liferay.atlassian.net/browse/LPS-167709) for the `p_p_id`.

Please let me know if you have any questions.

Thanks!