### PR TITLE
[technical-support] LPS-198677 - Select from list fields work incorrectly when dealing with not automatically generated values

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Select/Select.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Select/Select.es.js
@@ -83,11 +83,7 @@ function toArray(value = '') {
 		newValue = [newValue];
 	}
 
-	if (newValue.some((i) => typeof i === 'number')) {
-		newValue = newValue.map((item) => item.toString());
-	}
-
-	return newValue;
+	return newValue.map((value) => value.toString());
 }
 
 function handleDropdownItemClick({currentValue, multiple, option}) {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Select/Select.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Select/Select.es.js
@@ -83,6 +83,10 @@ function toArray(value = '') {
 		newValue = [newValue];
 	}
 
+	if (newValue.some((i) => typeof i === 'number')) {
+		newValue = newValue.map((item) => item.toString());
+	}
+
 	return newValue;
 }
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Select/Select.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Select/Select.es.js
@@ -83,7 +83,7 @@ function toArray(value = '') {
 		newValue = [newValue];
 	}
 
-	return newValue.map((value) => value.toString());
+	return newValue.map((value) => value?.toString());
 }
 
 function handleDropdownItemClick({currentValue, multiple, option}) {


### PR DESCRIPTION
Hi,
This is a fix to [LPS-198677](https://liferay.atlassian.net/browse/LPS-198677) .
The root cause of the issue is that if a value of a field form in a multiple select list is simply a number above 10 and not beginning with a zero or with "Option", it will be interpreted as a number by the front end code. Our logic only works if the values are interpreted as Strings.
I resolved it by adding a check in Select.es.js. If there is a value in the list which is a number, than it will be converted to a string.
Please review my changes.