### PR TITLE
LPS-203557 Error Uncaught TypeError: Cannot read properties of undefined (reading 'dateFieldName')

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Validation/ValidationDate.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Validation/ValidationDate.js
@@ -77,6 +77,25 @@ export default function ValidationDate({
 	validations,
 	visible,
 }) {
+	const initialParameter = {
+		endsOn: {
+			date: 'responseDate',
+			unit: 'days',
+			quantity: 1,
+			type: 'responseDate'
+		},
+		startsFrom: {
+			date: 'responseDate',
+			unit: 'days',
+			quantity: 1,
+			type: 'responseDate'
+		}
+	}
+
+	if(parameter["en_US"] === void(0)) {
+		parameter["en_US"] = initialParameter
+	}
+
 	const startDate = getFromParameter(parameter, 'startsFrom', localizedValue);
 	const endDate = getFromParameter(parameter, 'endsOn', localizedValue);
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Validation/ValidationDate.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Validation/ValidationDate.js
@@ -80,20 +80,20 @@ export default function ValidationDate({
 	const initialParameter = {
 		endsOn: {
 			date: 'responseDate',
-			unit: 'days',
 			quantity: 1,
-			type: 'responseDate'
+			type: 'responseDate',
+			unit: 'days',
 		},
 		startsFrom: {
 			date: 'responseDate',
-			unit: 'days',
 			quantity: 1,
-			type: 'responseDate'
-		}
-	}
+			type: 'responseDate',
+			unit: 'days',
+		},
+	};
 
-	if(parameter["en_US"] === void(0)) {
-		parameter["en_US"] = initialParameter
+	if (parameter['en_US'] === void 0) {
+		parameter['en_US'] = initialParameter;
 	}
 
 	const startDate = getFromParameter(parameter, 'startsFrom', localizedValue);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormAdminDisplayContext.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormAdminDisplayContext.java
@@ -99,6 +99,7 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.LocaleThreadLocal;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
@@ -386,7 +387,7 @@ public class DDMFormAdminDisplayContext {
 			ddmFormRenderingContext.setContainerId("settings");
 			ddmFormRenderingContext.setGroupId(getScopeGroupId());
 			ddmFormRenderingContext.setLocale(
-				LocaleUtil.fromLanguageId(getDefaultLanguageId()));
+				LocaleThreadLocal.getThemeDisplayLocale());
 			ddmFormRenderingContext.setPortletNamespace(
 				renderResponse.getNamespace());
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/internal/form/renderer/test/DDMFormTemplateContextFactoryTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/internal/form/renderer/test/DDMFormTemplateContextFactoryTest.java
@@ -23,6 +23,7 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
@@ -376,12 +377,13 @@ public class DDMFormTemplateContextFactoryTest {
 			HashMapBuilder.put(
 				"dateRange",
 				"futureDates({name}, \"{parameter}\") AND pastDates({name}, " +
-					"\"{parameter}\")"
+				"\"{parameter}\")"
 			).put(
 				"futureDates", "futureDates({name}, \"{parameter}\")"
 			).put(
 				"pastDates", "pastDates({name}, \"{parameter}\")"
-			).build());
+			).build(),
+			LocaleUtil.US);
 
 		_assertValidations(
 			actualValidationsMap, "numeric",
@@ -397,7 +399,8 @@ public class DDMFormTemplateContextFactoryTest {
 				"lteq", "{name} <= {parameter}"
 			).put(
 				"neq", "{name} != {parameter}"
-			).build());
+			).build(),
+			LocaleUtil.US);
 
 		_assertValidations(
 			actualValidationsMap, "string",
@@ -411,7 +414,68 @@ public class DDMFormTemplateContextFactoryTest {
 				"regularExpression", "match({name}, \"{parameter}\")"
 			).put(
 				"url", "isURL({name})"
-			).build());
+			).build(),
+			LocaleUtil.US);
+
+		ddmFormTemplateContext = builder.withHttpServletRequest(
+			_httpServletRequest
+		).withLocale(
+			LocaleUtil.BRAZIL
+		).build();
+
+		actualValidationsMap =
+			(HashMap<String, Object>)ddmFormTemplateContext.get("validations");
+
+		Assert.assertEquals(
+			actualValidationsMap.toString(), 3, actualValidationsMap.size());
+		Assert.assertTrue(actualValidationsMap.containsKey("date"));
+		Assert.assertTrue(actualValidationsMap.containsKey("numeric"));
+		Assert.assertTrue(actualValidationsMap.containsKey("string"));
+
+		_assertValidations(
+			actualValidationsMap, "date",
+			HashMapBuilder.put(
+				"dateRange",
+				"futureDates({name}, \"{parameter}\") AND pastDates({name}, " +
+				"\"{parameter}\")"
+			).put(
+				"futureDates", "futureDates({name}, \"{parameter}\")"
+			).put(
+				"pastDates", "pastDates({name}, \"{parameter}\")"
+			).build(),
+			LocaleUtil.BRAZIL);
+
+		_assertValidations(
+			actualValidationsMap, "numeric",
+			HashMapBuilder.put(
+				"eq", "{name} == {parameter}"
+			).put(
+				"gt", "{name} > {parameter}"
+			).put(
+				"gteq", "{name} >= {parameter}"
+			).put(
+				"lt", "{name} < {parameter}"
+			).put(
+				"lteq", "{name} <= {parameter}"
+			).put(
+				"neq", "{name} != {parameter}"
+			).build(),
+			LocaleUtil.BRAZIL);
+
+		_assertValidations(
+			actualValidationsMap, "string",
+			HashMapBuilder.put(
+				"contains", "contains({name}, \"{parameter}\")"
+			).put(
+				"email", "isEmailAddress({name})"
+			).put(
+				"notContains", "NOT(contains({name}, \"{parameter}\"))"
+			).put(
+				"regularExpression", "match({name}, \"{parameter}\")"
+			).put(
+				"url", "isURL({name})"
+			).build(),
+			LocaleUtil.BRAZIL);
 	}
 
 	@Test
