### PR TITLE
[TS] LPS-200189 - dragging&dropping a repeatable field after deleting a duplicate field causes exceptions

### DIFF
--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/components/FieldRepeatableDND.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/components/FieldRepeatableDND.js
@@ -23,7 +23,7 @@ const FieldRepeatableDND = ({children, field, index, nestedFieldIndex}) => {
 			return true;
 		},
 		item: {
-			id: field.fieldName,
+			id: field.name,
 			index,
 			nestedFieldIndex,
 			preview: () => (

--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/custom/form/reducers/repeatableDNDReducer.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/custom/form/reducers/repeatableDNDReducer.es.js
@@ -94,7 +94,7 @@ export default function repeatableDNDReducer(state, action) {
 
 						if (
 							!fields.find(
-								(field) => field.fieldName === sourceFieldName
+								(field) => field.name === sourceFieldName
 							)
 						) {
 							return fields.map((field) => {


### PR DESCRIPTION
Hi Forms Team!

Currently there can be an issue with dragging & dropping when fields have been duplicated. For example, if we have a structure with a repeatable field set and a repeatable field:

![Screenshot 2023-11-07 122250](https://github.com/liferay-forms/liferay-portal/assets/1923745/345fe0c5-2c4d-4bed-bdc2-41f5b5f7c6ac)

And we then duplicate this entire fieldset using the + button near the "Tab" title, we are given a second fieldset with one title field and three description fields. Deleting one of those description fields in our second fieldset and then returning to our original fieldset to drag and drop the last description fields causes an undefined name exception.

This is due to the fact that when we drag&drop we are:
1. only checking for the "fieldName" which is broadly shared between the two duplicated fieldSets rather than the more exact "name" which contains the instanceID for the exact field being dragged/dropped
2. blindly using the known indexes of the fields in the larger fieldSet

This means that both fieldSets will be checked initially for a reorder even though only one has the correct field and causes problems when we try to find the indexed version in the smaller fields map (since the index would exceed the indexes available). I've fixed this by checking specifically for the name rather than the fieldName since we only want to be dragging&dropping one specific field anyway. Please let me know if there's any questions or issues. Thanks!