### PR TITLE
[TS] LPS-197334 Post upgrade to DXP 7.4 from DXP 7.1 Form Rules with national characters are broken on save if the Form is modified

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Options/Options.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Options/Options.es.js
@@ -386,6 +386,8 @@ const Options = ({
 	const add = (fields, index, property, value) => {
 		fields[index][property] = value;
 
+		fields[index]['newField'] = true;
+
 		if (defaultLanguageId !== editingLanguageId) {
 			fields[index]['edited'] = true;
 		}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Options/util.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Options/util.es.js
@@ -151,7 +151,9 @@ export function normalizeValue(
 
 	value = dedupValue(fields, value, currentField.id, generateValueUsingLabel);
 
-	return allowSpecialCharacters ? value : normalizeFieldName(value);
+	return allowSpecialCharacters || !currentField.newField
+		? value
+		: normalizeFieldName(value);
 }
 
 export function normalizeFields(


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

Motivation
=======
On 7.4 special characters on form field options are no longer allowed, which could lead to problems when upgrading from a lower version.
For example, if there is an option that has the value `töst`
```
{
	"label" : {
		"en_US" : "töst"
	},
	"reference" : "töst",
	"value" : "töst"
}
```
when the form is edited, the value will be normalized by [this code](https://github.com/liferay/liferay-portal/blob/master/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Options/util.es.js#L136) and the special character `ö` will be removed from the value.

It will end up like this:
```
{
	"label" : {
		"en_US" : "töst"
	},
	"reference" : "töst",
	"value" : "tst"
}
```

If there is a form rule that references the option by its value, it will break.

`equals(getValue('Testtåst'), 'töst') OR equals(getValue('Testtåst'), 'tåst') OR equals(getValue('Testtåst'), 'täst')`

Proposed Solution
========
Normalization should be applied only for newly added options that are not referenced by a rule.

Steps to Verify
========
Please see the linked LPS for the reproduction steps.
https://liferay.atlassian.net/browse/LPS-197334

Thank you and best regards,
István