### PR TITLE
LPS-190908 Can't remove duplicated rich text if the Field Reference was edited

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
@@ -264,13 +264,12 @@ export function FieldBase({
 
 		const visitor = new PagesVisitor(pages);
 
-		const newFieldName = fieldName ?? fieldReference;
 		const newParentInstanceId = parentInstanceId;
 
 		visitor.mapFields(
 			(field) => {
 				if (
-					newFieldName === field.fieldName &&
+					fieldReference === field.fieldReference &&
 					newParentInstanceId === field.parentInstanceId
 				) {
 					repetitionsCounter++;


### PR DESCRIPTION
**Related Issue**: [**LPS-190908**](https://liferay.atlassian.net/browse/LPS-190908)

Since the filedName value behaves unexpectedly in different portlets, sometimes being undefined and others being static, and the fieldReference value is more stable,  originally equal to the fieldName's and only changing if you do so, maintaining the comparison only to it would be better.