### PR TITLE
[TS] LPS-196592 DDMFormTemplateContextFactoryHelper's regex pattern cannot match Unicode characters

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/java/com/liferay/dynamic/data/mapping/form/renderer/internal/helper/DDMFormTemplateContextFactoryHelper.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/java/com/liferay/dynamic/data/mapping/form/renderer/internal/helper/DDMFormTemplateContextFactoryHelper.java
@@ -120,6 +120,6 @@ public class DDMFormTemplateContextFactoryHelper {
 	}
 
 	private static final Pattern _pattern = Pattern.compile(
-		"'?([\\w]+)'?\\s*[,\\)]\\s*");
+		"'?([\\p{L}\\p{N}]+)'?\\s*[,\\)]\\s*");
 
 }


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

Motivation
=======
This [pattern](https://github.com/liferay/liferay-portal/blob/master/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/java/com/liferay/dynamic/data/mapping/form/renderer/internal/helper/DDMFormTemplateContextFactoryHelper.java#L123) cannot handle non-ASCII Unicode characters. This may lead to errors, for example breaking form validation on a field whose name contains national characters, for example, å, ä, and ö.

Proposed Solution
========
THe pattern should be updated to handle Unicode characters.

Steps to Verify
========
Please see the linked LPS for the reproduction steps.
https://liferay.atlassian.net/browse/LPS-196592

Thank you and best regards,
István