### PR TITLE
[TS] LPS-199877 Change to get local date from calendar with CalendarUtil

### DIFF
--- a/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-web/src/main/java/com/liferay/portal/reports/engine/console/web/internal/admin/portlet/action/GenerateReportMVCActionCommand.java
+++ b/modules/dxp/apps/portal-reports-engine-console/portal-reports-engine-console-web/src/main/java/com/liferay/portal/reports/engine/console/web/internal/admin/portlet/action/GenerateReportMVCActionCommand.java
@@ -14,6 +14,7 @@ import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextFactory;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.CalendarUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -101,7 +102,7 @@ public class GenerateReportMVCActionCommand extends BaseMVCActionCommand {
 				DateFormat dateFormat =
 					DateFormatFactoryUtil.getSimpleDateFormat("yyyy-MM-dd");
 
-				value = dateFormat.format(calendar.getTime());
+				value = dateFormat.format(CalendarUtil.getLTDate(calendar));
 			}
 
 			entryReportParameterJSONObject.put("value", value);


### PR DESCRIPTION
Hi Team,

May I ask if you could review my PR? 

Issue is https://liferay.atlassian.net/browse/LPS-199877, When the account is in a different timezone, than the JVM, the getTime() gives back one day before date, even the timezone is set to a different one.

Solution is to use CalendarUtil.getLTDate() to get back the set date from the timeZone which was set in com/liferay/portal/reports/engine/console/util/ReportsEngineConsoleUtil.java class.

Tested it locally and it solved the issue

Thank you in advance!

BR,
Gege



