### PR TITLE
[TS] LPS-198515 Error message not displayed on UI after exceeding the Upload Servlet Request limit

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -449,13 +449,6 @@ message.
 					<arg value="-Dbuild.profile=${build.profile}" />
 				</gradle-execute>
 
-				<gradle-execute dir="${project.dir}/modules" task="deployGlowroot">
-					<arg value="--parallel" />
-					<arg value="-Dbuild.exclude.dirs=${build.exclude.dirs}" />
-					<arg value="-Dbuild.include.dirs=${build.include.dirs}" />
-					<arg value="-Dbuild.profile=${build.profile}" />
-				</gradle-execute>
-
 				<pathconvert property="build.app.server.lib.marker.files" setonempty="false">
 					<fileset
 						dir="${project.dir}/modules"

--- a/build.xml
+++ b/build.xml
@@ -449,6 +449,13 @@ message.
 					<arg value="-Dbuild.profile=${build.profile}" />
 				</gradle-execute>
 
+				<gradle-execute dir="${project.dir}/modules" task="deployGlowroot">
+					<arg value="--parallel" />
+					<arg value="-Dbuild.exclude.dirs=${build.exclude.dirs}" />
+					<arg value="-Dbuild.include.dirs=${build.include.dirs}" />
+					<arg value="-Dbuild.profile=${build.profile}" />
+				</gradle-execute>
+
 				<pathconvert property="build.app.server.lib.marker.files" setonempty="false">
 					<fileset
 						dir="${project.dir}/modules"

