### PR TITLE
[TS] LPS-199526 Addition instead of updating the existing record in Dynamic Data List spreadsheet view

### DIFF
--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/java/com/liferay/dynamic/data/lists/web/internal/portlet/action/AddRecordMVCResourceCommand.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/java/com/liferay/dynamic/data/lists/web/internal/portlet/action/AddRecordMVCResourceCommand.java
@@ -6,6 +6,7 @@
 package com.liferay.dynamic.data.lists.web.internal.portlet.action;
 
 import com.liferay.dynamic.data.lists.constants.DDLPortletKeys;
+import com.liferay.dynamic.data.lists.model.DDLRecord;
 import com.liferay.dynamic.data.lists.model.DDLRecordSet;
 import com.liferay.dynamic.data.lists.service.DDLRecordService;
 import com.liferay.dynamic.data.lists.service.DDLRecordSetService;
@@ -14,6 +15,8 @@ import com.liferay.dynamic.data.mapping.io.DDMFormValuesDeserializerDeserializeR
 import com.liferay.dynamic.data.mapping.io.DDMFormValuesDeserializerDeserializeResponse;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.portlet.JSONPortletResponseUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCResourceCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -45,7 +48,7 @@ public class AddRecordMVCResourceCommand extends BaseMVCResourceCommand {
 			ResourceRequest resourceRequest, ResourceResponse resourceResponse)
 		throws Exception {
 
-		_ddlRecordService.addRecord(
+		DDLRecord ddlRecord = _ddlRecordService.addRecord(
 			ParamUtil.getLong(resourceRequest, "groupId"),
 			ParamUtil.getLong(resourceRequest, "recordSetId"),
 			ParamUtil.getInteger(resourceRequest, "displayIndex"),
@@ -53,6 +56,10 @@ public class AddRecordMVCResourceCommand extends BaseMVCResourceCommand {
 				ParamUtil.getString(resourceRequest, "ddmFormValues"),
 				ParamUtil.getLong(resourceRequest, "recordSetId")),
 			_getServiceContext(resourceRequest));
+
+		JSONPortletResponseUtil.writeJSON(
+			resourceRequest, resourceResponse,
+			JSONUtil.put("recordId", ddlRecord.getRecordId()));
 	}
 
 	private DDMFormValues _getDDMFormValues(

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/js/main.js
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/js/main.js
@@ -109,8 +109,8 @@ AUI.add(
 					dataType: 'JSON',
 					method: 'POST',
 					on: {
-						success() {
-							callback();
+						success(data) {
+							callback(JSON.parse(data.details[1].response));
 						},
 					},
 				});


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

Motivation
=======
When editing after adding a field's value in the Dynamic Data List spreadsheet view without refreshing the page in between, a new record is added instead of the existing record being updated.
This is because the newly created record's ID when adding the field is not returned to the fronted. The json [here](https://github.com/liferay/liferay-portal/blob/master/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/js/main.js#L665-L666) will be undefined.

Proposed Solution
========
The record's ID should be returned.

Steps to Verify
========
Please see the linked LPS for the reproduction steps.
https://liferay.atlassian.net/browse/LPS-199526

Thank you and best regards,
István