### PR TITLE
LPS-202999 Wait until form has been rendered

### DIFF
--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/custom/form/FormView.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/custom/form/FormView.es.js
@@ -188,11 +188,20 @@ const useFormSubmit = ({apiRef, containerRef}) => {
 	}, []);
 
 	useEffect(() => {
-		if (containerRef.current) {
-			const form = getFormNode(containerRef.current);
+		const container = containerRef.current;
 
-			if (form) {
-				const onHandle = Liferay.on(
+		if (!container) {
+			return;
+		}
+
+		let form;
+		let formSubmitHandler;
+
+		const waitForElementHandler = waitForElement(
+			container,
+			getFormNode,
+			(form) => {
+				formSubmitHandler = Liferay.on(
 					'submitForm',
 					(event) => {
 						if (event.form && event.form.getDOM() === form) {
@@ -203,14 +212,14 @@ const useFormSubmit = ({apiRef, containerRef}) => {
 				);
 
 				form.addEventListener('submit', handleFormSubmitted);
-
-				return () => {
-					onHandle.detach();
-
-					form.removeEventListener('submit', handleFormSubmitted);
-				};
 			}
-		}
+		);
+
+		return () => {
+			form?.removeEventListener('submit', handleFormSubmitted);
+			formSubmitHandler?.detach();
+			waitForElementHandler.dispose();
+		};
 	}, [containerRef, handleFormSubmitted]);
 };
 
@@ -447,5 +456,38 @@ export const FormView = React.forwardRef((props, ref) => {
 });
 
 FormView.displayName = 'FormView';
+
+function waitForElement(container, getElement, callback) {
+	const element = getElement(container);
+
+	if (element) {
+		callback(element);
+
+		return {
+			dispose() {},
+		};
+	}
+
+	const mutationObserver = new MutationObserver(() => {
+		const element = getElement(container);
+
+		if (element) {
+			mutationObserver.disconnect();
+			callback(element);
+		}
+	});
+
+	mutationObserver.observe(container, {
+		attributes: false,
+		childList: true,
+		subtree: true,
+	});
+
+	return {
+		dispose() {
+			mutationObserver.disconnect();
+		},
+	};
+}
 
 export default FormView;


### PR DESCRIPTION
> Needs feature.flag.LPS-114700 to test

Since we now are rendering our form content inside a clay:panel taglib, the content form element might not be available on first render. We need to wait for this element.

To solve this, I've added a simple MutationObserver that watches the DOM until the element is found.