### PR TITLE
LPS-198962-reverts

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
@@ -334,12 +334,10 @@ export function FieldBase({
 						)}
 						disabled={readOnly}
 						onClick={() =>
-							setTimeout(() => {
-								dispatch({
-									payload: name,
-									type: CORE_EVENT_TYPES.FIELD.REPEATED,
-								});
-							}, 200)
+							dispatch({
+								payload: name,
+								type: CORE_EVENT_TYPES.FIELD.REPEATED,
+							})
 						}
 						small
 						title={Liferay.Language.get('duplicate')}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Text/Text.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Text/Text.es.js
@@ -515,16 +515,7 @@ const Main = ({
 				name={name}
 				normalizeField={normalizeField}
 				onBlur={onBlur}
-				onChange={(event) => {
-					if (
-						!event?.relatedTarget ||
-						(event?.realatedTarget &&
-							event?.relatedTarget?.dataset?.restoreTitle !==
-								'Duplicate')
-					) {
-						onChange(event);
-					}
-				}}
+				onChange={onChange}
 				onFocus={onFocus}
 				onKeyDown={onKeyDown}
 				options={optionsMemo}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Text/Text.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Text/Text.es.js
@@ -63,7 +63,6 @@ const CounterContainer = ({
 };
 
 const Text = ({
-	accessibleProps,
 	defaultLanguageId,
 	disabled,
 	displayErrors,
@@ -80,7 +79,6 @@ const Text = ({
 	onBlur,
 	onChange,
 	onFocus,
-	onKeyDown,
 	placeholder,
 	setError,
 	shouldUpdateValue,

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Text/Text.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Text/Text.es.js
@@ -147,9 +147,8 @@ const Text = ({
 
 			event.target.value = value.replace(regex, '');
 		}
-
-		onChange(event);
 		setValue(event.target.value);
+		onChange(event);
 	};
 
 	return (

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Text/Text.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Text/Text.es.js
@@ -136,51 +136,44 @@ const Text = ({
 		shouldUpdateValue,
 	]);
 
-	const handleChangeInput = (event) => {
-		const {value} = event.target;
-
-		if (normalizeField) {
-			event.target.value = normalizeFieldName(value);
-		}
-		else if (invalidCharacters) {
-			const regex = new RegExp(invalidCharacters, 'g');
-
-			event.target.value = value.replace(regex, '');
-		}
-		setValue(event.target.value);
-		onChange(event);
-	};
-
 	return (
 		<>
-			<ClayTooltipProvider autoAlign>
-				<div
-					data-tooltip-align="top"
-					{...getTooltipTitle({placeholder, value})}
-				>
-					<ClayInput
-						{...accessibleProps}
-						className="ddm-field-text"
-						dir={Liferay.Language.direction[editingLanguageId]}
-						disabled={disabled}
-						id={id}
-						lang={editingLanguageId?.replaceAll('_', '-')}
-						maxLength={showCounter ? '' : maxLength}
-						name={name}
-						onBlur={(event) => {
-							onBlur(event);
-							handleChangeInput(event);
-						}}
-						onChange={handleChangeInput}
-						onFocus={onFocus}
-						onKeyDown={onKeyDown}
-						placeholder={placeholder}
-						ref={inputRef}
-						type="text"
-						value={value}
-					/>
-				</div>
-			</ClayTooltipProvider>
+			<ClayInput
+				className="ddm-field-text"
+				dir={Liferay.Language.direction[editingLanguageId]}
+				disabled={disabled}
+				id={id}
+				lang={editingLanguageId}
+				maxLength={showCounter ? '' : maxLength}
+				name={name}
+				onBlur={(event) => {
+					if (normalizeField) {
+						onBlur({target: {value: initialValue}});
+					}
+					else {
+						onBlur(event);
+					}
+				}}
+				onChange={(event) => {
+					const {value} = event.target;
+
+					if (normalizeField) {
+						event.target.value = normalizeFieldName(value);
+					}
+					else if (invalidCharacters) {
+						const regex = new RegExp(invalidCharacters, 'g');
+
+						event.target.value = value.replace(regex, '');
+					}
+					setValue(event.target.value);
+					onChange(event);
+				}}
+				onFocus={onFocus}
+				placeholder={placeholder}
+				ref={inputRef}
+				type="text"
+				value={value}
+			/>
 
 			<CounterContainer
 				counter={value?.length}


### PR DESCRIPTION
# Jira Link
- https://liferay.atlassian.net/browse/LPS-198962

# General Info
- All commits from [LPS-153738](https://liferay.atlassian.net/browse/LPS-153738) are being reverted since they cause the issue reported on the ticket above.

   - The issue lies on the attribution of onChange event functionality to onBlur, causing the onChange to be executed two times resulting in a double refresh, which caused the fields to vanish.
   
   - Fixes the collision of events.
   
- Some commits from [LPS-198962](https://liferay.atlassian.net/browse/LPS-198962) are being reverted since they are no longer needed to fix the issue.
   
   - We don't need to handle events collision anymore, therefore we need to get rid of the timeout.
   
   - The only commit which will stay is related to the conflict between the validation time and the field addition event, by making the validation faster we avoid and minimize the vanishing cases when we click the add button and the validation isn't completed.