@@ -432,9 +496,19 @@ public class DDMFormTemplateContextFactoryTest {
 		Assert.assertTrue((boolean)ddmFormTemplateContext.get("viewMode"));
 	}
 
+	private void _assertValidationLabels(
+		String actualValidationLabel, Locale locale,
+		HashMap<Locale, List<String>> expectedLabels) {
+
+		List<String> expectedLocalizedLabels = expectedLabels.get(locale);
+
+		Assert.assertTrue(
+			expectedLocalizedLabels.contains(actualValidationLabel));
+	}
+
 	private void _assertValidations(
 		HashMap<String, Object> actualValidationsMap, String dataType,
-		HashMap<String, String> expectedValidationsMap) {
+		HashMap<String, String> expectedValidationsMap, Locale locale) {
 
 		Object[] actualValidations = (Object[])actualValidationsMap.get(
 			dataType);
@@ -456,6 +530,52 @@ public class DDMFormTemplateContextFactoryTest {
 			Assert.assertEquals(
 				expectedValidationsMap.remove(actualValidationMap.get("name")),
 				actualValidationMap.get("template"));
+
+			if (StringUtil.equals(dataType, "date")) {
+				_assertValidationLabels(
+					(String)actualValidationMap.get("label"), locale,
+					HashMapBuilder.put(
+						LocaleUtil.BRAZIL,
+						Arrays.asList(
+							"Faixa", "Datas futuras", "Datas passadas")
+					).put(
+						LocaleUtil.US,
+						Arrays.asList("Range", "Future Dates", "Past Dates")
+					).build());
+			}
+
+			if (StringUtil.equals(dataType, "numeric")) {
+				_assertValidationLabels(
+					(String)actualValidationMap.get("label"), locale,
+					HashMapBuilder.put(
+						LocaleUtil.BRAZIL,
+						Arrays.asList(
+							"É igual a", "É maior ou igual a", "É maior que",
+							"Não é igual", "É menor ou igual a", "É menor que")
+					).put(
+						LocaleUtil.US,
+						Arrays.asList(
+							"Is Equal To", "Is Greater Than",
+							"Is Greater Than Or Equal To", "Is Less Than",
+							"Is Less Than Or Equal To", "Is Not Equal To")
+					).build());
+			}
+
+			if (StringUtil.equals(dataType, "string")) {
+				_assertValidationLabels(
+					(String)actualValidationMap.get("label"), locale,
+					HashMapBuilder.put(
+						LocaleUtil.BRAZIL,
+						Arrays.asList(
+							"Contêm", "Não contêm", "É um URL", "É um e-mail",
+							"Correspondências")
+					).put(
+						LocaleUtil.US,
+						Arrays.asList(
+							"Contains", "Is an email", "Does Not Contain",
+							"Matches", "Is a URL")
+					).build());
+			}
 		}
 
 		Assert.assertEquals(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/internal/form/renderer/test/DDMFormTemplateContextFactoryTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/internal/form/renderer/test/DDMFormTemplateContextFactoryTest.java
@@ -377,7 +377,7 @@ public class DDMFormTemplateContextFactoryTest {
 			HashMapBuilder.put(
 				"dateRange",
 				"futureDates({name}, \"{parameter}\") AND pastDates({name}, " +
-				"\"{parameter}\")"
+					"\"{parameter}\")"
 			).put(
 				"futureDates", "futureDates({name}, \"{parameter}\")"
 			).put(
@@ -437,7 +437,7 @@ public class DDMFormTemplateContextFactoryTest {
 			HashMapBuilder.put(
 				"dateRange",
 				"futureDates({name}, \"{parameter}\") AND pastDates({name}, " +
-				"\"{parameter}\")"
+					"\"{parameter}\")"
 			).put(
 				"futureDates", "futureDates({name}, \"{parameter}\")"
 			).put(


### PR DESCRIPTION
Hi team,
I am trying to solve the error in date validation when the view language is different from the default.
In the FrontEnd I saw that the broken was occurring because the parameter in ValidationDate.js was coming undefined, so I created a draft to provide a first value. This draft has as content an initial parameter for the validations fields (EndsOn, StartFrom...) and is the same value that is provided in a "normal" scenario when the error does not occur.
The BackEnd change was made to provide the correct translation to the validation labels.
The integration test was made by Mateus Santana before he left.
I am not sure if my explanation is clear, but feel free to contact me.