### PR TITLE
LPS-194047 - fix testDDLDisplayPortletPreferences test case to work with recordSetKey instead of recordSetId

### DIFF
--- a/modules/apps/staging/staging-test/src/testIntegration/java/com/liferay/staging/test/StagingDataPortletPreferencesTest.java
+++ b/modules/apps/staging/staging-test/src/testIntegration/java/com/liferay/staging/test/StagingDataPortletPreferencesTest.java
@@ -115,8 +115,13 @@ public class StagingDataPortletPreferencesTest
 			"formDDMTemplateId",
 			new String[] {String.valueOf(formDDMTemplate.getTemplateId())}
 		).put(
+			"groupId", new String[] {String.valueOf(ddlRecordSet.getGroupId())}
+		).put(
 			"recordSetId",
 			new String[] {String.valueOf(ddlRecordSet.getRecordSetId())}
+		).put(
+			"recordSetKey",
+			new String[] {String.valueOf(ddlRecordSet.getRecordSetKey())}
 		).build();
 
 		String portletId = publishLayoutWithDisplayPortlet(
@@ -131,8 +136,8 @@ public class StagingDataPortletPreferencesTest
 			livePortletPreferences.getValue(
 				"formDDMTemplateId", StringPool.BLANK));
 		Assert.assertEquals(
-			String.valueOf(ddlRecordSet.getRecordSetId()),
-			livePortletPreferences.getValue("recordSetId", StringPool.BLANK));
+			String.valueOf(ddlRecordSet.getRecordSetKey()),
+			livePortletPreferences.getValue("recordSetKey", StringPool.BLANK));
 
 		publishPortlet(DDLPortletKeys.DYNAMIC_DATA_LISTS);
 
@@ -158,8 +163,8 @@ public class StagingDataPortletPreferencesTest
 			livePortletPreferences.getValue(
 				"formDDMTemplateId", StringPool.BLANK));
 		Assert.assertEquals(
-			String.valueOf(liveDDLRecordSet.getRecordSetId()),
-			livePortletPreferences.getValue("recordSetId", StringPool.BLANK));
+			String.valueOf(liveDDLRecordSet.getRecordSetKey()),
+			livePortletPreferences.getValue("recordSetKey", StringPool.BLANK));
 	}
 
 	@Test


### PR DESCRIPTION
[LPS-194047](https://liferay.atlassian.net/browse/LPS-194047)

Regression : [LPS-167450](https://liferay.atlassian.net/browse/LPS-167450l)