### PR TITLE
[TS] LPS-200200 Nested fields are not saved in Dynamic Data List spreadsheet view

### DIFF
--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/java/com/liferay/dynamic/data/lists/web/internal/portlet/action/AddRecordMVCResourceCommand.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/java/com/liferay/dynamic/data/lists/web/internal/portlet/action/AddRecordMVCResourceCommand.java
@@ -6,6 +6,7 @@
 package com.liferay.dynamic.data.lists.web.internal.portlet.action;
 
 import com.liferay.dynamic.data.lists.constants.DDLPortletKeys;
+import com.liferay.dynamic.data.lists.model.DDLRecord;
 import com.liferay.dynamic.data.lists.model.DDLRecordSet;
 import com.liferay.dynamic.data.lists.service.DDLRecordService;
 import com.liferay.dynamic.data.lists.service.DDLRecordSetService;
@@ -14,6 +15,8 @@ import com.liferay.dynamic.data.mapping.io.DDMFormValuesDeserializerDeserializeR
 import com.liferay.dynamic.data.mapping.io.DDMFormValuesDeserializerDeserializeResponse;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.portlet.JSONPortletResponseUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCResourceCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -45,7 +48,7 @@ public class AddRecordMVCResourceCommand extends BaseMVCResourceCommand {
 			ResourceRequest resourceRequest, ResourceResponse resourceResponse)
 		throws Exception {
 
-		_ddlRecordService.addRecord(
+		DDLRecord ddlRecord = _ddlRecordService.addRecord(
 			ParamUtil.getLong(resourceRequest, "groupId"),
 			ParamUtil.getLong(resourceRequest, "recordSetId"),
 			ParamUtil.getInteger(resourceRequest, "displayIndex"),
@@ -53,6 +56,10 @@ public class AddRecordMVCResourceCommand extends BaseMVCResourceCommand {
 				ParamUtil.getString(resourceRequest, "ddmFormValues"),
 				ParamUtil.getLong(resourceRequest, "recordSetId")),
 			_getServiceContext(resourceRequest));
+
+		JSONPortletResponseUtil.writeJSON(
+			resourceRequest, resourceResponse,
+			JSONUtil.put("recordId", ddlRecord.getRecordId()));
 	}
 
 	private DDMFormValues _getDDMFormValues(

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/js/main.js
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/js/main.js
@@ -109,8 +109,8 @@ AUI.add(
 					dataType: 'JSON',
 					method: 'POST',
 					on: {
-						success() {
-							callback();
+						success(data) {
+							callback(JSON.parse(data.details[1].response));
 						},
 					},
 				});

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/js/main.js
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/js/main.js
@@ -506,15 +506,11 @@ AUI.add(
 					}
 				},
 
-				_normalizeFieldData(item, record, normalized) {
+				_normalizeFieldData(item, record, normalized, field) {
 					const instance = this;
 
 					const type = item.type;
 					let value = record.get(item.name);
-
-					if (!record.changed[item.id] && value && !!value.length) {
-						return;
-					}
 
 					if (type === 'ddm-link-to-page') {
 						value = FormBuilder.Util.parseJSON(value);
@@ -547,14 +543,21 @@ AUI.add(
 
 					normalized['fieldValues'].push(fieldValue);
 
-					if (isArray(item.fields)) {
-						item.fields.forEach((item) => {
+					if (isArray(item.fields) && !!item.fields.length) {
+						fieldValue['nestedFieldValues'] = [];
+
+						item.fields.forEach((nestedItem) => {
 							instance._normalizeFieldData(
-								item,
+								nestedItem,
 								record,
-								normalized
+								normalized,
+								fieldValue
 							);
 						});
+					}
+
+					if (field) {
+						field['nestedFieldValues'].push(fieldValue);
 					}
 				},
 


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

Please note that the pull request includes the commits for [LPS-199526](https://liferay.atlassian.net/browse/LPS-199526) because that issue blocks the demonstration of the current one.
 
Motivation
=======
When a value of an embedded field is inserted or edited in the Dynamic Data List spreadsheet view, it won't be saved.
This is because the `_normalizeFieldData` [function](https://github.com/liferay/liferay-portal/blob/master/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/js/main.js#L509) collects the nested fields in a serial arrangement instead of embedding them.
This is fine if the record is being updated because `UpdateRecordMVCResourceCommand._toDDMFormFieldValues` [processes the ddmFormFieldValues serially](https://github.com/liferay/liferay-portal/blob/master/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/java/com/liferay/dynamic/data/lists/web/internal/portlet/action/UpdateRecordMVCResourceCommand.java#L92-L160) but if it is being added, then the JSON data should reflect the structure of the DDMFormValues, see this [method](https://github.com/liferay/liferay-portal/blob/master/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/java/com/liferay/dynamic/data/lists/web/internal/portlet/action/AddRecordMVCResourceCommand.java#L58-L77).

Proposed Solution
========
`_normalizeFieldData` should place the nested field data inside the `fieldValue` as well.

Steps to Verify
========
Please see the linked LPS for the reproduction steps.
https://liferay.atlassian.net/browse/LPS-200200

Thank you and best regards,
István