### PR TITLE
LPS-204298 - escape user name to avoid issues when opening structure item selector

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-item-selector-web/src/main/java/com/liferay/dynamic/data/mapping/item/selector/web/internal/DDMStructureItemTableItemView.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-item-selector-web/src/main/java/com/liferay/dynamic/data/mapping/item/selector/web/internal/DDMStructureItemTableItemView.java
@@ -59,7 +59,8 @@ public class DDMStructureItemTableItemView implements TableItemView {
 
 		userNameSearchEntry.setCssClass(
 			"table-cell-expand-smaller table-cell-minw-150");
-		userNameSearchEntry.setName(_ddmStructure.getUserName());
+		userNameSearchEntry.setName(
+			HtmlUtil.escape(_ddmStructure.getUserName()));
 
 		searchEntries.add(userNameSearchEntry);
 


### PR DESCRIPTION
Hi @liferay-forms team,

When investigating a supposedly USM related XSS issue, I discovered another separate issue that could potentially occur during the reproduction steps with a script tag being used in a user's name. Specifically, if you have a user with a first name of "<script>alert("firstname")</script>" and they create a structure, if you open the structure selector in the WC template editor the script will activate. I wrote a small fix here and wanted it to send it your guy's way.

Let me know if this should be sent elsewhere (e.g. Lima or Echo). Thanks!