--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/utils/evaluation.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/utils/evaluation.es.js
@@ -153,6 +153,10 @@ const doEvaluate = debounce((fieldName, evaluatorContext, callback) => {
 		url: EVALUATOR_URL,
 	})
 		.then((newPages) => {
+			if (newPages.statusCode) {
+				callback(newPages);
+			}
+
 			const mergedPages = mergePages(
 				defaultLanguageId,
 				editingLanguageId,

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/java/com/liferay/dynamic/data/mapping/form/renderer/internal/servlet/DDMFormContextProviderServlet.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/java/com/liferay/dynamic/data/mapping/form/renderer/internal/servlet/DDMFormContextProviderServlet.java
@@ -22,12 +22,14 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.servlet.ServletResponseUtil;
+import com.liferay.portal.kernel.upload.UploadException;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.HtmlParser;
 import com.liferay.portal.kernel.util.LocaleThreadLocal;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.util.PropsValues;
 
 import java.io.IOException;
@@ -62,6 +64,23 @@ public class DDMFormContextProviderServlet extends HttpServlet {
 			HttpServletRequest httpServletRequest,
 			HttpServletResponse httpServletResponse)
 		throws IOException, ServletException {
+
+		UploadException uploadException =
+			(UploadException)httpServletRequest.getAttribute(
+				WebKeys.UPLOAD_EXCEPTION);
+
+		if ((uploadException != null) &&
+			(uploadException.isExceededFileSizeLimit() ||
+			 uploadException.isExceededLiferayFileItemSizeLimit() ||
+			 uploadException.isExceededUploadRequestSizeLimit())) {
+
+			httpServletResponse.sendError(
+				HttpServletResponse.SC_REQUEST_ENTITY_TOO_LARGE,
+				_language.get(
+					httpServletRequest, "upload-size-limit-has-been-exceeded"));
+
+			return;
+		}
 
 		createContext(httpServletRequest, httpServletResponse);
 

--- a/modules/apps/glowroot/glowroot-plugin-freemarker/bnd.bnd
+++ b/modules/apps/glowroot/glowroot-plugin-freemarker/bnd.bnd
@@ -1,3 +1,3 @@
 Bundle-Name: Liferay Glowroot Plugin FreeMarker
 Bundle-SymbolicName: com.liferay.glowroot.plugin.freemarker
-Bundle-Version: 1.0.2
+Bundle-Version: 1.0.3

--- a/modules/apps/glowroot/glowroot-plugin-freemarker/build.gradle
+++ b/modules/apps/glowroot/glowroot-plugin-freemarker/build.gradle
@@ -1,4 +1,14 @@
+task deployGlowroot
+
 dependencies {
 	compileInclude group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileInclude group: "org.glowroot", name: "glowroot-agent-plugin-api", version: "0.13.6"
+}
+
+deployGlowroot {
+	finalizedBy deploy
+}
+
+liferay {
+	deployDir = file("${liferayHome}/glowroot/plugins")
 }

--- a/modules/apps/glowroot/glowroot-plugin-freemarker/build.gradle
+++ b/modules/apps/glowroot/glowroot-plugin-freemarker/build.gradle
@@ -2,7 +2,3 @@ dependencies {
 	compileInclude group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileInclude group: "org.glowroot", name: "glowroot-agent-plugin-api", version: "0.13.6"
 }
-
-liferay {
-	deployDir = file("${liferayHome}/glowroot/plugins")
-}

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
@@ -139,12 +139,12 @@ export default function _JournalPortlet({
 		}
 	};
 
-	const handleDDMFormError = (error) => {
+	const handleDDMFormError = ({error}) => {
 		publishingLock.unlock();
 		console.error(error);
 
-		if (error.error?.statusCode) {
-			showAlert(error.error.message);
+		if (error.statusCode) {
+			showAlert(error.message);
 		}
 
 		const workflowActionInput = document.getElementById(

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
@@ -143,6 +143,10 @@ export default function _JournalPortlet({
 		publishingLock.unlock();
 		console.error(error);
 
+		if (error.error?.statusCode) {
+			showAlert(error.error.message);
+		}
+
 		const workflowActionInput = document.getElementById(
 			`${namespace}workflowAction`
 		);

--- a/modules/apps/object/object-test/src/testFunctional/macros/ObjectModelBuilder.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/ObjectModelBuilder.macro
@@ -1,0 +1,33 @@
+definition {
+
+	macro openObjectFolderInModelBuilder {
+		if (!(isSet(objectFolderName))) {
+			var objectFolderName = "Uncategorized";
+		}
+
+		Navigator.openWithAppendToBaseURL(
+			baseURL = ${baseURL},
+			urlAppend = "group/control_panel/manage?p_p_id=com_liferay_object_web_internal_object_definitions_portlet_ObjectDefinitionsPortlet&p_p_lifecycle=0&p_p_state=maximized&p_p_mode=view&p_p_auth=dShgR6Fp&_com_liferay_object_web_internal_object_definitions_portlet_ObjectDefinitionsPortlet_mvcRenderCommandName=%2Fobject_definitions%2Fview_model_builder&objectFolderName=${objectFolderName}");
+	}
+
+	macro publishObjectDefinitions {
+		Button.clickPublish();
+
+		for (var objectDefinitionName : list ${objectDefinitionsList}) {
+			Check.checkNotVisible(
+				locator1 = "ObjectModelBuilder#CONFIRM_PUBLISHING_OBJECT_DEFINITION_INPUT",
+				objectDefinition = ${objectDefinitionName});
+		}
+
+		Click(
+			key_text = "Publish Objects",
+			locator1 = "Modal#MODAL_FOOTER_BUTTON");
+
+		WaitForElementPresent(
+			locator1 = "Icon#ANY",
+			value1 = "check");
+
+		Click(locator1 = "Modal#CLOSE_BUTTON");
+	}
+
+}

--- a/modules/apps/object/object-test/src/testFunctional/paths/ObjectAdmin.path
+++ b/modules/apps/object/object-test/src/testFunctional/paths/ObjectAdmin.path
@@ -411,6 +411,11 @@
 		<td></td>
 	</tr>
 	<tr>
+		<td>FOLDER_LABEL</td>
+		<td>//span[contains(@class,'view-object-definitions-title') and contains(text(),'${folderLabel}')]</td>
+		<td></td>
+	</tr>
+	<tr>
 		<td>VIEW_OBJECT_FIELD_LABEL</td>
 		<td>//div[(@class = 'dnd-td') and contains (.,'${key_fieldLabel}')]</td>
 		<td></td>

--- a/modules/apps/object/object-test/src/testFunctional/paths/ObjectModelBuilder.path
+++ b/modules/apps/object/object-test/src/testFunctional/paths/ObjectModelBuilder.path
@@ -1,0 +1,26 @@
+<html>
+<head>
+<title>ObjectModelBuilder</title>
+</head>
+
+<body>
+<table border="1" cellpadding="1" cellspacing="1">
+<thead>
+<tr><td rowspan="1" colspan="3">ObjectModelBuilder</td></tr>
+</thead>
+
+<tbody>
+	<tr>
+		<td>CONFIRM_PUBLISHING_OBJECT_DEFINITION_INPUT</td>
+		<td>//*[contains(@class,'list-group-item') and contains(.,'${objectDefinition}')] //input</td>
+		<td></td>
+	</tr>
+	<tr>
+		<td>OBJECT_CARD_LABEL</td>
+		<td>//*[contains(@class,'objectDefinitionNode')][contains(.,'${objectDefinition}')] //*[contains(@class,'label-item')][normalize-space(text())='${labelText}']</td>
+		<td></td>
+	</tr>
+</tbody>
+</table>
+</body>
+</html>

--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectExportImport.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectExportImport.testcase
@@ -489,6 +489,7 @@ definition {
 	@description = "LPS-142175 - Verify if it is possible to import the data structure to a custom objects"
 	@priority = 5
 	test CanImportDataStructure {
+		property custom.properties = "feature.flag.LPS-148856=true";
 		property portal.acceptance = "true";
 
 		ObjectExportImport.importObject(

--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectExportImport.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectExportImport.testcase
@@ -496,6 +496,10 @@ definition {
 			objectName = "ImportedSimpleObject146358");
 
 		AssertElementPresent(
+			folderLabel = "Uncategorized",
+			locator1 = "ObjectAdmin#FOLDER_LABEL");
+
+		AssertElementPresent(
 			key_labelName = "Imported Simple Object",
 			locator1 = "CreateObject#OBJECT_NAME");
 	}

--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectModelBuilder.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectModelBuilder.testcase
@@ -1,0 +1,72 @@
+@component-name = "portal-object"
+definition {
+
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.main.component.name = "Object";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginPG();
+	}
+
+	tearDown {
+		ObjectAdmin.deleteAllCustomObjectsViaAPI();
+
+		var testLiferayVirtualInstance = PropsUtil.get("test.liferay.virtual.instance");
+
+		if (${testLiferayVirtualInstance} == "true") {
+			PortalInstances.tearDownCP();
+		}
+	}
+
+	@description = "LPS-148856 - Verify multiple custom object definitions can be published"
+	@priority = 5
+	test CanPublishMultipleObjectDefinitions {
+		task ("Given three custom object definitions that contains long text fields") {
+			for (var letter : list "A,B,C") {
+				ObjectAdmin.addObjectViaAPI(
+					labelName = "Custom Object 197932 ${letter}",
+					objectName = "CustomObject197932${letter}",
+					pluralLabelName = "Custom Objects 197932 ${letter}");
+
+				ObjectAdmin.addObjectFieldViaAPI(
+					fieldBusinessType = "LongText",
+					fieldLabelName = "Custom Field",
+					fieldName = "customObjectField",
+					fieldType = "Clob",
+					isRequired = "false",
+					objectName = "CustomObject197932${letter}");
+			}
+		}
+
+		task ("and Given the user is in the model builder view") {
+			ObjectAdmin.openObjectAdmin();
+
+			ObjectModelBuilder.openObjectFolderInModelBuilder();
+		}
+
+		task ("When the user publishes two custom object definitions") {
+			ObjectModelBuilder.publishObjectDefinitions(objectDefinitionsList = "Custom Object 197932 A,Custom Object 197932 B");
+		}
+
+		task ("Then two object definitions are published and one remains in draft status") {
+			AssertVisible(
+				labelText = "approved",
+				locator1 = "ObjectModelBuilder#OBJECT_CARD_LABEL",
+				objectDefinition = "Custom Object 197932 A");
+
+			AssertVisible(
+				labelText = "approved",
+				locator1 = "ObjectModelBuilder#OBJECT_CARD_LABEL",
+				objectDefinition = "Custom Object 197932 B");
+
+			AssertVisible(
+				labelText = "draft",
+				locator1 = "ObjectModelBuilder#OBJECT_CARD_LABEL",
+				objectDefinition = "Custom Object 197932 C");
+		}
+	}
+
+}

--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectPartialValidation.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectPartialValidation.testcase
@@ -1,0 +1,95 @@
+@component-name = "portal-object"
+definition {
+
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.main.component.name = "Object";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginPG();
+	}
+
+	tearDown {
+		ObjectAdmin.deleteAllCustomObjectsViaAPI();
+
+		var testLiferayVirtualInstance = PropsUtil.get("test.liferay.virtual.instance");
+
+		if (${testLiferayVirtualInstance} == "true") {
+			PortalInstances.tearDownCP();
+		}
+	}
+
+	@description = "LPS-182586 - Verify an error message is seen for an invalid field in an object entry if the validation is set to partial validation"
+	@priority = 5
+	test CanValidateField {
+		property custom.properties = "feature.flag.LPS-187846=true";
+
+		task ("Given an custom object definition and a precision decimal field") {
+			ObjectAdmin.addObjectViaAPI(
+				labelName = "Custom Object 192638",
+				objectName = "CustomObject192638",
+				pluralLabelName = "Custom Objects 192638");
+
+			ObjectAdmin.addObjectFieldViaAPI(
+				fieldBusinessType = "PrecisionDecimal",
+				fieldLabelName = "Custom Field",
+				fieldName = "customField",
+				fieldType = "BigDecimal",
+				isRequired = "false",
+				objectName = "CustomObject192638");
+
+			ObjectAdmin.publishObjectViaAPI(objectName = "CustomObject192638");
+		}
+
+		task ("and Given an expression builder validation set to partial validation with the precision decimal field") {
+			ObjectAdmin.openObjectAdmin();
+
+			ObjectPortlet.selectCustomObject(label = "Custom Object 192638");
+
+			ObjectAdmin.goToValidationsTab();
+
+			ObjectCustomValidation.addObjectValidation(
+				validationName = "Custom Validation",
+				validationType = "Expression Builder");
+
+			ObjectCustomValidation.gotoCustomValidation(validationName = "Custom Validation");
+
+			ObjectCustomValidation.activeValidation();
+
+			ObjectCustomValidation.gotoTab(tabName = "Conditions");
+
+			ObjectCustomValidation.insertScriptOnValidation(scriptValidation = "NOT(contains(customField, 123))");
+
+			ObjectCustomValidation.addErrorMessage(errorMessage = "This entry is not possible.");
+
+			Click.clickNoWaitForVisible(
+				key_optionSelected = "partialValidation",
+				locator1 = "FormFields#OPTION_SELECTED");
+
+			Click(locator1 = "ObjectCustomViews#SELECT_AUTO_COMPLETE");
+
+			Click(
+				key_columnOption = "Custom Field",
+				locator1 = "ObjectCustomViews#SELECT_AUTO_COMPLETE_OPTION");
+
+			PortletEntry.save();
+		}
+
+		task ("When the user attempts to create an invalid object entry") {
+			ObjectAdmin.goToCustomObject(objectName = "CustomObject192638");
+
+			ObjectPortlet.addSingleFieldEntryViaUI(entry = 123);
+		}
+
+		task ("Then an error message is seen and the object entry isn't added") {
+			Alert.viewErrorMessage(errorMessage = "Error:This entry is not possible.");
+
+			ObjectAdmin.goToCustomObject(objectName = "CustomObject192638");
+
+			ObjectPortlet.assertEntryNotPresent(entry = 123);
+		}
+	}
+
+}

--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectWorkflow.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectWorkflow.testcase
@@ -125,4 +125,102 @@ definition {
 			locator1 = "ObjectAdmin#VIEW_FIELD_VALUE_DISABLED");
 	}
 
+	@description = "LPS-181663 - Verify when a user creates an object entry and saves it as a draft, the workflow related to that object definition is not triggered"
+	@priority = 4
+	test CheckWorkflowNotTriggeredForDraftEntry {
+		property custom.properties = "feature.flag.LPS-181663=true";
+
+		task ("Given a custom object definition scoped by site") {
+			ObjectAdmin.addObjectViaAPI(
+				labelName = "Custom Object 197509",
+				objectName = "CustomObject197509",
+				panelCategoryKey = "site_administration.content",
+				pluralLabelName = "Custom Objects 197509",
+				scope = "site");
+
+			ObjectAdmin.addObjectFieldViaAPI(
+				fieldBusinessType = "Text",
+				fieldLabelName = "Text Field",
+				fieldName = "textField",
+				fieldType = "String",
+				isRequired = "false",
+				objectName = "CustomObject197509");
+		}
+
+		task ("and Given the 'Allow users to save entries as draft' configuration is activated") {
+			ObjectAdmin.openObjectAdmin();
+
+			ObjectPortlet.selectCustomObject(label = "Custom Object 197509");
+
+			Check.checkToggleSwitch(
+				key_toggleSwitchLabel = "Allow Users to Save Entries as Draft",
+				locator1 = "ToggleSwitch#ANY_TOGGLE_SWITCH");
+
+			PortletEntry.publish();
+		}
+
+		task ("and Given a mapped form fontainer on a content page") {
+			JSONLayout.addPublicLayout(
+				groupName = "Guest",
+				layoutName = "Object Page",
+				type = "content");
+
+			ContentPagesNavigator.openEditContentPage(
+				pageName = "Object Page",
+				siteName = "Guest");
+
+			PageEditor.addFragment(
+				collectionName = "Form Components",
+				fragmentName = "Form Container");
+
+			PageEditor.mapFormContainerToObject(contentType = "Custom Object 197509");
+
+			Click.javaScriptClick(
+				index = 1,
+				key_fragmentName = "Submit Button",
+				locator1 = "Fragment#FRAGMENT_LABEL");
+
+			Select(
+				key_fieldLabel = "Submitted Entry Status",
+				locator1 = "Select#GENERIC_SELECT_FIELD",
+				value1 = "Draft");
+
+			PageEditor.publish();
+		}
+
+		task ("and Given a workflow is set for that object definition") {
+			Workflow.openWorkflowProcessBuilderConfiguration();
+
+			Workflow.configureWorkflow(
+				workflowDefinition = "Single Approver",
+				workflowResourceValue = "Custom Object 197509");
+		}
+
+		task ("When the user adds an object entry") {
+			ContentPagesNavigator.openViewContentPage(
+				pageName = "Object Page",
+				siteName = "Guest");
+
+			Type.sendKeys(
+				key_text = "Text Field",
+				locator1 = "TextInput#ANY",
+				value1 = "Draft entry");
+
+			AssertClick(
+				locator1 = "Button#MAIN_CONTENT_SUBMIT",
+				value1 = "Submit");
+		}
+
+		task ("Then the status of object entry is draft") {
+			ProductMenu.gotoPortlet(
+				category = "Content & Data",
+				portlet = "Custom Objects 197509");
+
+			AssertElementPresent(
+				key_entry = "Draft entry",
+				key_status = "Draft",
+				locator1 = "ObjectPortlet#ENTRY_STATUS");
+		}
+	}
+
 }

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/LeftSidebar/LeftSidebar.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/LeftSidebar/LeftSidebar.tsx
@@ -55,10 +55,14 @@ export default function LeftSidebar({setShowModal}: LeftSidebarProps) {
 			};
 		});
 
-		setExpandedKeys(new Set(keys));
+		const selectedObjectFolderKey = keys.find(
+			(key) => key === selectedObjectFolder.name
+		) as string;
+
+		setExpandedKeys(new Set([selectedObjectFolderKey]));
 
 		return newLeftSidebarItems;
-	}, [leftSidebarItems, query]);
+	}, [leftSidebarItems, query, selectedObjectFolder]);
 
 	const leftSidebarOtherObjectFoldersItems = filteredLeftSidebarItems.filter(
 		(filteredLeftSidebarItem) =>

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -19646,6 +19646,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes.
 upload-resume=Upload Resume
 upload-servlet-request-configuration-name=Upload Servlet Request
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded.
 upload-thumbnail=Upload Thumbnail
 upload-x=Upload {0}
 upload-your-talend-job-file=Upload your Talend job file.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=تحميل أو تحدي
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=وصل طلب التحميل إلى الحد الأقصى المسموح به لحجم {0} بايت.
 upload-resume=تحميل السيرة الذاتية
 upload-servlet-request-configuration-name=تحميل طلب Servlet
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=تحميل صورة مصغرة
 upload-x=تحميل {0}
 upload-your-talend-job-file=قم بتحميل ملف مهمة Talend الخاص بك.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes. (Automatic Copy)
 upload-resume=Подновяване на качването
 upload-servlet-request-configuration-name=Заявка за качване на услуга (Automatic Translation)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Качване на миниатюра (Automatic Translation)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Качете файла с вашата работа на Таландд. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
@@ -19642,6 +19642,7 @@ upload-or-select-from-documents-and-media-item-selector=Pugeu o seleccioneu des 
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=La sol·licitud de càrrega ha assolit la mida màxima permesa de {0} bytes.
 upload-resume=Puja el curriculum vitae
 upload-servlet-request-configuration-name=Sol·licitud del servlet de càrrega
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Penja la miniatura
 upload-x=Carrega {0}
 upload-your-talend-job-file=Pugeu el vostre fitxer de treball Talend.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes. (Automatic Copy)
 upload-resume=Pokračovat v nahrávání.
 upload-servlet-request-configuration-name=Upload Servlet Request (Automatic Copy)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Upload Thumbnail (Automatic Copy)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Upload your Talend job file. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes. (Automatic Copy)
 upload-resume=Overfør resume
 upload-servlet-request-configuration-name=Overfør Servlet-anmodning (Automatic Translation)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Miniaturebillede af overførsel (Automatic Translation)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Overfør din Talend-jobfil. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
@@ -19642,6 +19642,7 @@ upload-or-select-from-documents-and-media-item-selector=Hochladen oder Auswähle
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload-Anfrage hat die maximal zulässige Größe von {0} Bytes erreicht.
 upload-resume=Upload fortsetzen
 upload-servlet-request-configuration-name=Servlet Upload-Request
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Thumbnail hochladen
 upload-x={0} hochladen
 upload-your-talend-job-file=Laden Sie Ihre Talend-Job-Datei hoch.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes. (Automatic Copy)
 upload-resume=Ανέβασμα βιογραφικού
 upload-servlet-request-configuration-name=Αποστολή αιτήματος σερβλετών (Automatic Translation)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Αποστολή μικρογραφίας (Automatic Translation)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Ανεβάστε το αρχείο εργασίας talend. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
@@ -19646,6 +19646,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes.
 upload-resume=Upload Resume
 upload-servlet-request-configuration-name=Upload Servlet Request
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded.
 upload-thumbnail=Upload Thumbnail
 upload-x=Upload {0}
 upload-your-talend-job-file=Upload your Talend job file.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes.
 upload-resume=Upload Resume (Automatic Copy)
 upload-servlet-request-configuration-name=Upload Servlet Request (Automatic Copy)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Upload Thumbnail (Automatic Copy)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Upload your Talend job file. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes.
 upload-resume=Upload Resume (Automatic Copy)
 upload-servlet-request-configuration-name=Upload Servlet Request (Automatic Copy)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Upload Thumbnail (Automatic Copy)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Upload your Talend job file. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
@@ -19642,6 +19642,7 @@ upload-or-select-from-documents-and-media-item-selector=Cargue o seleccione arch
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=La solicitud de carga alcanzó el tamaño máximo permitido de {0} bytes.
 upload-resume=Subir curriculum vitae
 upload-servlet-request-configuration-name=Solicitud de carga de servlet
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Cargar miniatura
 upload-x=Cargar {0}
 upload-your-talend-job-file=Cargue un archivo de trabajo de Talend.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_AR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_AR.properties
@@ -19642,6 +19642,7 @@ upload-or-select-from-documents-and-media-item-selector=Cargue o seleccione arch
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=La solicitud de carga alcanzó el tamaño máximo permitido de {0} bytes.
 upload-resume=Subir curriculum vitae
 upload-servlet-request-configuration-name=Solicitud de carga de servlet
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Cargar miniatura
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Cargue un archivo de trabajo de Talend.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
@@ -19642,6 +19642,7 @@ upload-or-select-from-documents-and-media-item-selector=Cargue o seleccione arch
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=La solicitud de carga alcanzó el tamaño máximo permitido de {0} bytes.
 upload-resume=Subir curriculum vitae
 upload-servlet-request-configuration-name=Solicitud de carga de servlet
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Cargar miniatura
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Cargue un archivo de trabajo de Talend.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_MX.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_MX.properties
@@ -19642,6 +19642,7 @@ upload-or-select-from-documents-and-media-item-selector=Cargue o seleccione arch
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=La solicitud de carga alcanzó el tamaño máximo permitido de {0} bytes.
 upload-resume=Subir curriculum vitae
 upload-servlet-request-configuration-name=Solicitud de carga de servlet
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Cargar miniatura
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Cargue un archivo de trabajo de Talend.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes. (Automatic Copy)
 upload-resume=Laadi üles resümee
 upload-servlet-request-configuration-name=Servleti taotluse üleslaadimine (Automatic Translation)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Pisipildi üleslaadimine (Automatic Translation)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Laadige üles oma Talendi tööfail. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes. (Automatic Copy)
 upload-resume=Igo curriculum vitae
 upload-servlet-request-configuration-name=Upload Servlet Request (Automatic Copy)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Upload Thumbnail (Automatic Copy)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Upload your Talend job file. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes. (Automatic Copy)
 upload-resume=بارگذاری رزومه
 upload-servlet-request-configuration-name=آپلود درخواست سرولت (Automatic Translation)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=آپلود بندانگشتی (Automatic Translation)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=فایل شغلی تالند خود را آپلود کنید. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
@@ -19638,6 +19638,7 @@ upload-or-select-from-documents-and-media-item-selector=Lataa tai valitse asiaki
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Latauspyyntö saavutti sallitun enimmäiskoon {0} tavua.
 upload-resume=Lataa ansioluettelo
 upload-servlet-request-configuration-name=Sisääntuonnin Palvelinsovelman Pyyntö
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Lataa Pikkukuva
 upload-x=Lataa {0}
 upload-your-talend-job-file=Lataa Talend-työtiedostosi palvelimeen.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
@@ -19642,6 +19642,7 @@ upload-or-select-from-documents-and-media-item-selector=Téléverser ou sélecti
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=La demande de téléversement a atteint la taille autorisée maximum de {0} octets.
 upload-resume=Reprendre le téléchargement
 upload-servlet-request-configuration-name=Requête servlet de téléversement
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Téléverser une vignette
 upload-x=Téléverser {0}
 upload-your-talend-job-file=Téléchargez votre fichier de job Talend.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=La demande de téléversement a atteint la taille autorisée maximum de {0} octets.
 upload-resume=Reprendre le téléchargement
 upload-servlet-request-configuration-name=Requête servlet de téléversement
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Téléverser une vignette
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Téléchargez votre fichier de job Talend.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes. (Automatic Copy)
 upload-resume=Subir curriculum vitae
 upload-servlet-request-configuration-name=Upload Servlet Request (Automatic Copy)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Upload Thumbnail (Automatic Copy)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Upload your Talend job file. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes. (Automatic Copy)
 upload-resume=अपलोड Resume
 upload-servlet-request-configuration-name=सर्वलेट अनुरोध अपलोड करें (Automatic Translation)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=थंबनेल अपलोड करें (Automatic Translation)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=अपनी टैलेंड जॉब फाइल अपलोड करें। (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes. (Automatic Copy)
 upload-resume=Upload-aj sažetak
 upload-servlet-request-configuration-name=Upload Servlet Request (Automatic Copy)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Upload Thumbnail (Automatic Copy)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Upload your Talend job file. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
@@ -19643,6 +19643,7 @@ upload-or-select-from-documents-and-media-item-selector=Töltse fel, vagy válas
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=A feltöltési kérelem elérte a {0} bájtos maximális megengedett méretet.
 upload-resume=Önéletrajz feltöltése
 upload-servlet-request-configuration-name=Servlet feltöltési kérelem
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Bélyegkép feltöltése
 upload-x={0} feltöltése
 upload-your-talend-job-file=Töltse fel a Talend feladatfájlját.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes. (Automatic Copy)
 upload-resume=Lanjutkan Meng-Upload
 upload-servlet-request-configuration-name=Unggah Permintaan Servlet (Automatic Translation)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Unggah Gambar Mini (Automatic Translation)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Unggah file lowongan Kerja Talend Anda. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
@@ -19641,6 +19641,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes. (Automatic Copy)
 upload-resume=Riprendi Caricamento
 upload-servlet-request-configuration-name=Carica richiesta Servlet (Automatic Translation)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Carica miniatura (Automatic Translation)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Caricare il file di lavoro di Talend. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=בקשת ההעלאה הגיעה לגודל המרבי המותר של {0} בתים.
 upload-resume=המשך העלאה
 upload-servlet-request-configuration-name=העלה בקשת Servlet
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=העלה תמונה ממוזערת (Automatic Translation)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=העלה את קובץ העבודה של טאלנד. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
@@ -19642,6 +19642,7 @@ upload-or-select-from-documents-and-media-item-selector=ドキュメントとメ
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=アップロードリクエストが最大許容サイズに達しました({0} バイト)
 upload-resume=概要の更新
 upload-servlet-request-configuration-name=アップロードサーブレットリクエスト
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=サムネイルをアップロード
 upload-x={0}をアップロード
 upload-your-talend-job-file=Talend ジョブファイルをアップロードしてください。

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes. (Automatic Copy)
 upload-resume=Upload Resume (Automatic Copy)
 upload-servlet-request-configuration-name=Upload Servlet Request (Automatic Copy)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Upload Thumbnail (Automatic Copy)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Upload your Talend job file. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_km.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_km.properties
@@ -19646,6 +19646,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes.
 upload-resume=Upload Resume
 upload-servlet-request-configuration-name=Upload Servlet Request
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Upload Thumbnail
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Upload your Talend job file.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
@@ -19639,6 +19639,7 @@ upload-or-select-from-documents-and-media-item-selector=문서 및 미디어 항
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=업로드 요청이 {0}바이트의 최대 허용 크기에 도달했습니다.
 upload-resume=올려주기 이력서
 upload-servlet-request-configuration-name=서블릿 요청 업로드
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=썸네일 업로드
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Talend 작업 파일을 업로드합니다.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes. (Automatic Copy)
 upload-resume=ອັບໂຫຼດຄືນ
 upload-servlet-request-configuration-name=Upload Servlet Request (Automatic Copy)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Upload Thumbnail (Automatic Copy)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Upload your Talend job file. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes. (Automatic Copy)
 upload-resume=Nusiuntimo tęsimas (Automatic Translation)
 upload-servlet-request-configuration-name=Įkelti servlet užklausą (Automatic Translation)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Įkelti miniatiūrą (Automatic Translation)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Įkelkite savo Talend darbo failą. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes. (Automatic Copy)
 upload-resume=Muat Naik Sambung Semula (Automatic Translation)
 upload-servlet-request-configuration-name=Muat Naik Permintaan Servlet (Automatic Translation)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Muat naik Lakaran Kenit (Automatic Translation)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Muat naik fail kerja Talend anda. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes. (Automatic Copy)
 upload-resume=Gjennoppta opplastning
 upload-servlet-request-configuration-name=Last opp Servlet-forespørsel (Automatic Translation)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Last opp thumbnail
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Last opp talend jobbfilen din. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
@@ -19643,6 +19643,7 @@ upload-or-select-from-documents-and-media-item-selector=Uploaden of selecteren m
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Het uploadverzoek heeft de maximale toegestane grootte van {0} bytes bereikt.
 upload-resume=Samenvatting uploaden
 upload-servlet-request-configuration-name=Uploadverzoek servlet
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Miniatuur uploaden
 upload-x={0} uploaden
 upload-your-talend-job-file=Upload uw Talend-taakbestand.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
@@ -19643,6 +19643,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes. (Automatic Copy)
 upload-resume=Samenvatting uploaden
 upload-servlet-request-configuration-name=Upload Servlet Request (Automatic Copy)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Upload Thumbnail (Automatic Copy)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Upload your Talend job file. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes. (Automatic Copy)
 upload-resume=Załaduj streszczenie
 upload-servlet-request-configuration-name=Przekaż żądanie servlet (Automatic Translation)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Przekaż miniaturę (Automatic Translation)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Prześlij swój plik pracy Talend. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Carregue ou selecione do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=A solicitação de envio alcançou o tamanho máximo permitido de {0} bytes.
 upload-resume=Resumir o upload
 upload-servlet-request-configuration-name=Solicitação de servlet de upload
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Carregar Miniatura
 upload-x=Upload {0}
 upload-your-talend-job-file=Faça o upload de seu arquivo de trabalho Talend.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
@@ -19642,6 +19642,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes. (Automatic Copy)
 upload-resume=Continuar o Upload
 upload-servlet-request-configuration-name=Upload de solicitação de servlet (Automatic Translation)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Carregar miniatura (Automatic Translation)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Faça o upload do seu arquivo de trabalho talend. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes. (Automatic Copy)
 upload-resume=Reia Incarcarea
 upload-servlet-request-configuration-name=Încărcare solicitare Servlet (Automatic Translation)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Încărcare miniatură (Automatic Translation)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Încărcați fișierul de lucru Talend. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes. (Automatic Copy)
 upload-resume=Загрузить резюме
 upload-servlet-request-configuration-name=Загрузить запрос на сервлет (Automatic Translation)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Загрузить Thumbnail (Automatic Translation)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Загрузите файл задания Talend. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes. (Automatic Copy)
 upload-resume=Nahrať resumé
 upload-servlet-request-configuration-name=Nahrať požiadavku na Servlet (Automatic Translation)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Nahrať miniatúru (Automatic Translation)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Nahrajte súbor úlohy Talend. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes. (Automatic Copy)
 upload-resume=Nadaljuj prenos
 upload-servlet-request-configuration-name=Nalaganje zahteve za servlet (Automatic Translation)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Nalaganje sličice (Automatic Translation)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Naložite datoteko projekta Talend. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes. (Automatic Copy)
 upload-resume=Настави Отпремање
 upload-servlet-request-configuration-name=Upload Servlet Request (Automatic Copy)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Upload Thumbnail (Automatic Copy)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Upload your Talend job file. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes. (Automatic Copy)
 upload-resume=Nastavi Otpremanje
 upload-servlet-request-configuration-name=Upload Servlet Request (Automatic Copy)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Upload Thumbnail (Automatic Copy)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Upload your Talend job file. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Ladda upp eller välj fr
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Begäran för överföring har maximalt tillåten storlek på {0} byte.
 upload-resume=Återuppta uppladdning
 upload-servlet-request-configuration-name=Överför servlet-begäran
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Ladda upp miniatyr
 upload-x=Ladda upp {0}
 upload-your-talend-job-file=Ladda upp din Talend-jobbfil.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=பதிவேற்ற கோரிக்கை, அதிகபட்ச அளவான {0} பைட்டுக்களை அடைந்திருக்கிறது.
 upload-resume=Resume பதிவேற்றவும்
 upload-servlet-request-configuration-name=Upload Servlet Request (Automatic Copy)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Upload Thumbnail (Automatic Copy)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Upload your Talend job file. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=อัปโหลดห
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=คำขออัปโหลดถึงขนาดสูงสุดที่อนุญาต {0} ไบต์
 upload-resume=อัพโหลดรีซูเม่
 upload-servlet-request-configuration-name=อัปโหลดคำขอเซิร์ฟเล็ต
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=อัพโหลดธัมเนล
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=อัพโหลดไฟล์งาน Talend ของคุณ

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes. (Automatic Copy)
 upload-resume=Eski Halini Yükle
 upload-servlet-request-configuration-name=Servlet İsteğini Karşıya Yükle (Automatic Translation)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Küçük Resmi Karşıya Yükle (Automatic Translation)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Talend iş dosyanızı yükleyin. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes. (Automatic Copy)
 upload-resume=Завантажити резюме
 upload-servlet-request-configuration-name=Запит на вивантаження серверів (Automatic Translation)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Передати ескіз (Automatic Translation)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Завантажте файл завдання Talend. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes. (Automatic Copy)
 upload-resume=Tiếp tục tải lên
 upload-servlet-request-configuration-name=Tải lên yêu cầu Servlet (Automatic Translation)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Tải lên Hình thu nhỏ (Automatic Translation)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Tải lên tệp công việc Talend của bạn. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
@@ -19642,6 +19642,7 @@ upload-or-select-from-documents-and-media-item-selector=上传或从"文档与�
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=上传请求已达到 {0} 字节的最大允许大小。
 upload-resume=上传履历
 upload-servlet-request-configuration-name=上传Servlet请求
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=上传缩略图
 upload-x=上传{0}
 upload-your-talend-job-file=上传您的 Talend 作业文件。

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
@@ -19641,6 +19641,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=上傳請求已達到 {0} 位元組的最大允許大小。
 upload-resume=恢復上傳
 upload-servlet-request-configuration-name=上傳 Servlet 請求
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=上傳縮圖
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=上船您的 Talend 工作檔案。

--- a/modules/apps/site-initializer/site-initializer-liferay-marketplace/src/main/resources/site-initializer/ddm-templates/solutions-search-results/ddm-template.ftl
+++ b/modules/apps/site-initializer/site-initializer-liferay-marketplace/src/main/resources/site-initializer/ddm-templates/solutions-search-results/ddm-template.ftl
@@ -93,8 +93,7 @@
 						productId = entry.getClassPK() + 1
 						product = restClient.get("/headless-commerce-admin-catalog/v1.0/products/" + productId + "?nestedFields=productSpecifications,attachments")
 						productAttachments = product.attachments![]
-						productCategories = restClient.get("/headless-commerce-admin-catalog/v1.0/products/" + productId + "/categories").items
-						productCategoriesItems = []
+						productCategories=product.categories![]
 						productDescription = stringUtil.shorten(htmlUtil.stripHtml(product.description.en_US!""), 150, "...")
 						productSpecifications = product.productSpecifications![]
 						productURL = portalURL?replace("solutions-marketplace", "p") + "/" + product.urls.en_US
@@ -134,29 +133,25 @@
 							</div>
 
 							<#if productCategories?has_content>
-								<div class="align-center d-flex labels">
-									<#list productCategories as category>
+								<#assign solutionCategories = productCategories?filter(category -> category.vocabulary == 'marketplace solution category') />
 
-										<#if category.vocabulary == 'marketplace solution category'>
-											<div class="border-radius-small category-label font-size-paragraph-small font-weight-semi-bold px-1 rounded">
-												${category.name}
-											</div>
-											<#break>
-										</#if>
+								<div class="align-items-center d-flex labels">
+									<#list solutionCategories as category>
+										<div class="border-radius-small category-label font-size-paragraph-small font-weight-semi-bold px-1 rounded">
+											${category.name}
+										</div>
+										<#break>
 									</#list>
-									<#list productCategories as category>
-										<#if category.vocabulary == 'marketplace solution category'>
-											<#assign productCategoriesItems = productCategoriesItems + [category.name] />
-										</#if>
-									</#list>
+
+									<#assign productCategoriesItems = solutionCategories?map(category -> category.name) />
 
 									<#if (productCategoriesItems?size > 1)>
 										<div class="category-label-remainder pl-2 position-relative text-primary">
 											+${productCategoriesItems?size - 1}
 											<div class="category-names font-size-paragraph-base p-4 position-absolute rounded text-white">
-												<#list productCategories as category>
-													<#if !category?is_first && category.vocabulary == 'marketplace solution category'>
-														${category.name}
+												<#list productCategoriesItems as category>
+													<#if category_index != 0>
+														${category}
 														<#sep>,</#sep>
 													</#if>
 												</#list>

--- a/modules/apps/site-initializer/site-initializer-liferay-marketplace/src/main/resources/site-initializer/ddm-templates/solutions-search-results/ddm-template.ftl
+++ b/modules/apps/site-initializer/site-initializer-liferay-marketplace/src/main/resources/site-initializer/ddm-templates/solutions-search-results/ddm-template.ftl
@@ -45,7 +45,7 @@
 		display: block;
 	}
 
-	.developer-name {
+	solution-search-results-card .card-image-title-container .developer-name {
 		color: #545d69;
 	}
 
@@ -53,8 +53,10 @@
 		color: #545d69;
 	}
 
-	.solution-search-image {
+	.adt-solutions-search-results .solution-search-results-card .solution-search-image {
+		height: 180px;
 		object-fit: cover;
+		width: 329px;
 	}
 
 	@media screen and (max-width: 599px) {
@@ -102,7 +104,6 @@
 					<a class="solution-search-results-card bg-white border-radius-medium d-flex flex-column mb-0 rounded text-dark text-decoration-none" href=${productURL}>
 						<div class="align-items-center d-flex image-container justify-content-center mb-3">
 							<img
-								width="329" height="180"
 								alt=${product.name.en_US}
 								class="solution-search-image rounded"
 								src="${product.thumbnail}"

--- a/modules/apps/site-initializer/site-initializer-liferay-marketplace/src/main/resources/site-initializer/ddm-templates/solutions-search-results/ddm-template.ftl
+++ b/modules/apps/site-initializer/site-initializer-liferay-marketplace/src/main/resources/site-initializer/ddm-templates/solutions-search-results/ddm-template.ftl
@@ -45,8 +45,16 @@
 		display: block;
 	}
 
+	.developer-name {
+		color: #545d69;
+	}
+
 	.productSpec {
 		color: #545d69;
+	}
+
+	.solution-search-image {
+		object-fit: cover;
 	}
 
 	@media screen and (max-width: 599px) {
@@ -57,7 +65,7 @@
 		}
 	}
 
-	@media screen and (min-width:600px) and (max-width: 899px) {
+	@media screen and (min-width: 600px) and (max-width: 899px) {
 		.adt-solutions-search-results .cards-container {
 			grid-template-columns: repeat(2, minmax(0, 1fr));
 		}
@@ -81,74 +89,82 @@
 			<#list entries as entry>
 				<#if entry?has_content>
 					<#assign
-						portalURL=portalUtil.getLayoutURL(themeDisplay)
-						productId=entry.getClassPK() + 1
-						product=restClient.get("/headless-commerce-admin-catalog/v1.0/products/" + productId + "?nestedFields=productSpecifications,attachments" )
-						productAttachments=product.attachments![]
-						productCategories=product.categories![]
-						productDescription=stringUtil.shorten(htmlUtil.stripHtml(product.description.en_US!""), 150, "..." )
-						productSpecifications=product.productSpecifications![]
-						productURL=portalURL?replace("solutions-marketplace", "p" ) + "/" + product.urls.en_US />
+						portalURL = portalUtil.getLayoutURL(themeDisplay)
+						productId = entry.getClassPK() + 1
+						product = restClient.get("/headless-commerce-admin-catalog/v1.0/products/" + productId + "?nestedFields=productSpecifications,attachments")
+						productAttachments = product.attachments![]
+						productCategories = restClient.get("/headless-commerce-admin-catalog/v1.0/products/" + productId + "/categories").items
+						productCategoriesItems = []
+						productDescription = stringUtil.shorten(htmlUtil.stripHtml(product.description.en_US!""), 150, "...")
+						productSpecifications = product.productSpecifications![]
+						productURL = portalURL?replace("solutions-marketplace", "p") + "/" + product.urls.en_US
+					/>
 
 					<a class="solution-search-results-card bg-white border-radius-medium d-flex flex-column mb-0 rounded text-dark text-decoration-none" href=${productURL}>
-						<div class="align-items-center d-flex image-container justify-content-center">
+						<div class="align-items-center d-flex image-container justify-content-center mb-3">
 							<img
+								width="329" height="180"
 								alt=${product.name.en_US}
-								class="h-100 mw-100 rounded"
-								src="${product.thumbnail}" />
+								class="solution-search-image rounded"
+								src="${product.thumbnail}"
+							/>
 						</div>
 
-						<div class="align-items-center card-image-title-container d-flex pb-3">
+						<div class="align-items-center card-image-title-container d-flex">
 							<div class="pl-2">
-								<div class="font-weight-semi-bold h2 mt-1">
-									${product.name.en_US}
-								</div>
-
 								<#if productSpecifications?has_content>
 									<#assign productPriceModels = productSpecifications?filter(item -> item.specificationKey == "developer-name") />
 
 									<#list productPriceModels as productPriceModel>
-										<div class="color-neutral-3 font-size-paragraph-small mt-1">
+										<div class="developer-name font-size-paragraph-small">
 											${productPriceModel.value.en_US}
 										</div>
 									</#list>
 								</#if>
+
+								<div class="font-weight-semi-bold h2 mt-1">
+									${product.name.en_US}
+								</div>
 							</div>
 						</div>
 
 						<div class="d-flex flex-column font-size-paragraph-small h-100 justify-content-between p-2">
-							<div>
-								<div class="font-weight-normal mb-2">
-									${productDescription}
-								</div>
-
-								<#if productCategories?has_content>
-									<div class="align-center d-flex labels">
-										<#list productCategories as category>
-											<#if category.vocabulary=='marketplace solution category'>
-												<div class="border-radius-small category-label font-size-paragraph-small font-weight-semi-bold px-1">
-													${category.name}
-												</div>
-												<#break>
-											</#if>
-										</#list>
-
-										<#if (productCategories?size > 1)>
-											<div class="category-label-remainder pl-2 position-relative text-primary">
-												+${productCategories?size - 1}
-												<div class="category-names font-size-paragraph-base p-4 position-absolute rounded text-white">
-													<#list productCategories as category>
-														<#if !category?is_first && category.vocabulary == 'marketplace solution category'>
-															${category.name}
-															<#sep>, </#sep>
-														</#if>
-													</#list>
-												</div>
-											</div>
-										</#if>
-									</div>
-								</#if>
+							<div class="font-weight-normal mb-2">
+								${productDescription}
 							</div>
+
+							<#if productCategories?has_content>
+								<div class="align-center d-flex labels">
+									<#list productCategories as category>
+
+										<#if category.vocabulary == 'marketplace solution category'>
+											<div class="border-radius-small category-label font-size-paragraph-small font-weight-semi-bold px-1 rounded">
+												${category.name}
+											</div>
+											<#break>
+										</#if>
+									</#list>
+									<#list productCategories as category>
+										<#if category.vocabulary == 'marketplace solution category'>
+											<#assign productCategoriesItems = productCategoriesItems + [category.name] />
+										</#if>
+									</#list>
+
+									<#if (productCategoriesItems?size > 1)>
+										<div class="category-label-remainder pl-2 position-relative text-primary">
+											+${productCategoriesItems?size - 1}
+											<div class="category-names font-size-paragraph-base p-4 position-absolute rounded text-white">
+												<#list productCategories as category>
+													<#if !category?is_first && category.vocabulary == 'marketplace solution category'>
+														${category.name}
+														<#sep>,</#sep>
+													</#if>
+												</#list>
+											</div>
+										</div>
+									</#if>
+								</div>
+							</#if>
 						</div>
 					</a>
 				</#if>

--- a/modules/apps/site-initializer/site-initializer-liferay-marketplace/src/main/resources/site-initializer/ddm-templates/solutions-search-results/ddm-template.ftl
+++ b/modules/apps/site-initializer/site-initializer-liferay-marketplace/src/main/resources/site-initializer/ddm-templates/solutions-search-results/ddm-template.ftl
@@ -98,15 +98,32 @@
 						productCategories=product.categories![]
 						productDescription = stringUtil.shorten(htmlUtil.stripHtml(product.description.en_US!""), 150, "...")
 						productSpecifications = product.productSpecifications![]
-						productURL = portalURL?replace("solutions-marketplace", "p") + "/" + product.urls.en_US
 					/>
+
+					<#if product.name.en_US?has_content>
+						<#assign productName = product.name.en_US />
+					<#else>
+						<#assign productName = "" />
+					</#if>
+
+					<#if product.thumbnail?has_content>
+						<#assign productThumbnail = product.thumbnail />
+					<#else>
+						<#assign productThumbnail = "" />
+					</#if>
+
+					<#if product.urls.en_US?has_content>
+						<#assign productURL = portalURL?replace("solutions-marketplace", "p") + "/" + product.urls.en_US />
+					<#else>
+						<#assign productURL = "" />
+					</#if>
 
 					<a class="solution-search-results-card bg-white border-radius-medium d-flex flex-column mb-0 rounded text-dark text-decoration-none" href=${productURL}>
 						<div class="align-items-center d-flex image-container justify-content-center mb-3">
 							<img
-								alt=${product.name.en_US}
+								alt=${productName}
 								class="solution-search-image rounded"
-								src="${product.thumbnail}"
+								src="${productThumbnail}"
 							/>
 						</div>
 
@@ -123,7 +140,7 @@
 								</#if>
 
 								<div class="font-weight-semi-bold h2 mt-1">
-									${product.name.en_US}
+									${productName}
 								</div>
 							</div>
 						</div>

--- a/modules/apps/site-initializer/site-initializer-liferay-marketplace/src/main/resources/site-initializer/layouts/03_solutions_marketplace/page-definition.json
+++ b/modules/apps/site-initializer/site-initializer-liferay-marketplace/src/main/resources/site-initializer/layouts/03_solutions_marketplace/page-definition.json
@@ -78,14 +78,8 @@
 							],
 							"indexed": true,
 							"layout": {
-								"borderWidth": 0,
-								"marginTop": 0,
-								"opacity": 100,
 								"paddingBottom": 6,
-								"paddingLeft": 0,
-								"paddingRight": 0,
-								"paddingTop": 6,
-								"widthType": "Fluid"
+								"paddingTop": 6
 							}
 						},
 						"pageElements": [
@@ -132,10 +126,6 @@
 									],
 									"indexed": true,
 									"layout": {
-										"borderWidth": 0,
-										"opacity": 100,
-										"paddingLeft": 0,
-										"paddingRight": 0,
 										"widthType": "Fixed"
 									}
 								},
@@ -211,20 +201,23 @@
 															"id": "tablet"
 														}
 													],
