### PR TITLE
LPS-199345 Fix forms radio buttons keyboard navigation

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Radio/Radio.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Radio/Radio.es.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {ClayRadio} from '@clayui/form';
+import {ClayRadio, ClayRadioGroup} from '@clayui/form';
 import React, {useMemo} from 'react';
 
 import {FieldBase} from '../FieldBase/ReactFieldBase.es';
@@ -58,23 +58,28 @@ const Radio = ({
 	return (
 		<FieldBase {...otherProps} name={name} readOnly={disabled}>
 			<div className="ddm__radio" onBlur={onBlur} onFocus={onFocus}>
-				{options.map((option, index) => (
-					<ClayRadio
-						aria-required={otherProps.required}
-						checked={currentValue === option.value}
-						disabled={disabled}
-						inline={inline}
-						key={option.value}
-						label={option.label}
-						name={`${name}_${index}`}
-						onChange={(event) => {
-							setCurrentValue(option.value);
-
-							onChange(event);
-						}}
-						value={option.value}
-					/>
-				))}
+				<ClayRadioGroup
+					inline={inline}
+					onChange={(value) => {
+						setCurrentValue(value);
+						onChange({target: {value}});
+					}}
+					value={currentValue}
+				>
+					{options.map((option, index) => (
+						<ClayRadio
+							aria-required={otherProps.required}
+							containerProps={{
+								'data-checked': currentValue === option.value,
+							}}
+							disabled={disabled}
+							key={option.value}
+							label={option.label}
+							name={`${name}_${index}`}
+							value={option.value}
+						/>
+					))}
+				</ClayRadioGroup>
 			</div>
 
 			<input name={name} type="hidden" value={currentValue} />

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Radio/__snapshots__/Radio.es.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Radio/__snapshots__/Radio.es.js.snap
@@ -11,48 +11,52 @@ exports[`Field Radio has a helptext 1`] = `
       class="ddm__radio"
     >
       <div
-        class="custom-control custom-radio custom-control-outside"
+        class=""
       >
-        <label>
-          <input
-            class="custom-control-input"
-            name="radioField_0"
-            role="radio"
-            type="radio"
-            value="option1"
-          />
-          <span
-            class="custom-control-label"
-          >
+        <div
+          class="custom-control custom-radio custom-control-outside"
+          data-checked="false"
+        >
+          <label>
+            <input
+              class="custom-control-input"
+              role="radio"
+              type="radio"
+              value="option1"
+            />
             <span
-              class="custom-control-label-text"
+              class="custom-control-label"
             >
-              Option 1
+              <span
+                class="custom-control-label-text"
+              >
+                Option 1
+              </span>
             </span>
-          </span>
-        </label>
-      </div>
-      <div
-        class="custom-control custom-radio custom-control-outside"
-      >
-        <label>
-          <input
-            class="custom-control-input"
-            name="radioField_1"
-            role="radio"
-            type="radio"
-            value="option2"
-          />
-          <span
-            class="custom-control-label"
-          >
+          </label>
+        </div>
+        <div
+          class="custom-control custom-radio custom-control-outside"
+          data-checked="false"
+        >
+          <label>
+            <input
+              class="custom-control-input"
+              role="radio"
+              type="radio"
+              value="option2"
+            />
             <span
-              class="custom-control-label-text"
+              class="custom-control-label"
             >
-              Option 2
+              <span
+                class="custom-control-label-text"
+              >
+                Option 2
+              </span>
             </span>
-          </span>
-        </label>
+          </label>
+        </div>
       </div>
     </div>
     <input
@@ -101,48 +105,52 @@ exports[`Field Radio has a label 1`] = `
       class="ddm__radio"
     >
       <div
-        class="custom-control custom-radio custom-control-outside"
+        class=""
       >
-        <label>
-          <input
-            class="custom-control-input"
-            name="radioField_0"
-            role="radio"
-            type="radio"
-            value="option1"
-          />
-          <span
-            class="custom-control-label"
-          >
+        <div
+          class="custom-control custom-radio custom-control-outside"
+          data-checked="false"
+        >
+          <label>
+            <input
+              class="custom-control-input"
+              role="radio"
+              type="radio"
+              value="option1"
+            />
             <span
-              class="custom-control-label-text"
+              class="custom-control-label"
             >
-              Option 1
+              <span
+                class="custom-control-label-text"
+              >
+                Option 1
+              </span>
             </span>
-          </span>
-        </label>
-      </div>
-      <div
-        class="custom-control custom-radio custom-control-outside"
-      >
-        <label>
-          <input
-            class="custom-control-input"
-            name="radioField_1"
-            role="radio"
-            type="radio"
-            value="option2"
-          />
-          <span
-            class="custom-control-label"
-          >
+          </label>
+        </div>
+        <div
+          class="custom-control custom-radio custom-control-outside"
+          data-checked="false"
+        >
+          <label>
+            <input
+              class="custom-control-input"
+              role="radio"
+              type="radio"
+              value="option2"
+            />
             <span
-              class="custom-control-label-text"
+              class="custom-control-label"
             >
-              Option 2
+              <span
+                class="custom-control-label-text"
+              >
+                Option 2
+              </span>
             </span>
-          </span>
-        </label>
+          </label>
+        </div>
       </div>
     </div>
     <input
@@ -176,48 +184,52 @@ exports[`Field Radio has a placeholder 1`] = `
       class="ddm__radio"
     >
       <div
-        class="custom-control custom-radio custom-control-outside"
+        class=""
       >
-        <label>
-          <input
-            class="custom-control-input"
-            name="radioField_0"
-            role="radio"
-            type="radio"
-            value="option1"
-          />
-          <span
-            class="custom-control-label"
-          >
+        <div
+          class="custom-control custom-radio custom-control-outside"
+          data-checked="false"
+        >
+          <label>
+            <input
+              class="custom-control-input"
+              role="radio"
+              type="radio"
+              value="option1"
+            />
             <span
-              class="custom-control-label-text"
+              class="custom-control-label"
             >
-              Option 1
+              <span
+                class="custom-control-label-text"
+              >
+                Option 1
+              </span>
             </span>
-          </span>
-        </label>
-      </div>
-      <div
-        class="custom-control custom-radio custom-control-outside"
-      >
-        <label>
-          <input
-            class="custom-control-input"
-            name="radioField_1"
-            role="radio"
-            type="radio"
-            value="option2"
-          />
-          <span
-            class="custom-control-label"
-          >
+          </label>
+        </div>
+        <div
+          class="custom-control custom-radio custom-control-outside"
+          data-checked="false"
+        >
+          <label>
+            <input
+              class="custom-control-input"
+              role="radio"
+              type="radio"
+              value="option2"
+            />
             <span
-              class="custom-control-label-text"
+              class="custom-control-label"
             >
-              Option 2
+              <span
+                class="custom-control-label-text"
+              >
+                Option 2
+              </span>
             </span>
-          </span>
-        </label>
+          </label>
+        </div>
       </div>
     </div>
     <input
@@ -245,48 +257,52 @@ exports[`Field Radio has a value 1`] = `
       class="ddm__radio"
     >
       <div
-        class="custom-control custom-radio custom-control-outside"
+        class=""
       >
-        <label>
-          <input
-            class="custom-control-input"
-            name="radioField_0"
-            role="radio"
-            type="radio"
-            value="option1"
-          />
-          <span
-            class="custom-control-label"
-          >
+        <div
+          class="custom-control custom-radio custom-control-outside"
+          data-checked="false"
+        >
+          <label>
+            <input
+              class="custom-control-input"
+              role="radio"
+              type="radio"
+              value="option1"
+            />
             <span
-              class="custom-control-label-text"
+              class="custom-control-label"
             >
-              Option 1
+              <span
+                class="custom-control-label-text"
+              >
+                Option 1
+              </span>
             </span>
-          </span>
-        </label>
-      </div>
-      <div
-        class="custom-control custom-radio custom-control-outside"
-      >
-        <label>
-          <input
-            class="custom-control-input"
-            name="radioField_1"
-            role="radio"
-            type="radio"
-            value="option2"
-          />
-          <span
-            class="custom-control-label"
-          >
+          </label>
+        </div>
+        <div
+          class="custom-control custom-radio custom-control-outside"
+          data-checked="false"
+        >
+          <label>
+            <input
+              class="custom-control-input"
+              role="radio"
+              type="radio"
+              value="option2"
+            />
             <span
-              class="custom-control-label-text"
+              class="custom-control-label"
             >
-              Option 2
+              <span
+                class="custom-control-label-text"
+              >
+                Option 2
+              </span>
             </span>
-          </span>
-        </label>
+          </label>
+        </div>
       </div>
     </div>
     <input
@@ -314,48 +330,52 @@ exports[`Field Radio has an id 1`] = `
       class="ddm__radio"
     >
       <div
-        class="custom-control custom-radio custom-control-outside"
+        class=""
       >
-        <label>
-          <input
-            class="custom-control-input"
-            name="radioField_0"
-            role="radio"
-            type="radio"
-            value="option1"
-          />
-          <span
-            class="custom-control-label"
-          >
+        <div
+          class="custom-control custom-radio custom-control-outside"
+          data-checked="false"
+        >
+          <label>
+            <input
+              class="custom-control-input"
+              role="radio"
+              type="radio"
+              value="option1"
+            />
             <span
-              class="custom-control-label-text"
+              class="custom-control-label"
             >
-              Option 1
+              <span
+                class="custom-control-label-text"
+              >
+                Option 1
+              </span>
             </span>
-          </span>
-        </label>
-      </div>
-      <div
-        class="custom-control custom-radio custom-control-outside"
-      >
-        <label>
-          <input
-            class="custom-control-input"
-            name="radioField_1"
-            role="radio"
-            type="radio"
-            value="option2"
-          />
-          <span
-            class="custom-control-label"
-          >
+          </label>
+        </div>
+        <div
+          class="custom-control custom-radio custom-control-outside"
+          data-checked="false"
+        >
+          <label>
+            <input
+              class="custom-control-input"
+              role="radio"
+              type="radio"
+              value="option2"
+            />
             <span
-              class="custom-control-label-text"
+              class="custom-control-label"
             >
-              Option 2
+              <span
+                class="custom-control-label-text"
+              >
+                Option 2
+              </span>
             </span>
-          </span>
-        </label>
+          </label>
+        </div>
       </div>
     </div>
     <input
@@ -383,50 +403,54 @@ exports[`Field Radio is not editable 1`] = `
       class="ddm__radio"
     >
       <div
-        class="custom-control custom-radio custom-control-outside"
+        class=""
       >
-        <label>
-          <input
-            class="custom-control-input"
-            disabled=""
-            name="radioField_0"
-            role="radio"
-            type="radio"
-            value="option1"
-          />
-          <span
-            class="custom-control-label"
-          >
+        <div
+          class="custom-control custom-radio custom-control-outside"
+          data-checked="false"
+        >
+          <label>
+            <input
+              class="custom-control-input"
+              disabled=""
+              role="radio"
+              type="radio"
+              value="option1"
+            />
             <span
-              class="custom-control-label-text"
+              class="custom-control-label"
             >
-              Option 1
+              <span
+                class="custom-control-label-text"
+              >
+                Option 1
+              </span>
             </span>
-          </span>
-        </label>
-      </div>
-      <div
-        class="custom-control custom-radio custom-control-outside"
-      >
-        <label>
-          <input
-            class="custom-control-input"
-            disabled=""
-            name="radioField_1"
-            role="radio"
-            type="radio"
-            value="option2"
-          />
-          <span
-            class="custom-control-label"
-          >
+          </label>
+        </div>
+        <div
+          class="custom-control custom-radio custom-control-outside"
+          data-checked="false"
+        >
+          <label>
+            <input
+              class="custom-control-input"
+              disabled=""
+              role="radio"
+              type="radio"
+              value="option2"
+            />
             <span
-              class="custom-control-label-text"
+              class="custom-control-label"
             >
-              Option 2
+              <span
+                class="custom-control-label-text"
+              >
+                Option 2
+              </span>
             </span>
-          </span>
-        </label>
+          </label>
+        </div>
       </div>
     </div>
     <input
@@ -454,50 +478,54 @@ exports[`Field Radio is not required 1`] = `
       class="ddm__radio"
     >
       <div
-        class="custom-control custom-radio custom-control-outside"
+        class=""
       >
-        <label>
-          <input
-            aria-required="false"
-            class="custom-control-input"
-            name="radioField_0"
-            role="radio"
-            type="radio"
-            value="option1"
-          />
-          <span
-            class="custom-control-label"
-          >
+        <div
+          class="custom-control custom-radio custom-control-outside"
+          data-checked="false"
+        >
+          <label>
+            <input
+              aria-required="false"
+              class="custom-control-input"
+              role="radio"
+              type="radio"
+              value="option1"
+            />
             <span
-              class="custom-control-label-text"
+              class="custom-control-label"
             >
-              Option 1
+              <span
+                class="custom-control-label-text"
+              >
+                Option 1
+              </span>
             </span>
-          </span>
-        </label>
-      </div>
-      <div
-        class="custom-control custom-radio custom-control-outside"
-      >
-        <label>
-          <input
-            aria-required="false"
-            class="custom-control-input"
-            name="radioField_1"
-            role="radio"
-            type="radio"
-            value="option2"
-          />
-          <span
-            class="custom-control-label"
-          >
+          </label>
+        </div>
+        <div
+          class="custom-control custom-radio custom-control-outside"
+          data-checked="false"
+        >
+          <label>
+            <input
+              aria-required="false"
+              class="custom-control-input"
+              role="radio"
+              type="radio"
+              value="option2"
+            />
             <span
-              class="custom-control-label-text"
+              class="custom-control-label"
             >
-              Option 2
+              <span
+                class="custom-control-label-text"
+              >
+                Option 2
+              </span>
             </span>
-          </span>
-        </label>
+          </label>
+        </div>
       </div>
     </div>
     <input
@@ -530,48 +558,52 @@ exports[`Field Radio renders Label if showLabel is true 1`] = `
       class="ddm__radio"
     >
       <div
-        class="custom-control custom-radio custom-control-outside"
+        class=""
       >
-        <label>
-          <input
-            class="custom-control-input"
-            name="radioField_0"
-            role="radio"
-            type="radio"
-            value="option1"
-          />
-          <span
-            class="custom-control-label"
-          >
+        <div
+          class="custom-control custom-radio custom-control-outside"
+          data-checked="false"
+        >
+          <label>
+            <input
+              class="custom-control-input"
+              role="radio"
+              type="radio"
+              value="option1"
+            />
             <span
-              class="custom-control-label-text"
+              class="custom-control-label"
             >
-              Option 1
+              <span
+                class="custom-control-label-text"
+              >
+                Option 1
+              </span>
             </span>
-          </span>
-        </label>
-      </div>
-      <div
-        class="custom-control custom-radio custom-control-outside"
-      >
-        <label>
-          <input
-            class="custom-control-input"
-            name="radioField_1"
-            role="radio"
-            type="radio"
-            value="option2"
-          />
-          <span
-            class="custom-control-label"
-          >
+          </label>
+        </div>
+        <div
+          class="custom-control custom-radio custom-control-outside"
+          data-checked="false"
+        >
+          <label>
+            <input
+              class="custom-control-input"
+              role="radio"
+              type="radio"
+              value="option2"
+            />
             <span
-              class="custom-control-label-text"
+              class="custom-control-label"
             >
-              Option 2
+              <span
+                class="custom-control-label-text"
+              >
+                Option 2
+              </span>
             </span>
-          </span>
-        </label>
+          </label>
+        </div>
       </div>
     </div>
     <input
@@ -603,7 +635,11 @@ exports[`Field Radio renders no options when options is empty 1`] = `
   >
     <div
       class="ddm__radio"
-    />
+    >
+      <div
+        class=""
+      />
+    </div>
     <input
       name="radioField"
       type="hidden"
@@ -629,48 +665,52 @@ exports[`Field Radio renders options 1`] = `
       class="ddm__radio"
     >
       <div
-        class="custom-control custom-radio custom-control-outside"
+        class=""
       >
-        <label>
-          <input
-            class="custom-control-input"
-            name="radioField_0"
-            role="radio"
-            type="radio"
-            value="item"
-          />
-          <span
-            class="custom-control-label"
-          >
+        <div
+          class="custom-control custom-radio custom-control-outside"
+          data-checked="false"
+        >
+          <label>
+            <input
+              class="custom-control-input"
+              role="radio"
+              type="radio"
+              value="item"
+            />
             <span
-              class="custom-control-label-text"
+              class="custom-control-label"
             >
-              label
+              <span
+                class="custom-control-label-text"
+              >
+                label
+              </span>
             </span>
-          </span>
-        </label>
-      </div>
-      <div
-        class="custom-control custom-radio custom-control-outside"
-      >
-        <label>
-          <input
-            class="custom-control-input"
-            name="radioField_1"
-            role="radio"
-            type="radio"
-            value="item2"
-          />
-          <span
-            class="custom-control-label"
-          >
+          </label>
+        </div>
+        <div
+          class="custom-control custom-radio custom-control-outside"
+          data-checked="false"
+        >
+          <label>
+            <input
+              class="custom-control-input"
+              role="radio"
+              type="radio"
+              value="item2"
+            />
             <span
-              class="custom-control-label-text"
+              class="custom-control-label"
             >
-              label2
+              <span
+                class="custom-control-label-text"
+              >
+                label2
+              </span>
             </span>
-          </span>
-        </label>
+          </label>
+        </div>
       </div>
     </div>
     <input

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/forms/FormFields.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/forms/FormFields.path
@@ -212,7 +212,7 @@
 </tr>
 <tr>
 	<td>FIELD_TARGET_LABEL_AND_BODY_OPTION</td>
-	<td>//div[contains(@class,'ddm-drag')]//div[contains(*,'${key_fieldName}')]/*/*/*/*/*/*[contains(text(),'${key_optionName}')]</td>
+	<td>//div[contains(@class,'ddm-drag')]//div[contains(@*,'${key_fieldName}')]//following-sibling::div[@class='ddm__radio']//descendant::div//descendant::span[text()='${key_optionName}']</td>
 	<td></td>
 </tr>
 <tr>
@@ -537,12 +537,12 @@
 
 <tr>
 	<td>RADIO_OPTION_LABEL</td>
-	<td>//label[contains(.,'${key_radioOption}')]/input[@type='radio' and contains(@name,'${key_fieldName}')]/../span | //div[@class='ddm-field']//*[text()='${key_fieldName}']/..//span[text()='${key_radioOption}']</td>
+	<td>//div[contains(@*,'${key_fieldName}')]//following-sibling::div[@class='ddm__radio']/descendant::span[text()='${key_radioOption}'] | //div[@*='${key_fieldName}']//div[contains(@*,'ddm__radio')]//descendant::span[text()='${key_radioOption}']</td>
 	<td></td>
 </tr>
 <tr>
 	<td>RADIO_OPTION_CHECKED</td>
-	<td>//label[contains(@*,'${key_radioOption}') or contains(.,'${key_radioOption}')]/input[@type='radio' and @checked="checked" and contains(@name,'${key_fieldName}')] | //label[contains(@*,'${key_radioOption}') or contains(.,'${key_radioOption}')]/input[@type='radio' and @checked="" and contains(@name,'${key_fieldName}')] | //fieldset//legend[text()='${key_fieldName}']/..//span[text()='${key_radioOption}']</td>
+	<td>//div[@*='${key_fieldName}']//div[contains(@*,'ddm__radio')]//div[@data-checked='true']//descendant::span[text()='${key_radioOption}']</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/fields/FormsSelectFromListField.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/fields/FormsSelectFromListField.testcase
@@ -498,6 +498,8 @@ definition {
 			fieldPositionNumber = 0,
 			fieldType = "Single Selection");
 
+		var singleSelectionFieldName = FormFields.getFieldName();
+
 		FormFields.editOptionsRow(
 			optionValue = "United",
 			rowNumber = 1);
@@ -543,7 +545,7 @@ definition {
 		FormsAdminNavigator.gotoPublishedForm();
 
 		FormFields.selectRadioOption(
-			fieldName = "Single Selection",
+			fieldName = ${singleSelectionFieldName},
 			radioOption = "United");
 
 		Click.javaScriptClick(

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/fields/FormsSingleSelectionField.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/fields/FormsSingleSelectionField.testcase
@@ -106,6 +106,8 @@ definition {
 			fieldType = "Single Selection",
 			formPageNumber = 0);
 
+		var singleSelectionFieldName = FormFields.getFieldName();
+
 		Type(
 			key_rowNumber = 1,
 			locator1 = "FormFields#OPTIONS_OPTION_VALUE_FIELD",
@@ -124,20 +126,22 @@ definition {
 			key_selectOption = "Duplicate",
 			locator1 = "FormViewBuilder#SELECT_FIELD_OPTIONS_LIST");
 
+		var duplicatedSingleSelectionFieldName = FormFields.getFieldName();
+
 		FormFields.viewOptionSingleSelection(
-			fieldName = "Single Selection",
+			fieldName = ${singleSelectionFieldName},
 			optionName = "Option 1");
 
 		FormFields.viewOptionSingleSelection(
-			fieldName = "Single Selection",
+			fieldName = ${singleSelectionFieldName},
 			optionName = "Option 2");
 
 		FormFields.viewOptionSingleSelection(
-			fieldName = "Copy of Single Selection",
+			fieldName = ${duplicatedSingleSelectionFieldName},
 			optionName = "Option 1");
 
 		FormFields.viewOptionSingleSelection(
-			fieldName = "Copy of Single Selection",
+			fieldName = ${duplicatedSingleSelectionFieldName},
 			optionName = "Option 2");
 
 		FormViewBuilder.assertHelpTextPresent(


### PR DESCRIPTION
Related issue: https://liferay.atlassian.net/browse/LPS-199345

Hello Reviewer! :cherry_blossom:

This PR fixes the keyboard navigation of radio buttons inside forms, by introducing the `<ClayRadioGroup>`  before `<ClayRadio>` and also putting the `onChange` on `<ClayRadioGroup>`. On the `onChange` I'm sending `{target: {value}}` because the function expects an event; you can see a similar approach on `Numeric.tsx line 294` on `dynamic-data-mapping`.

Let me know if you have any questions, thanks!