### PR TITLE
[TS] LPS-199911 Label and Error Message when activating Require Confirmation for a Field text in a form is empty for forms after upgrading from 7.2/7.3 to 7.4

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/bnd.bnd
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/bnd.bnd
@@ -36,6 +36,6 @@ Import-Package:\
 	org.tukaani.*;resolution:=optional,\
 	\
 	*
-Liferay-Require-SchemaVersion: 5.4.0
+Liferay-Require-SchemaVersion: 5.4.1
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/registry/DDMServiceUpgradeStepRegistrator.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/registry/DDMServiceUpgradeStepRegistrator.java
@@ -533,6 +533,13 @@ public class DDMServiceUpgradeStepRegistrator
 			"5.3.3", "5.4.0",
 			new com.liferay.dynamic.data.mapping.internal.upgrade.v5_4_0.
 				DDMFieldUpgradeProcess());
+
+		registry.register(
+			"5.4.0", "5.4.1",
+			new com.liferay.dynamic.data.mapping.internal.upgrade.v5_4_1.
+				DDMStructureUpgradeProcess(
+					_jsonDDMFormDeserializer, _jsonDDMFormSerializer,
+					_language));
 	}
 
 	@Activate

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_4_1/DDMStructureUpgradeProcess.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_4_1/DDMStructureUpgradeProcess.java
@@ -1,0 +1,220 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.dynamic.data.mapping.internal.upgrade.v5_4_1;
+
+import com.liferay.dynamic.data.mapping.form.field.type.constants.DDMFormFieldTypeConstants;
+import com.liferay.dynamic.data.mapping.io.DDMFormDeserializer;
+import com.liferay.dynamic.data.mapping.io.DDMFormSerializer;
+import com.liferay.dynamic.data.mapping.model.DDMForm;
+import com.liferay.dynamic.data.mapping.model.DDMFormField;
+import com.liferay.dynamic.data.mapping.model.LocalizedValue;
+import com.liferay.dynamic.data.mapping.util.DDMFormDeserializeUtil;
+import com.liferay.dynamic.data.mapping.util.DDMFormSerializeUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * @author István András Dézsi
+ */
+public class DDMStructureUpgradeProcess extends UpgradeProcess {
+
+	public DDMStructureUpgradeProcess(
+		DDMFormDeserializer ddmFormDeserializer,
+		DDMFormSerializer ddmFormSerializer, Language language) {
+
+		_ddmFormDeserializer = ddmFormDeserializer;
+		_ddmFormSerializer = ddmFormSerializer;
+		_language = language;
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		_upgradeDDMStructure();
+		_upgradeDDMStructureVersion();
+	}
+
+	private void _addConfirmationErrorMessageAndConfirmationLabel(
+		Set<Locale> availableLocales, List<DDMFormField> ddmFormFields) {
+
+		for (DDMFormField ddmFormField : ddmFormFields) {
+			if (Objects.equals(
+					ddmFormField.getType(), DDMFormFieldTypeConstants.TEXT) ||
+				Objects.equals(
+					ddmFormField.getType(),
+					DDMFormFieldTypeConstants.NUMERIC)) {
+
+				if (!_isConfirmationErrorMessageSet(ddmFormField)) {
+					ddmFormField.setProperty(
+						"confirmationErrorMessage",
+						new LocalizedValue() {
+							{
+								for (Locale locale : availableLocales) {
+									addString(
+										locale,
+										_language.get(
+											locale,
+											"the-information-does-not-match"));
+								}
+							}
+						});
+				}
+
+				if (!_isConfirmationLabelSet(ddmFormField)) {
+					ddmFormField.setProperty(
+						"confirmationLabel",
+						new LocalizedValue() {
+							{
+								for (Locale locale : availableLocales) {
+									addString(
+										locale,
+										_language.get(locale, "confirm"));
+								}
+							}
+						});
+				}
+			}
+
+			if (ListUtil.isNotEmpty(ddmFormField.getNestedDDMFormFields())) {
+				_addConfirmationErrorMessageAndConfirmationLabel(
+					availableLocales, ddmFormField.getNestedDDMFormFields());
+			}
+		}
+	}
+
+	private String _addConfirmationErrorMessageAndConfirmationLabel(
+			String dataDefinition)
+		throws Exception {
+
+		DDMForm ddmForm = DDMFormDeserializeUtil.deserialize(
+			_ddmFormDeserializer, dataDefinition);
+
+		_addConfirmationErrorMessageAndConfirmationLabel(
+			ddmForm.getAvailableLocales(), ddmForm.getDDMFormFields());
+
+		return DDMFormSerializeUtil.serialize(ddmForm, _ddmFormSerializer);
+	}
+
+	private boolean _isConfirmationErrorMessageSet(DDMFormField ddmFormField) {
+		LocalizedValue localizedValue =
+			(LocalizedValue)ddmFormField.getProperty(
+				"confirmationErrorMessage");
+
+		if (localizedValue != null) {
+			Map<Locale, String> values = localizedValue.getValues();
+
+			for (String value : values.values()) {
+				if (Validator.isNotNull(value)) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	private boolean _isConfirmationLabelSet(DDMFormField ddmFormField) {
+		LocalizedValue localizedValue =
+			(LocalizedValue)ddmFormField.getProperty("confirmationLabel");
+
+		if (localizedValue != null) {
+			Map<Locale, String> values = localizedValue.getValues();
+
+			for (String value : values.values()) {
+				if (Validator.isNotNull(value)) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	private void _upgradeDDMStructure() throws Exception {
+		try (PreparedStatement preparedStatement1 = connection.prepareStatement(
+				"select structureId, definition from DDMStructure where " +
+					"classNameId = ? order by createDate");
+			PreparedStatement preparedStatement2 =
+				AutoBatchPreparedStatementUtil.concurrentAutoBatch(
+					connection,
+					"update DDMStructure set definition = ? where " +
+						"structureId = ?")) {
+
+			preparedStatement1.setLong(
+				1, PortalUtil.getClassNameId(_CLASS_NAME_DDM_FORM_INSTANCE));
+
+			try (ResultSet resultSet = preparedStatement1.executeQuery()) {
+				while (resultSet.next()) {
+					preparedStatement2.setString(
+						1,
+						_addConfirmationErrorMessageAndConfirmationLabel(
+							resultSet.getString("definition")));
+					preparedStatement2.setLong(
+						2, resultSet.getLong("structureId"));
+
+					preparedStatement2.addBatch();
+				}
+
+				preparedStatement2.executeBatch();
+			}
+		}
+	}
+
+	private void _upgradeDDMStructureVersion() throws Exception {
+		try (PreparedStatement preparedStatement1 = connection.prepareStatement(
+				StringBundler.concat(
+					"select DDMStructure.structureKey,  ",
+					"DDMStructureVersion.structureVersionId, ",
+					"DDMStructureVersion.definition from DDMStructureVersion ",
+					"inner join DDMStructure on DDMStructure.structureId = ",
+					"DDMStructureVersion.structureId where ",
+					"DDMStructure.classNameId = ? "));
+			PreparedStatement preparedStatement2 =
+				AutoBatchPreparedStatementUtil.concurrentAutoBatch(
+					connection,
+					"update DDMStructureVersion set definition = ? where " +
+						"structureVersionId = ?")) {
+
+			preparedStatement1.setLong(
+				1, PortalUtil.getClassNameId(_CLASS_NAME_DDM_FORM_INSTANCE));
+
+			try (ResultSet resultSet = preparedStatement1.executeQuery()) {
+				while (resultSet.next()) {
+					preparedStatement2.setString(
+						1,
+						_addConfirmationErrorMessageAndConfirmationLabel(
+							resultSet.getString("definition")));
+					preparedStatement2.setLong(
+						2, resultSet.getLong("structureVersionId"));
+					preparedStatement2.addBatch();
+				}
+
+				preparedStatement2.executeBatch();
+			}
+		}
+	}
+
+	private static final String _CLASS_NAME_DDM_FORM_INSTANCE =
+		"com.liferay.dynamic.data.mapping.model.DDMFormInstance";
+
+	private final DDMFormDeserializer _ddmFormDeserializer;
+	private final DDMFormSerializer _ddmFormSerializer;
+	private final Language _language;
+
+}


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

Motivation
=======
For Forms that were upgraded from 7.2/7.3 to 7.4, the Label and Error Message when activating Require Confirmation for Text and Numeric fields are empty instead of having the default values, "The information does not match." and "Confirm", respectively. 
This is because the `confirmationErrorMessage` and `confirmationLabel` properties were only introduced in 7.4.

Proposed Solution
========
To add an upgrade process that adds these properties with their respective default values.

Steps to Verify
========
Please see the linked LPS for the reproduction steps.
https://liferay.atlassian.net/browse/LPS-199911

Thank you and best regards,
István