### PR TITLE
[TS] LPS-197993 Sanitize Captcha HTML from Request

### DIFF
--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/utils/evaluation.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/utils/evaluation.es.js
@@ -39,6 +39,18 @@ export function mergeFieldOptions(field, newField) {
 	return newValue;
 }
 
+const sanitizePagesCaptchaHTML = (pages) => {
+	const visitor = new PagesVisitor(pages);
+
+	visitor.mapFields(
+		(field) => {
+			if (field.fieldName === "_CAPTCHA_") {
+				delete field.html;
+			}
+		},
+	);
+};
+
 export function mergePages(
 	defaultLanguageId,
 	editingLanguageId,
@@ -131,6 +143,8 @@ const doEvaluate = debounce((fieldName, evaluatorContext, callback) => {
 	if (window.AbortController) {
 		controller = new AbortController();
 	}
+
+	sanitizePagesCaptchaHTML(pages);
 
 	makeFetch({
 		body: convertToFormData({

--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/utils/evaluation.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/utils/evaluation.es.js
@@ -42,13 +42,11 @@ export function mergeFieldOptions(field, newField) {
 const sanitizePagesCaptchaHTML = (pages) => {
 	const visitor = new PagesVisitor(pages);
 
-	visitor.mapFields(
-		(field) => {
-			if (field.fieldName === "_CAPTCHA_") {
-				delete field.html;
-			}
-		},
-	);
+	visitor.mapFields((field) => {
+		if (field.fieldName === '_CAPTCHA_') {
+			delete field.html;
+		}
+	});
 };
 
 export function mergePages(


### PR DESCRIPTION
Hi Team,

May I ask to review this PR?

issue is: [LPS-197993](https://liferay.atlassian.net/browse/LPS-197993), When enable captcha for forms, in the html request we are sending html data.

solution : html parameter is included in the page, before fetching we sanitize the data. : https://github.com/gergelyszalay/liferay-portal/blob/9167d952f7e0f551d7cc08f1cb22e03b56d6f605/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/utils/evaluation.es.js#L42

Tested locally the solution.

BR,
Gege