### PR TITLE
[TS] LPS-202728 Datepicker in DateAndTime Form is not fully displayed

### DIFF
--- a/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/VerticalBar/CustomVerticalBar.scss
+++ b/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/VerticalBar/CustomVerticalBar.scss
@@ -27,9 +27,3 @@
 		transition: transform 0.5s;
 	}
 }
-
-.dropdown-menu {
-	max-width: 17rem;
-	width: 17rem;
-	z-index: 1035;
-}


### PR DESCRIPTION
Hi Team,

Could you please review this PR?

issue is: [LPS-202728](https://liferay.atlassian.net/browse/LPS-202728), Datepicker in DateAndTime Form is not fully displayed

Solution: 
The DatePicker should be according to these attributes: 
https://liferay.design/lexicon/core-components/forms/picker-date-time/#attributes
In this previous commit: https://github.com/brianchandotcom/liferay-portal/pull/139462/commits/5fb61c7f4701d9320858491dafb28ae493be1156, some modifications were applied to all dropdown menus, including DatePicker.
My modification removes only the added styles from the dropdown menus. Our tests do not show regression.


Thanks,
Tamas