### PR TITLE
[TS] LPS-197919 Image Selector UI is empty when browser does not support the image file type

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/ImagePicker/ImagePicker.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/ImagePicker/ImagePicker.es.js
@@ -81,6 +81,25 @@ const ImagePicker = ({
 					onFieldChanged(mergedValues)
 				);
 			});
+
+			selectedImage.addEventListener('error', (event) => {
+				const imageData = {
+					...{
+						description: '',
+						event,
+						height: 0,
+						title: '',
+						url: '',
+						width: 0,
+					},
+					...selectedItemValue,
+				};
+
+				dispatchValue({value: imageData}, (mergedValues) =>
+					onFieldChanged(mergedValues)
+				);
+			});
+
 			selectedImage.src = selectedItemValue.url;
 		}
 	};
@@ -214,6 +233,12 @@ const ImagePicker = ({
 								alt={imageValues.description}
 								className="d-block img-fluid mb-2 rounded"
 								onClick={() => setModalVisible(true)}
+								onError={(event) =>
+									event.currentTarget.classList.add('hide')
+								}
+								onLoad={(event) =>
+									event.currentTarget.classList.remove('hide')
+								}
 								src={imageValues.url}
 								style={{
 									cursor: 'pointer',


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPS-197919

@alinedoleron This PR replaces https://github.com/liferay-forms/liferay-portal/pull/2339 .

- Found issue when editing already created web contents, should be fixed in this PR.
- For simplicity, there is no UI text message with an error but the image can be selected (Similar to other components when browser does not support image format).