### PR TITLE
[TS] LPS-202878 - pass timezone information to datepicker field

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/date/DateDDMFormFieldTemplateContextContributor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/date/DateDDMFormFieldTemplateContextContributor.java
@@ -14,6 +14,7 @@ import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.util.CalendarUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.TimeZoneUtil;
 
 import java.time.DayOfWeek;
 import java.time.temporal.WeekFields;
@@ -24,6 +25,7 @@ import java.util.Calendar;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.TimeZone;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -60,6 +62,8 @@ public class DateDDMFormFieldTemplateContextContributor
 				ddmFormField, ddmFormFieldRenderingContext.getLocale(),
 				"predefinedValue")
 		).put(
+			"timeZone", _getTimeZone()
+		).put(
 			"tooltip",
 			DDMFormFieldTypeUtil.getPropertyValue(
 				ddmFormField, ddmFormFieldRenderingContext.getLocale(),
@@ -81,6 +85,12 @@ public class DateDDMFormFieldTemplateContextContributor
 		DayOfWeek dayOfWeek = weekFields.getFirstDayOfWeek();
 
 		return dayOfWeek.getValue() % 7;
+	}
+
+	private String _getTimeZone() {
+		TimeZone defaultTimeZone = TimeZoneUtil.getDefault();
+
+		return defaultTimeZone.getID();
 	}
 
 	private List<Integer> _getYears() {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/DatePicker/DatePicker.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/DatePicker/DatePicker.es.js
@@ -31,6 +31,7 @@ export default function DatePicker({
 	onFocus,
 	predefinedValue,
 	readOnly,
+	timeZone,
 	type,
 	value,
 	weekdaysShort,
@@ -209,6 +210,7 @@ export default function DatePicker({
 						placeholder={placeholder}
 						ref={inputRef}
 						time={isDateTime}
+						timezone={timeZone}
 						use12Hours={use12Hours}
 						value={formattedDate}
 						weekdaysShort={weekdaysShort}


### PR DESCRIPTION
Hi Forms team!

This is an client reported issue related to difficulty reading/understanding times in the time zone field. Currently, unlike many other features in the portal, the times do not adjust based on time zone. This makes it unclear about what time exactly the time placed in the datetime field is at for users who work across time zones. Therefore, adding some form of context for time zone is ncessary.

Since the Clay Timepicker only supports passing a time zone string, I've opted to pass the company default timezone for display to keep this as consistent as possible. While it'd be nice to make a more sophisticated solution than this such as adding automatic timezone support, the lack of localization options in Timepicker as of right now (see: [LPS-137401](https://liferay.atlassian.net/browse/LPS-137401)) makes it rather difficult. Please let me know if you have any suggestions or questions. Thanks!