-													"size": 5
+													"size": 8
 												},
 												"pageElements": [
 													{
 														"definition": {
 															"fragment": {
-																"key": "BASIC_COMPONENT-heading"
+																"key": "text",
+																"siteKey": "[$GROUP_KEY$]"
 															},
 															"fragmentConfig": {
-																"headingLevel": "h1"
+																"fontSize": "font-size-paragraph-base",
+																"smallCaps": false,
+																"tabletScreenCenter": false
 															},
 															"fragmentFields": [
 																{
-																	"id": "element-text",
+																	"id": "text",
 																	"value": {
 																		"fragmentLink": {
 																		},
@@ -237,6 +230,9 @@
 																}
 															],
 															"fragmentStyle": {
+																"fontFamily": "system-ui, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, Oxygen-Sans, Ubuntu, Cantarell, \"Helvetica Neue\", Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Segoe UI Symbol\"",
+																"fontSize": "49px",
+																"fontWeight": "600",
 																"textColor": "whiteColor"
 															},
 															"indexed": true
@@ -265,6 +261,7 @@
 																}
 															],
 															"fragmentStyle": {
+																"fontSize": "26px",
 																"textColor": "whiteColor"
 															},
 															"indexed": true
@@ -294,7 +291,7 @@
 															"id": "tablet"
 														}
 													],
