### PR TITLE
LPS-196361 DDMFieldUpgradeProcess doesn't handle duplicate instanceIds, which is a possibility that is likely to happen in 7.3 due to a bug

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v4_1_0/DDMFieldUpgradeProcess.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v4_1_0/DDMFieldUpgradeProcess.java
@@ -230,9 +230,15 @@ public class DDMFieldUpgradeProcess extends UpgradeProcess {
 		List<DDMFormFieldValue> ddmFormValues, String parentInstanceId) {
 
 		for (DDMFormFieldValue ddmFormFieldValue : ddmFormValues) {
+			String instanceId = ddmFormFieldValue.getInstanceId();
+
+			if (ddmFieldInfoMap.containsKey(instanceId)) {
+				instanceId =
+					com.liferay.portal.kernel.util.StringUtil.randomString(8);
+			}
+
 			DDMFieldInfo ddmFieldInfo = new DDMFieldInfo(
-				ddmFormFieldValue.getName(), ddmFormFieldValue.getInstanceId(),
-				parentInstanceId);
+				ddmFormFieldValue.getName(), instanceId, parentInstanceId);
 
 			ddmFieldInfoMap.put(ddmFieldInfo._instanceId, ddmFieldInfo);
 


### PR DESCRIPTION
In 7.3 and earlier, when repeating a form's fieldsets, the instanceIds of the child fields will be duplicated. This bug was fixed in [LPS-125422](https://liferay.atlassian.net/browse/LPS-125422), but it wasn't backported to 7.3.x until very recently. So, we need to handle this possibility during the upgrade process.

Please see [LPS-196361](https://liferay.atlassian.net/browse/LPS-196361) for a more detailed description and steps to reproduce.