### PR TITLE
LPS-172282

### DIFF
--- a/modules/apps/document-library-google-docs/document-library-google-docs/src/main/java/com/liferay/document/library/google/docs/internal/helper/GoogleDocsMetadataHelper.java
+++ b/modules/apps/document-library-google-docs/document-library-google-docs/src/main/java/com/liferay/document/library/google/docs/internal/helper/GoogleDocsMetadataHelper.java
@@ -154,26 +154,29 @@ public class GoogleDocsMetadataHelper {
 			fields.put(
 				new Field(
 					ddmStructureId,
+					GoogleDocsConstants.DDM_FIELD_NAME_DESCRIPTION,
 					GoogleDocsConstants.DDM_FIELD_NAME_DESCRIPTION, ""));
 			fields.put(
 				new Field(
 					ddmStructureId,
+					GoogleDocsConstants.DDM_FIELD_NAME_EMBEDDABLE_URL,
 					GoogleDocsConstants.DDM_FIELD_NAME_EMBEDDABLE_URL, ""));
 			fields.put(
 				new Field(
 					ddmStructureId, GoogleDocsConstants.DDM_FIELD_NAME_ICON_URL,
-					""));
+					GoogleDocsConstants.DDM_FIELD_NAME_ICON_URL, ""));
 			fields.put(
 				new Field(
-					ddmStructureId, GoogleDocsConstants.DDM_FIELD_NAME_ID, ""));
+					ddmStructureId, GoogleDocsConstants.DDM_FIELD_NAME_ID,
+					GoogleDocsConstants.DDM_FIELD_NAME_ID, ""));
 			fields.put(
 				new Field(
 					ddmStructureId, GoogleDocsConstants.DDM_FIELD_NAME_NAME,
-					""));
+					GoogleDocsConstants.DDM_FIELD_NAME_NAME, ""));
 			fields.put(
 				new Field(
 					ddmStructureId, GoogleDocsConstants.DDM_FIELD_NAME_URL,
-					""));
+					GoogleDocsConstants.DDM_FIELD_NAME_URL, ""));
 
 			ServiceContext serviceContext = new ServiceContext();
 

--- a/modules/apps/document-library/document-library-video/src/main/java/com/liferay/document/library/video/internal/helper/DLVideoExternalShortcutMetadataHelper.java
+++ b/modules/apps/document-library/document-library-video/src/main/java/com/liferay/document/library/video/internal/helper/DLVideoExternalShortcutMetadataHelper.java
@@ -160,16 +160,19 @@ public class DLVideoExternalShortcutMetadataHelper {
 			fields.put(
 				new Field(
 					ddmStructureId, DLVideoConstants.DDM_FIELD_NAME_DESCRIPTION,
-					""));
+					DLVideoConstants.DDM_FIELD_NAME_DESCRIPTION, ""));
 			fields.put(
 				new Field(
-					ddmStructureId, DLVideoConstants.DDM_FIELD_NAME_HTML, ""));
+					ddmStructureId, DLVideoConstants.DDM_FIELD_NAME_HTML,
+					DLVideoConstants.DDM_FIELD_NAME_HTML, ""));
 			fields.put(
 				new Field(
-					ddmStructureId, DLVideoConstants.DDM_FIELD_NAME_TITLE, ""));
+					ddmStructureId, DLVideoConstants.DDM_FIELD_NAME_TITLE,
+					DLVideoConstants.DDM_FIELD_NAME_TITLE, ""));
 			fields.put(
 				new Field(
-					ddmStructureId, DLVideoConstants.DDM_FIELD_NAME_URL, ""));
+					ddmStructureId, DLVideoConstants.DDM_FIELD_NAME_URL,
+					DLVideoConstants.DDM_FIELD_NAME_URL, ""));
 
 			ServiceContext serviceContext = new ServiceContext();
 

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/service/impl/DDLRecordLocalServiceImpl.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/service/impl/DDLRecordLocalServiceImpl.java
@@ -22,6 +22,7 @@ import com.liferay.dynamic.data.lists.service.persistence.DDLRecordVersionPersis
 import com.liferay.dynamic.data.lists.util.DDL;
 import com.liferay.dynamic.data.lists.util.comparator.DDLRecordIdComparator;
 import com.liferay.dynamic.data.mapping.exception.StorageException;
+import com.liferay.dynamic.data.mapping.model.DDMFormField;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
 import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
