### PR TITLE
[TS] LPS-193762 Follow up to fix parameter ordering

### DIFF
--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/thunks/pageLanguageUpdate.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/thunks/pageLanguageUpdate.es.js
@@ -75,9 +75,9 @@ export default function pageLanguageUpdate({
 		});
 
 		fetch(
-			`/o/data-engine/v2.0/data-layouts/${ddmStructureLayoutId}/context?p_p_id=${getPortletId(
+			`/o/data-engine/v2.0/data-layouts/${ddmStructureLayoutId}/context?p_l_id=${themeDisplay.getPlid()}&p_p_id=${getPortletId(
 				portletNamespace
-			)}&p_l_id=${themeDisplay.getPlid()}`,
+			)}`,
 			{
 				body: JSON.stringify({
 					dataRecordValues,


### PR DESCRIPTION
Hi @liferay-forms team,

This is a followup PR to https://github.com/brianchandotcom/liferay-portal/pull/139820 to fix the ordering of parameters (`p_l_id` should go before `p_p_id`; see https://github.com/brianchandotcom/liferay-portal/pull/139820#issuecomment-1695958962).

Thanks!