### PR TITLE
[TS] [Urgent] LPS-194985 Add "ddm-paragraph" field type back into the supported form field types so that Form Templates using it can render correctly

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/constants/DDMConstants.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/constants/DDMConstants.java
@@ -33,10 +33,11 @@ public class DDMConstants {
 		DDMFormFieldType.IMAGE, DDMFormFieldType.INTEGER,
 		DDMFormFieldType.JOURNAL_ARTICLE, DDMFormFieldType.LINK_TO_PAGE,
 		DDMFormFieldType.LOCALIZABLE_TEXT, DDMFormFieldType.NUMBER,
-		DDMFormFieldType.NUMERIC, DDMFormFieldType.PASSWORD,
-		DDMFormFieldType.RADIO, DDMFormFieldType.SELECT,
-		DDMFormFieldType.SEPARATOR, DDMFormFieldType.TEXT,
-		DDMFormFieldType.TEXT_AREA, DDMFormFieldType.TEXT_HTML
+		DDMFormFieldType.NUMERIC, DDMFormFieldType.PARAGRAPH,
+		DDMFormFieldType.PASSWORD, DDMFormFieldType.RADIO,
+		DDMFormFieldType.SELECT, DDMFormFieldType.SEPARATOR,
+		DDMFormFieldType.TEXT, DDMFormFieldType.TEXT_AREA,
+		DDMFormFieldType.TEXT_HTML
 	};
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/model/DDMFormFieldType.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/model/DDMFormFieldType.java
@@ -45,6 +45,8 @@ public class DDMFormFieldType {
 
 	public static final String NUMERIC = "numeric";
 
+	public static final String PARAGRAPH = "ddm-paragraph";
+
 	public static final String PASSWORD = "password";
 
 	public static final String RADIO = "radio";

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/resources/com/liferay/dynamic/data/mapping/model/packageinfo
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/resources/com/liferay/dynamic/data/mapping/model/packageinfo
@@ -1,1 +1,1 @@
-version 7.1.0
+version 7.2.0


### PR DESCRIPTION
Ticket: [LPS-194985](https://liferay.atlassian.net/browse/LPS-194985)

Please see the linked ticket for steps to reproduce the issue and an explanation of why we need to add "ddm-paragraph" back into the Supported Field Types.