@@ -194,8 +195,8 @@ public class DDLRecordLocalServiceImpl extends DDLRecordLocalServiceBaseImpl {
 		DDMStructure ddmStructure = recordSet.getDDMStructure();
 
 		Fields fields = toFields(
-			ddmStructure.getStructureId(), fieldsMap,
-			serviceContext.getLocale(), LocaleUtil.getSiteDefault());
+			ddmStructure, fieldsMap, serviceContext.getLocale(),
+			LocaleUtil.getSiteDefault());
 
 		DDMFormValues ddmFormValues = fieldsToDDMFormValuesConverter.convert(
 			ddmStructure, fields);
@@ -852,11 +853,9 @@ public class DDLRecordLocalServiceImpl extends DDLRecordLocalServiceBaseImpl {
 
 		DDLRecordSet recordSet = record.getRecordSet();
 
-		DDMStructure ddmStructure = recordSet.getDDMStructure();
-
 		Fields fields = toFields(
-			ddmStructure.getStructureId(), fieldsMap,
-			serviceContext.getLocale(), oldDDMFormValues.getDefaultLocale());
+			recordSet.getDDMStructure(), fieldsMap, serviceContext.getLocale(),
+			oldDDMFormValues.getDefaultLocale());
 
 		if (mergeFields) {
 			DDLRecordVersion recordVersion = record.getLatestRecordVersion();
@@ -1168,15 +1167,22 @@ public class DDLRecordLocalServiceImpl extends DDLRecordLocalServiceBaseImpl {
 	}
 
 	protected Fields toFields(
-		long ddmStructureId, Map<String, Serializable> fieldsMap, Locale locale,
-		Locale defaultLocale) {
+			DDMStructure ddmStructure, Map<String, Serializable> fieldsMap,
+			Locale locale, Locale defaultLocale)
+		throws PortalException {
 
 		Fields fields = new Fields();
 
 		for (Map.Entry<String, Serializable> entry : fieldsMap.entrySet()) {
 			Field field = new Field();
 
-			field.setDDMStructureId(ddmStructureId);
+			field.setDDMStructureId(ddmStructure.getStructureId());
+
+			DDMFormField ddmFormField = ddmStructure.getDDMFormField(
+				entry.getKey());
+
+			field.setFieldReference(ddmFormField.getFieldReference());
+
 			field.setName(entry.getKey());
 
 			Serializable value = entry.getValue();
@@ -1222,8 +1228,8 @@ public class DDLRecordLocalServiceImpl extends DDLRecordLocalServiceBaseImpl {
 			}
 
 			fieldsDisplayField = new Field(
-				ddmStructureId, _FIELDS_DISPLAY_NAME,
-				fieldsDisplayFieldSB.toString());
+				ddmStructure.getStructureId(), _FIELDS_DISPLAY_NAME,
+				_FIELDS_DISPLAY_NAME, fieldsDisplayFieldSB.toString());
 
 			fields.put(fieldsDisplayField);
 		}

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/service/impl/DDLRecordLocalServiceImpl.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-service/src/main/java/com/liferay/dynamic/data/lists/service/impl/DDLRecordLocalServiceImpl.java
@@ -1210,7 +1210,7 @@ public class DDLRecordLocalServiceImpl extends DDLRecordLocalServiceBaseImpl {
 			fields.put(field);
 		}
 
-		Field fieldsDisplayField = fields.get(_FIELDS_DISPLAY_NAME);
+		Field fieldsDisplayField = fields.get(DDM.FIELDS_DISPLAY_NAME);
 
 		if (fieldsDisplayField == null) {
 			StringBundler fieldsDisplayFieldSB = new StringBundler(
@@ -1228,8 +1228,8 @@ public class DDLRecordLocalServiceImpl extends DDLRecordLocalServiceBaseImpl {
 			}
 
 			fieldsDisplayField = new Field(
-				ddmStructure.getStructureId(), _FIELDS_DISPLAY_NAME,
-				_FIELDS_DISPLAY_NAME, fieldsDisplayFieldSB.toString());
+				ddmStructure.getStructureId(), DDM.FIELDS_DISPLAY_NAME,
+				DDM.FIELDS_DISPLAY_NAME, fieldsDisplayFieldSB.toString());
 
 			fields.put(fieldsDisplayField);
 		}
@@ -1352,8 +1352,6 @@ public class DDLRecordLocalServiceImpl extends DDLRecordLocalServiceBaseImpl {
 
 		return serializableValues;
 	}
-
-	private static final String _FIELDS_DISPLAY_NAME = "_fieldsDisplay";
 
 	private static final String _INSTANCE_SEPARATOR = "_INSTANCE_";
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/bnd.bnd
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Dynamic Data Mapping API
 Bundle-SymbolicName: com.liferay.dynamic.data.mapping.api
-Bundle-Version: 25.1.0
+Bundle-Version: 26.0.0
 Export-Package:\
 	com.liferay.dynamic.data.mapping.annotations,\
 	com.liferay.dynamic.data.mapping.configuration,\

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/storage/Field.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/storage/Field.java
@@ -37,34 +37,40 @@ public class Field implements Serializable {
 	}
 
 	public Field(
-		long ddmStructureId, String name, List<Serializable> values,
-		Locale locale) {
+		long ddmStructureId, String fieldReference, String name,
+		List<Serializable> values, Locale locale) {
 
 		_ddmStructureId = ddmStructureId;
+		_fieldReference = fieldReference;
 		_name = name;
 
 		_valuesMap.put(locale, values);
 	}
 
 	public Field(
-		long ddmStructureId, String name,
+		long ddmStructureId, String fieldReference, String name,
 		Map<Locale, List<Serializable>> valuesMap, Locale defaultLocale) {
 
 		_ddmStructureId = ddmStructureId;
+		_fieldReference = fieldReference;
 		_name = name;
 		_valuesMap = valuesMap;
 		_defaultLocale = defaultLocale;
 	}
 
-	public Field(long ddmStructureId, String name, Serializable value) {
+	public Field(
+		long ddmStructureId, String fieldReference, String name,
+		Serializable value) {
+
 		_ddmStructureId = ddmStructureId;
+		_fieldReference = fieldReference;
 		_name = name;
 
 		setValue(value);
 	}
 
-	public Field(String name, Serializable value) {
-		this(0, name, value);
+	public Field(String fieldReference, String name, Serializable value) {
+		this(0, fieldReference, name, value);
 	}
 
 	public void addValue(Locale locale, Serializable value) {
@@ -98,6 +104,7 @@ public class Field implements Serializable {
 		Field field = (Field)object;
 
 		if ((_ddmStructureId == field._ddmStructureId) &&
+			Objects.equals(_fieldReference, field._fieldReference) &&
 			Objects.equals(_name, field._name) &&
 			Objects.equals(_valuesMap, field._valuesMap)) {
 
@@ -127,6 +134,10 @@ public class Field implements Serializable {
 
 	public Locale getDefaultLocale() {
 		return _defaultLocale;
+	}
+
+	public String getFieldReference() {
+		return _fieldReference;
 	}
 
 	public String getName() {
@@ -206,6 +217,8 @@ public class Field implements Serializable {
 	public int hashCode() {
 		int hash = HashUtil.hash(0, _ddmStructureId);
 
+		hash = HashUtil.hash(hash, _fieldReference);
+
 		hash = HashUtil.hash(hash, _name);
 
 		return HashUtil.hash(hash, _valuesMap);
@@ -244,6 +257,10 @@ public class Field implements Serializable {
 
 	public void setDefaultLocale(Locale defaultLocale) {
 		_defaultLocale = defaultLocale;
+	}
+
+	public void setFieldReference(String fieldReference) {
+		_fieldReference = fieldReference;
 	}
 
 	public void setName(String name) {
@@ -318,6 +335,7 @@ public class Field implements Serializable {
 
 	private long _ddmStructureId;
 	private Locale _defaultLocale;
+	private String _fieldReference;
 	private String _name;
 	private Map<Locale, List<Serializable>> _valuesMap = new HashMap<>();
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/storage/Fields.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/storage/Fields.java
@@ -28,7 +28,13 @@ import java.util.Set;
 public class Fields implements Iterable<Field>, Serializable {
 
 	public boolean contains(String name) {
-		return _fieldsMap.containsKey(name);
+		if (_fieldsMap.containsKey(name) ||
+			_fieldsReferencesMap.containsKey(name)) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	@Override
@@ -66,7 +72,13 @@ public class Fields implements Iterable<Field>, Serializable {
 	}
 
 	public Field get(String name) {
-		return _fieldsMap.get(name);
+		Field field = _fieldsMap.get(name);
+
+		if (field == null) {
+			field = _fieldsReferencesMap.get(name);
+		}
+
+		return field;
 	}
 
 	public Set<Locale> getAvailableLocales() {
@@ -147,10 +159,16 @@ public class Fields implements Iterable<Field>, Serializable {
 
 	public void put(Field field) {
 		_fieldsMap.put(field.getName(), field);
+
+		_fieldsReferencesMap.put(field.getFieldReference(), field);
 	}
 
 	public Field remove(String name) {
-		return _fieldsMap.remove(name);
+		Field field = _fieldsMap.remove(name);
+
+		_fieldsReferencesMap.remove(field.getFieldReference());
+
+		return field;
 	}
 
 	protected List<Field> getFieldsList(boolean includePrivateFields) {
@@ -168,5 +186,6 @@ public class Fields implements Iterable<Field>, Serializable {
 	}
 
 	private final Map<String, Field> _fieldsMap = new HashMap<>();
+	private final Map<String, Field> _fieldsReferencesMap = new HashMap<>();
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/resources/com/liferay/dynamic/data/mapping/storage/packageinfo
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/resources/com/liferay/dynamic/data/mapping/storage/packageinfo
@@ -1,1 +1,1 @@
-version 3.0.0
+version 4.0.0

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMFormValuesToFieldsConverterImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMFormValuesToFieldsConverterImpl.java
@@ -64,7 +64,7 @@ public class DDMFormValuesToFieldsConverterImpl
 		fields.put(
 			new Field(
 				ddmStructure.getStructureId(), DDMImpl.FIELDS_DISPLAY_NAME,
-				StringPool.BLANK));
+				DDMImpl.FIELDS_DISPLAY_NAME, StringPool.BLANK));
 
 		for (DDMFormFieldValue ddmFormFieldValue :
 				ddmFormValues.getDDMFormFieldValues()) {
@@ -160,6 +160,7 @@ public class DDMFormValuesToFieldsConverterImpl
 
 		field.setDDMStructureId(ddmStructureId);
 		field.setDefaultLocale(defaultLocale);
+		field.setFieldReference(ddmFormField.getFieldReference());
 		field.setName(ddmFormFieldValue.getName());
 
 		Value value = ddmFormFieldValue.getValue();

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMImpl.java
@@ -600,8 +600,9 @@ public class DDMImpl implements DDM {
 	}
 
 	protected Field createField(
-		DDMStructure ddmStructure, String fieldName,
-		List<Serializable> fieldValues, ServiceContext serviceContext) {
+			DDMStructure ddmStructure, String fieldName,
+			List<Serializable> fieldValues, ServiceContext serviceContext)
+		throws PortalException {
 
 		Field field = new Field();
 
@@ -626,6 +627,11 @@ public class DDMImpl implements DDM {
 
 		field.setDefaultLocale(defaultLocale);
 		field.setName(fieldName);
+
+		DDMFormField ddmFormField = ddmStructure.getDDMFormField(fieldName);
+
+		field.setFieldReference(ddmFormField.getFieldReference());
+
 		field.setValues(locale, fieldValues);
 
 		return field;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMXMLImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMXMLImpl.java
@@ -8,6 +8,7 @@ package com.liferay.dynamic.data.mapping.internal.util;
 import com.liferay.dynamic.data.mapping.constants.DDMStructureConstants;
 import com.liferay.dynamic.data.mapping.exception.StructureDefinitionException;
 import com.liferay.dynamic.data.mapping.exception.StructureDuplicateElementException;
+import com.liferay.dynamic.data.mapping.model.DDMFormField;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.storage.Field;
 import com.liferay.dynamic.data.mapping.storage.Fields;
@@ -130,6 +131,12 @@ public class DDMXMLImpl implements DDMXML {
 					field.setDefaultLocale(
 						LocaleUtil.fromLanguageId(defaultLanguageId));
 					field.setDDMStructureId(structure.getStructureId());
+
+					DDMFormField ddmFormField = structure.getDDMFormField(
+						fieldName);
+
+					field.setFieldReference(ddmFormField.getFieldReference());
+
 					field.setName(fieldName);
 					field.setValue(locale, fieldValueSerializable);
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/test/java/com/liferay/dynamic/data/mapping/internal/storage/GeolocationFieldRendererTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/test/java/com/liferay/dynamic/data/mapping/internal/storage/GeolocationFieldRendererTest.java
@@ -95,7 +95,8 @@ public class GeolocationFieldRendererTest {
 	}
 
 	private Field _createField() {
-		return new Field("field", "{latitude: 9.8765, longitude: 1.2345}");
+		return new Field(
+			"field", "field", "{latitude: 9.8765, longitude: 1.2345}");
 	}
 
 	private static final Language _language = Mockito.mock(Language.class);

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalConverterImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalConverterImpl.java
@@ -89,7 +89,7 @@ public class JournalConverterImpl implements JournalConverter {
 			ddmFields.put(
 				new Field(
 					ddmStructure.getStructureId(), DDM.FIELDS_DISPLAY_NAME,
-					StringPool.BLANK));
+					DDM.FIELDS_DISPLAY_NAME, StringPool.BLANK));
 
 			DDMForm ddmForm = ddmStructure.getDDMForm();
 
@@ -390,15 +390,17 @@ public class JournalConverterImpl implements JournalConverter {
 
 		String name = dynamicElementElement.attributeValue("name");
 
+		DDMFormField ddmFormField = ddmStructure.getDDMFormField(name);
+
+		ddmField.setFieldReference(ddmFormField.getFieldReference());
+
+		ddmField.setName(name);
+
 		if (!GetterUtil.getBoolean(
 				ddmStructure.getFieldProperty(name, "localizable"))) {
 
 			availableLanguageIds = StringPool.EMPTY_ARRAY;
 		}
-
-		ddmField.setName(name);
-
-		DDMFormField ddmFormField = ddmStructure.getDDMFormField(name);
 
 		Set<String> missingLanguageIds = SetUtil.fromArray(
 			availableLanguageIds);

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/util/test/JournalConverterUtilTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/util/test/JournalConverterUtilTest.java
@@ -669,7 +669,7 @@ public class JournalConverterUtilTest {
 			).build());
 
 		Field fieldsDisplayField = new Field(
-			ddmStructureId, DDM.FIELDS_DISPLAY_NAME,
+			ddmStructureId, DDM.FIELDS_DISPLAY_NAME, DDM.FIELDS_DISPLAY_NAME,
 			StringBundler.concat(
 				"boolean_INSTANCE_YELSrniM,document_library_INSTANCE_HzKJrSts,",
 				"link_to_layout_INSTANCE_eHQALxHa,text_area_INSTANCE_ucizquBv,",
@@ -806,7 +806,7 @@ public class JournalConverterUtilTest {
 			).build());
 
 		Field fieldsDisplayField = new Field(
-			ddmStructureId, DDM.FIELDS_DISPLAY_NAME,
+			ddmStructureId, DDM.FIELDS_DISPLAY_NAME, DDM.FIELDS_DISPLAY_NAME,
 			"backgroundcolor_INSTANCE_koamvduz,titulo_INSTANCE_ieaastyz," +
 				"subtitulo_INSTANCE_lsamnmcz");
 

--- a/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/info/item/updater/JournalArticleInfoItemFieldValuesUpdater.java
+++ b/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/info/item/updater/JournalArticleInfoItemFieldValuesUpdater.java
@@ -9,6 +9,7 @@ import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.asset.link.model.AssetLink;
 import com.liferay.asset.link.service.AssetLinkLocalService;
+import com.liferay.dynamic.data.mapping.model.DDMFormField;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.storage.Field;
 import com.liferay.dynamic.data.mapping.storage.Fields;
@@ -195,9 +196,12 @@ public class JournalArticleInfoItemFieldValuesUpdater
 			Fields ddmFields, List<String> ddmFieldValues)
 		throws Exception {
 
+		DDMFormField ddmFormField = ddmStructure.getDDMFormField(ddmFieldName);
+
 		Field ddmField = new Field(
-			ddmStructure.getStructureId(), ddmFieldName,
-			Collections.emptyList(), ddmFields.getDefaultLocale());
+			ddmStructure.getStructureId(), ddmFormField.getFieldReference(),
+			ddmFieldName, Collections.emptyList(),
+			ddmFields.getDefaultLocale());
 
 		ddmField.setValues(
 			targetLocale,


### PR DESCRIPTION
Hey guys,

It is a POC, I'm trying to fix the problem without doing a new upgrade process and also without making name and field reference have same value. It is because maybe we have new clients that are using name and field reference in other ways, and changing it can lead in new issues.

Motivation
-----
Fix backward compatibility with names and field references in templates.

Proposed Solution
-----
Add new field reference attribute to field object, in that way we can mirror the fieldsMap on fields object, we can also have a map with the fieldReference. With this new map, we can look for it in the new map if we don't find the field in fieldsMap.

I didn't test it since a don't have clear steps to reproduce it or to check the client behavior, if you can share those with me, I can do some testing.

Please let me know if you have any question and if this solution feet for you.