-													"size": 7
+													"size": 4
 												},
 												"type": "Column"
 											}
@@ -473,16 +470,6 @@
 							},
 							"indexed": true,
 							"layout": {
-								"borderWidth": 0,
-								"marginBottom": 0,
-								"marginLeft": 0,
-								"marginRight": 0,
-								"marginTop": 0,
-								"opacity": 100,
-								"paddingBottom": 0,
-								"paddingLeft": 0,
-								"paddingRight": 0,
-								"paddingTop": 0,
 								"widthType": "Fixed"
 							}
 						},

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/model/LCPProject.java
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/model/LCPProject.java
@@ -111,9 +111,7 @@ public class LCPProject {
 		SA("ac-southamericaeast1", "southamerica-east1-ac1-c1"),
 		UAT("ac-asahuat", "us-west1-ac-uat-c1"),
 		US("ac-uswest1", "us-west1-ac4-c1"),
-		US_LRDCOM(
-			"ac-uswest1asah652a6babdba143d086a19db542781bc2",
-			"us-west1-ac4-c1-2");
+		US_LRDCOM("ac-uswest1", "us-west1-ac4-c1-2");
 
 		public static Cluster fromString(String value) {
 			if (StringUtil.equals(value, Cluster.AS1._value)) {

--- a/modules/sdk/gradle-plugins-defaults/src/main/java/com/liferay/gradle/plugins/defaults/LiferayOSGiDefaultsPlugin.java
+++ b/modules/sdk/gradle-plugins-defaults/src/main/java/com/liferay/gradle/plugins/defaults/LiferayOSGiDefaultsPlugin.java
@@ -259,6 +259,8 @@ public class LiferayOSGiDefaultsPlugin implements Plugin<Project> {
 
 	public static final String DEPLOY_TOOL_TASK_NAME = "deployTool";
 
+	public static final String DEPLOY_GLOWROOT_TASK_NAME = "deployGlowroot";
+
 	public static final String DOWNLOAD_COMPILED_JSP_TASK_NAME =
 		"downloadCompiledJSP";
 
@@ -335,10 +337,14 @@ public class LiferayOSGiDefaultsPlugin implements Plugin<Project> {
 		final boolean publishing = _isPublishing(project);
 
 		boolean deployToAppServerLibs = false;
+		boolean deployToGlowroot = false;
 		boolean deployToTools = false;
 
 		if (FileUtil.exists(project, ".lfrbuild-app-server-lib")) {
 			deployToAppServerLibs = true;
+		}
+		else if (FileUtil.exists(project, ".lfrbuild-glowroot")) {
+			deployToGlowroot = true;
 		}
 		else if (FileUtil.exists(project, ".lfrbuild-tool")) {
 			deployToTools = true;
@@ -425,6 +431,11 @@ public class LiferayOSGiDefaultsPlugin implements Plugin<Project> {
 				project, DEPLOY_TOOL_TASK_NAME,
 				LiferayBasePlugin.DEPLOY_TASK_NAME);
 		}
+		else if (deployToGlowroot) {
+			_addTaskAlias(
+				project, DEPLOY_GLOWROOT_TASK_NAME,
+				LiferayBasePlugin.DEPLOY_TASK_NAME);
+		}
 
 		final Jar jarJSPsTask = _addTaskJarJSP(project);
 		final Jar jarJavadocTask = _addTaskJarJavadoc(project);
@@ -446,7 +457,8 @@ public class LiferayOSGiDefaultsPlugin implements Plugin<Project> {
 			project, appBndFile, liferayExtension, publishing);
 		_configureDependencyChecker(project);
 		_configureDeployDir(
-			project, liferayExtension, deployToAppServerLibs, deployToTools);
+			project, liferayExtension, deployToAppServerLibs, deployToGlowroot,
+			deployToTools);
 		_configureEclipse(project);
 		_configureJavaPlugin(project);
 		_configureLocalPortalTool(
@@ -2602,7 +2614,8 @@ public class LiferayOSGiDefaultsPlugin implements Plugin<Project> {
 
 	private void _configureDeployDir(
 		final Project project, final LiferayExtension liferayExtension,
-		final boolean deployToAppServerLibs, final boolean deployToTools) {
+		final boolean deployToAppServerLibs, final boolean deployToGlowroot,
+		final boolean deployToTools) {
 
 		liferayExtension.setDeployDir(
 			new Callable<File>() {
@@ -2613,6 +2626,12 @@ public class LiferayOSGiDefaultsPlugin implements Plugin<Project> {
 						return new File(
 							liferayExtension.getAppServerPortalDir(),
 							"WEB-INF/lib");
+					}
+
+					if (deployToGlowroot) {
+						return new File(
+							liferayExtension.getLiferayHome(),
+							"glowroot/" + project.getName());
 					}
 
 					if (deployToTools) {

--- a/modules/sdk/gradle-plugins-defaults/src/main/java/com/liferay/gradle/plugins/defaults/LiferayOSGiDefaultsPlugin.java
+++ b/modules/sdk/gradle-plugins-defaults/src/main/java/com/liferay/gradle/plugins/defaults/LiferayOSGiDefaultsPlugin.java
@@ -2631,7 +2631,7 @@ public class LiferayOSGiDefaultsPlugin implements Plugin<Project> {
 					if (deployToGlowroot) {
 						return new File(
 							liferayExtension.getLiferayHome(),
-							"glowroot/" + project.getName());
+							"glowroot/plugins");
 					}
 
 					if (deployToTools) {

--- a/modules/sdk/gradle-plugins-defaults/src/main/java/com/liferay/gradle/plugins/defaults/LiferayOSGiDefaultsPlugin.java
+++ b/modules/sdk/gradle-plugins-defaults/src/main/java/com/liferay/gradle/plugins/defaults/LiferayOSGiDefaultsPlugin.java
@@ -259,8 +259,6 @@ public class LiferayOSGiDefaultsPlugin implements Plugin<Project> {
 
 	public static final String DEPLOY_TOOL_TASK_NAME = "deployTool";
 
-	public static final String DEPLOY_GLOWROOT_TASK_NAME = "deployGlowroot";
-
 	public static final String DOWNLOAD_COMPILED_JSP_TASK_NAME =
 		"downloadCompiledJSP";
 
@@ -337,14 +335,10 @@ public class LiferayOSGiDefaultsPlugin implements Plugin<Project> {
 		final boolean publishing = _isPublishing(project);
 
 		boolean deployToAppServerLibs = false;
-		boolean deployToGlowroot = false;
 		boolean deployToTools = false;
 
 		if (FileUtil.exists(project, ".lfrbuild-app-server-lib")) {
 			deployToAppServerLibs = true;
-		}
-		else if (FileUtil.exists(project, ".lfrbuild-glowroot")) {
-			deployToGlowroot = true;
 		}
 		else if (FileUtil.exists(project, ".lfrbuild-tool")) {
 			deployToTools = true;
@@ -431,11 +425,6 @@ public class LiferayOSGiDefaultsPlugin implements Plugin<Project> {
 				project, DEPLOY_TOOL_TASK_NAME,
 				LiferayBasePlugin.DEPLOY_TASK_NAME);
 		}
-		else if (deployToGlowroot) {
-			_addTaskAlias(
-				project, DEPLOY_GLOWROOT_TASK_NAME,
-				LiferayBasePlugin.DEPLOY_TASK_NAME);
-		}
 
 		final Jar jarJSPsTask = _addTaskJarJSP(project);
 		final Jar jarJavadocTask = _addTaskJarJavadoc(project);
@@ -457,8 +446,7 @@ public class LiferayOSGiDefaultsPlugin implements Plugin<Project> {
 			project, appBndFile, liferayExtension, publishing);
 		_configureDependencyChecker(project);
 		_configureDeployDir(
-			project, liferayExtension, deployToAppServerLibs, deployToGlowroot,
-			deployToTools);
+			project, liferayExtension, deployToAppServerLibs, deployToTools);
 		_configureEclipse(project);
 		_configureJavaPlugin(project);
 		_configureLocalPortalTool(
@@ -2614,8 +2602,7 @@ public class LiferayOSGiDefaultsPlugin implements Plugin<Project> {
 
 	private void _configureDeployDir(
 		final Project project, final LiferayExtension liferayExtension,
-		final boolean deployToAppServerLibs, final boolean deployToGlowroot,
-		final boolean deployToTools) {
+		final boolean deployToAppServerLibs, final boolean deployToTools) {
 
 		liferayExtension.setDeployDir(
 			new Callable<File>() {
@@ -2626,12 +2613,6 @@ public class LiferayOSGiDefaultsPlugin implements Plugin<Project> {
 						return new File(
 							liferayExtension.getAppServerPortalDir(),
 							"WEB-INF/lib");
-					}
-
-					if (deployToGlowroot) {
-						return new File(
-							liferayExtension.getLiferayHome(),
-							"glowroot/plugins");
 					}
 
 					if (deployToTools) {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/gogoshell/GogoShell.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/gogoshell/GogoShell.testcase
@@ -42,7 +42,7 @@ definition {
 
 		GogoShell.executeCommand(commandName = "system:check");
 
-		for (var outputContent : list "Declarative Service Soft Circular Dependency System Checker check result: No issues were found,Declarative Service Unsatisfied Component Checker check result: No issues were found,Spring Extender Unavailable Component System Checker check result: No issues were found") {
+		for (var outputContent : list "Declarative Service Soft Circular Dependency System Checker check result: No issues were found,Declarative Service Unsatisfied Component System Checker check result: No issues were found,Spring Extender Unavailable Component System Checker check result: No issues were found") {
 			GogoShell.viewOutput(outputContent = ${outputContent});
 		}
 	}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/segmentation/ExperienceCreateExperience.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/segmentation/ExperienceCreateExperience.testcase
@@ -4047,6 +4047,8 @@ definition {
 
 			PageEditor.publish();
 
+			ContentPages.gotoPageEditor();
+
 			PageEditor.addFragment(
 				collectionName = "Layout Elements",
 				fragmentName = "Container");

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/layout/pagetemplate/contentpagetemplate/ContentPageTemplatesUI.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/layout/pagetemplate/contentpagetemplate/ContentPageTemplatesUI.testcase
@@ -125,7 +125,7 @@ definition {
 				key_headerName = "Page Template Collection",
 				locator1 = "Portlet#H2_HEADER_VERTICAL_ELLIPSIS");
 
-			MenuItem.viewOrder(menuItemList = "Edit,Rename,Permissions,Delete");
+			MenuItem.viewOrder(menuItemList = "Edit,Permissions,Delete");
 
 			Click.waitForMenuToggleJSClick(
 				key_headerName = "Page Template Collection",


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

Motivation
=======
If the length of a Journal Article's content exceeds the configured Upload Servlet Request limit (in bytes) the creation of the Article fails but no message is displayed on the UI indicating the cause of the error.
Only a warning is logged to the console which may not be readily visible to the end user.
The root cause of the issue is that the POST request initiated [here](https://github.com/liferay/liferay-portal/blob/6ce0b9eb049e99a50285a324a3bd4afd76d340ab/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/utils/evaluation.es.js#L135-L167) will fail because of the `UploadException` but it is not handled properly on the backend, in the class `DDMFormContextProviderServlet`. 

Proposed Solution
========
Adding logic that processes the exception in `DDMFormContextProviderServlet` and displays the error message on the front end.

Steps to Verify
========
Please see the linked LPS for the reproduction steps.
https://liferay.atlassian.net/browse/LPS-198515

Thank you and best regards,
István