### PR TITLE
LPS-203465 Remove 'for' attribute on forms from fields with type select to respect accessibility rules

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
@@ -241,10 +241,10 @@ export function FieldBase({
 		type === 'numeric' ||
 		type === 'image' ||
 		type === 'rich_text' ||
-		type === 'search_location' ||
-		type === 'select';
+		type === 'search_location';
 	const readFieldDetails = !showFor;
-	const hasFieldDetails = accessible && fieldDetails && readFieldDetails;
+	const hasFieldDetails =
+		accessible && fieldDetails && readFieldDetails && type !== 'select';
 
 	const accessiblePropsGroup = {
 		...(!renderLabel && {'aria-labelledby': fieldDetailsId}),

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/forms/FormFields.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/forms/FormFields.path
@@ -831,7 +831,7 @@
 </tr>
 <tr>
 	<td>SELECT_FIELD</td>
-	<td>//label[contains(text(),'${key_fieldName}') or contains(@for,'${key_fieldName}')]/following-sibling::div//input[contains(@class, 'form-control')] | //label[contains(text(),'${key_fieldName}') or contains(@for,'${key_fieldName}')]/following-sibling::div//button[contains(@class, 'form-control')]</td>
+	<td>//label[contains(text(),'${key_fieldName}') or contains(@for,'${key_fieldName}') or contains(@id,'${key_fieldName}')]/following-sibling::div//input[contains(@class, 'form-control')] | //label[contains(text(),'${key_fieldName}') or contains(@for,'${key_fieldName}') or contains(@id,'${key_fieldName}')]/following-sibling::div//button[contains(@class, 'form-control')]</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
related issue: https://liferay.atlassian.net/browse/LPS-203465

i had to remove the `for` attribute on forms from fields with type `select` to follow the recommendations of [this comment](https://liferay.atlassian.net/browse/LPS-203465?focusedCommentId=2542849). it was oriented to us that `select from list` fields should have the `aria-labelledby` approach instead, which was already implemented but it needed to remove the `for` property to be fully correct.

this solution is a follow-up of https://github.com/liferay/liferay-portal/commit/a157dff3138765785546865bdc22a56d31f95b8f