### PR TITLE
LPS-204394 We don't need to verify the View permission of a DDMStructure when getting the DataLayoutRenderingContext to render the DataLayoutRendererTagLib

### DIFF
--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/DataLayoutResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/DataLayoutResourceImpl.java
@@ -223,10 +223,6 @@ public class DataLayoutResourceImpl extends BaseDataLayoutResourceImpl {
 
 		DDMStructure ddmStructure = ddmStructureLayout.getDDMStructure();
 
-		DataDefinitionPermissionUtil.check(
-			PermissionThreadLocal.getPermissionChecker(), ddmStructure,
-			ActionKeys.VIEW);
-
 		DDMForm ddmForm = ddmStructure.getDDMForm();
 
 		DDMFormRenderingContext ddmFormRenderingContext =


### PR DESCRIPTION
Related issue: https://liferay.atlassian.net/browse/LPS-204394