### PR TITLE
LPD-15313 BuildLang

### DIFF
--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/paths/DataEngineRenderer.path
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/paths/DataEngineRenderer.path
@@ -102,7 +102,7 @@
 </tr>
 <tr>
 	<td>MULTIPLE_SELECTION_OPTION_INDEXED</td>
-	<td>xpath=((//legend[normalize-space(text())='${key_fieldLabel}'])[${fieldIndex}]//following-sibling::div//input//following-sibling::span[normalize-space()='${key_optionValue}']//preceding-sibling::input)[${optionIndex}]</td>
+	<td>xpath=((//label[normalize-space(text())='${key_fieldLabel}'])[${fieldIndex}]//following-sibling::div//input//following-sibling::span[normalize-space()='${key_optionValue}']//preceding-sibling::input)[${optionIndex}]</td>
 	<td></td>
 </tr>
 <tr>

--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/paths/DataEngineRenderer.path
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/paths/DataEngineRenderer.path
@@ -72,7 +72,7 @@
 </tr>
 <tr>
 	<td>GRID_OPTION_INDEXED</td>
-	<td>xpath=(//legend[normalize-space(text())='${key_fieldLabel}'])[${fieldIndex}]//following-sibling::div//tbody/tr[${key_row}]/td[${key_column}]//input</td>
+	<td>xpath=(//label[normalize-space(text())='${key_fieldLabel}'])[${fieldIndex}]//following-sibling::div//tbody/tr[${key_row}]/td[${key_column}]//input</td>
 	<td></td>
 </tr>
 <tr>
@@ -132,7 +132,7 @@
 </tr>
 <tr>
 	<td>SINGLE_SELECTION_OPTION_INDEXED</td>
-	<td>xpath=((//legend[normalize-space(text())='${key_fieldLabel}'])[${fieldIndex}]//following-sibling::div//input//following-sibling::span[normalize-space()='${key_optionValue}']//preceding-sibling::input)[${optionIndex}]</td>
+	<td>xpath=((//label[normalize-space(text())='${key_fieldLabel}'])[${fieldIndex}]//following-sibling::div//input//following-sibling::span[normalize-space()='${key_optionValue}']//preceding-sibling::input)[${optionIndex}]</td>
 	<td></td>
 </tr>
 <tr>
@@ -147,7 +147,7 @@
 </tr>
 <tr>
 	<td>WEB_CONTENT_DISABLED_FIELD</td>
-	<td>xpath=(//div[contains(@data-field-name, '${key_fieldName}')]//input[@disabled=''] | //legend[text()='${key_fieldName}']/..//input[@disabled=''])</td>
+	<td>xpath=(//div[contains(@data-field-name, '${key_fieldName}')]//input[@disabled=''] | //label[text()='${key_fieldName}']/..//input[@disabled=''])</td>
 	<td></td>
 </tr>
 </tbody>

--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/paths/FormViewBuilder.path
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/paths/FormViewBuilder.path
@@ -287,7 +287,7 @@
 </tr>
 <tr>
 	<td>CHECKBOX_AT_FORM_BODY</td>
-	<td>//legend[contains(text(),'${key_fieldName}')]/..//input[contains(@type,'checkbox')]//following-sibling::span[contains(.,'${key_fieldValue}')]/..//input[contains(@type,'checkbox')]</td>
+	<td>//label[contains(text(),'${key_fieldName}')]/..//input[contains(@type,'checkbox')]//following-sibling::span[contains(.,'${key_fieldValue}')]/..//input[contains(@type,'checkbox')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
@@ -433,7 +433,9 @@ export function FieldBase({
 						<fieldset>
 							<legend
 								{...accessiblePropsFields}
-								className="lfr-ddm-legend"
+								className={classNames('lfr-ddm-legend', {
+									'text-muted': showDisabledFieldIcon,
+								})}
 							>
 								{showLabel && label}
 
@@ -465,6 +467,7 @@ export function FieldBase({
 									'ddm-empty': !showLabel && !required,
 									'ddm-label': showLabel || required,
 									'ddm-repeatable': repeatable,
+									'text-muted': showDisabledFieldIcon,
 								})}
 								{...(type === 'select' && {id: id ?? name})}
 							>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
@@ -454,14 +454,14 @@ export function FieldBase({
 								{showLabel && label}
 
 								{required && <RequiredProperty />}
-
-								{tooltip && (
-									<TooltipProperty
-										showPopover={showPopover}
-										tooltip={tooltip}
-									/>
-								)}
 							</label>
+
+							{tooltip && (
+								<TooltipProperty
+									showPopover={showPopover}
+									tooltip={tooltip}
+								/>
+							)}
 
 							{showDisabledFieldIcon && (
 								<TooltipProperty
@@ -495,14 +495,14 @@ export function FieldBase({
 								{required && <RequiredProperty />}
 
 								{hideField && <HideFieldProperty />}
-
-								{showLabel && tooltip && (
-									<TooltipProperty
-										showPopover={showPopover}
-										tooltip={tooltip}
-									/>
-								)}
 							</label>
+
+							{showLabel && tooltip && (
+								<TooltipProperty
+									showPopover={showPopover}
+									tooltip={tooltip}
+								/>
+							)}
 
 							{showDisabledFieldIcon && (
 								<TooltipProperty

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import ClayButton from '@clayui/button';
+import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
 import ClayForm from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import ClayLabel from '@clayui/label';
@@ -137,6 +137,7 @@ const Popover = ({tooltip}) => {
 	return (
 		<ClayPopover
 			alignPosition="right-bottom"
+			closeOnClickOutside
 			data-testid="clayPopover"
 			disableScroll
 			header={Liferay.Language.get('input-mask-format')}
@@ -144,13 +145,24 @@ const Popover = ({tooltip}) => {
 			show={isPopoverVisible}
 			style={{maxWidth: POPOVER_MAX_WIDTH}}
 			trigger={
-				<span
-					className="ddm-tooltip"
-					onMouseOut={() => setIsPopoverVisible(false)}
-					onMouseOver={() => setIsPopoverVisible(true)}
-				>
-					<ClayIcon symbol="question-circle-full" />
-				</span>
+				Liferay.FeatureFlags['LPS-114700'] ? (
+					<ClayButtonWithIcon
+						aria-label={Liferay.Language.get('more-information')}
+						className="c-ml-2 text-secondary"
+						displayType="unstyled"
+						monospaced={false}
+						size="sm"
+						symbol="question-circle-full"
+					/>
+				) : (
+					<span
+						className="ddm-tooltip"
+						onMouseOut={() => setIsPopoverVisible(false)}
+						onMouseOver={() => setIsPopoverVisible(true)}
+					>
+						<ClayIcon symbol="question-circle-full" />
+					</span>
+				)
 			}
 		>
 			<p>{tooltip}</p>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
@@ -128,7 +128,7 @@ const TooltipProperty = ({showPopover = false, tooltip}) => {
 };
 
 const Popover = ({tooltip}) => {
-	const [isPopoverVisible, setPopoverVisible] = useState(false);
+	const [isPopoverVisible, setIsPopoverVisible] = useState(false);
 
 	const POPOVER_IMAGE_HEIGHT = 170;
 	const POPOVER_IMAGE_WIDTH = 232;
@@ -140,14 +140,14 @@ const Popover = ({tooltip}) => {
 			data-testid="clayPopover"
 			disableScroll
 			header={Liferay.Language.get('input-mask-format')}
-			onShowChange={setPopoverVisible}
+			onShowChange={setIsPopoverVisible}
 			show={isPopoverVisible}
 			style={{maxWidth: POPOVER_MAX_WIDTH}}
 			trigger={
 				<span
 					className="ddm-tooltip"
-					onMouseOut={() => setPopoverVisible(false)}
-					onMouseOver={() => setPopoverVisible(true)}
+					onMouseOut={() => setIsPopoverVisible(false)}
+					onMouseOver={() => setIsPopoverVisible(true)}
 				>
 					<ClayIcon symbol="question-circle-full" />
 				</span>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
@@ -109,9 +109,17 @@ const RequiredProperty = () => {
 	);
 };
 
-const TooltipProperty = ({showPopover, tooltip}) => {
+const TooltipProperty = ({showPopover = false, tooltip}) => {
 	return showPopover ? (
 		<Popover tooltip={tooltip} />
+	) : Liferay.FeatureFlags['LPS-114700'] ? (
+		<span
+			className="c-ml-2 text-4 text-secondary"
+			tabIndex={0}
+			title={tooltip}
+		>
+			<ClayIcon symbol="question-circle-full" />
+		</span>
 	) : (
 		<span className="ddm-tooltip" title={tooltip}>
 			<ClayIcon symbol="question-circle-full" />
@@ -164,6 +172,7 @@ export function FieldBase({
 	accessible = true,
 	children,
 	displayErrors,
+	editOnlyInDefaultLanguage,
 	errorMessage,
 	fieldName,
 	fieldReference,
@@ -239,6 +248,11 @@ export function FieldBase({
 
 	const renderLabel =
 		(label && showLabel) || hideField || repeatable || required || tooltip;
+	const showDisabledFieldIcon =
+		Liferay.FeatureFlags['LPS-114700'] &&
+		editOnlyInDefaultLanguage &&
+		showLabel &&
+		readOnly;
 	const showLegend =
 		type === 'checkbox_multiple' ||
 		type === 'grid' ||
@@ -433,6 +447,14 @@ export function FieldBase({
 								)}
 							</legend>
 
+							{showDisabledFieldIcon && (
+								<TooltipProperty
+									tooltip={Liferay.Language.get(
+										'this-field-can-not-be-localized'
+									)}
+								/>
+							)}
+
 							{children}
 						</fieldset>
 					) : (
@@ -464,6 +486,14 @@ export function FieldBase({
 									/>
 								)}
 							</label>
+
+							{showDisabledFieldIcon && (
+								<TooltipProperty
+									tooltip={Liferay.Language.get(
+										'this-field-can-not-be-localized'
+									)}
+								/>
+							)}
 
 							{children}
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
@@ -219,6 +219,7 @@ export function FieldBase({
 	});
 
 	const fieldDetailsId = `${id ?? name}_fieldDetails`;
+	const fieldLabelId = `${id ?? name}_fieldLabel`;
 
 	const hiddenTranslations = useMemo(() => {
 		if (!localizedValue) {
@@ -430,12 +431,13 @@ export function FieldBase({
 			{renderLabel && (
 				<>
 					{showLegend ? (
-						<fieldset>
-							<legend
+						<div aria-labelledby={fieldLabelId} role="group">
+							<label
 								{...accessiblePropsFields}
 								className={classNames('lfr-ddm-legend', {
 									'text-muted': showDisabledFieldIcon,
 								})}
+								id={fieldLabelId}
 							>
 								{showLabel && label}
 
@@ -447,7 +449,7 @@ export function FieldBase({
 										tooltip={tooltip}
 									/>
 								)}
-							</legend>
+							</label>
 
 							{showDisabledFieldIcon && (
 								<TooltipProperty
@@ -458,7 +460,7 @@ export function FieldBase({
 							)}
 
 							{children}
-						</fieldset>
+						</div>
 					) : (
 						<>
 							<label

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
@@ -266,7 +266,7 @@ export function FieldBase({
 		editOnlyInDefaultLanguage &&
 		showLabel &&
 		readOnly;
-	const showLegend =
+	const showGroup =
 		type === 'checkbox_multiple' ||
 		type === 'grid' ||
 		type === 'paragraph' ||
@@ -442,7 +442,7 @@ export function FieldBase({
 
 			{renderLabel && (
 				<>
-					{showLegend ? (
+					{showGroup ? (
 						<div aria-labelledby={fieldLabelId} role="group">
 							<label
 								{...accessiblePropsFields}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/FieldBase/ReactFieldBase.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/FieldBase/ReactFieldBase.es.js
@@ -248,6 +248,26 @@ describe('ReactFieldBase', () => {
 		Liferay.FeatureFlags['LPS-114700'] = false;
 	});
 
+	it('renders the label with info icon and its corresponding styles when the field is non-localizable', () => {
+		Liferay.FeatureFlags['LPS-114700'] = true;
+
+		const {getByLabelText, getByTitle} = render(
+			<FieldBaseWithProvider
+				editOnlyInDefaultLanguage
+				label="my-label"
+				readOnly
+			/>
+		);
+
+		expect(
+			getByTitle('this-field-can-not-be-localized')
+		).toBeInTheDocument();
+
+		expect(getByLabelText('my-label')).toHaveClass('text-muted');
+
+		Liferay.FeatureFlags['LPS-114700'] = false;
+	});
+
 	describe('Hide Field', () => {
 		it('renders the FieldBase with hideField markup', () => {
 			const {getAllByText, getByText} = render(

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
@@ -284,12 +284,13 @@ journalEditArticleDisplayContext.setViewAttributes();
 											sb.append(LanguageUtil.get(request, "the-friendly-url-may-be-modified-to-ensure-uniqueness"));
 											%>
 
-											<clay:icon
-												cssClass="lfr-portal-tooltip"
-												symbol="question-circle-full"
-												title="<%= sb.toString() %>"
-											/>
 										</label>
+
+										<span class="d-inline-block lfr-portal-tooltip text-4 text-secondary" tabindex="0" title="<%= sb.toString() %>">
+											<clay:icon
+												symbol="question-circle-full"
+											/>
+										</span>
 
 										<liferay-friendly-url:input
 											className="<%= JournalArticle.class.getName() %>"

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -19154,6 +19154,7 @@ this-favicon-replaces-the-one-from-the-theme=This favicon replaces the one from 
 this-feature-is-deprecated=This feature is deprecated.
 this-feature-is-in-testing=This feature is in testing. Please use it with caution.
 this-feature-requires-internet-explorer-5.5-and-above=This feature requires Internet Explorer 5.5 and above.
+this-field-can-not-be-localized=This field can not be localized.
 this-field-contains-an-invalid-number=This field contains an invalid number. Only positive numbers between 1 and 1000 are allowed.
 this-field-contains-more-than-25-elements=This field contains more than 25 elements.
 this-field-does-not-apply-if-the-show-all-options-toggle-is-active=This field does not apply if the show all options toggle is active.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
@@ -19148,6 +19148,7 @@ this-favicon-replaces-the-one-from-the-theme=مورد favicon هذا يحل مح
 this-feature-is-deprecated=هذه الميزة مهملة.
 this-feature-is-in-testing=هذه الميزة قيد الاختبار. يُرجى استخدامها بحذر.
 this-feature-requires-internet-explorer-5.5-and-above=هذه الميزة تتطلب Internet Explorer 5.5 أو أحدث.
+this-field-can-not-be-localized=This field can not be localized. (Automatic Copy)
 this-field-contains-an-invalid-number=يحتوي هذا الحقل على رقم غير صالح. يُسمح فقط بالأرقام الإيجابية بين 1 و1000.
 this-field-contains-more-than-25-elements=يحتوي هذا الحقل على أكثر من 25 عنصرًا.
 this-field-does-not-apply-if-the-show-all-options-toggle-is-active=لا ينطبق هذا الحقل إذا كان زر تبديل إظهال جميع الخيارات نشطًا.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
@@ -19148,6 +19148,7 @@ this-favicon-replaces-the-one-from-the-theme=This favicon replaces the one from 
 this-feature-is-deprecated=This feature is deprecated. (Automatic Copy)
 this-feature-is-in-testing=This feature is in testing. Please use it with caution. (Automatic Copy)
 this-feature-requires-internet-explorer-5.5-and-above=Тази функзионалност изисква Internet Explorer 5.5 или по-нова версия.
+this-field-can-not-be-localized=This field can not be localized. (Automatic Copy)
 this-field-contains-an-invalid-number=This field contains an invalid number. Only positive numbers between 1 and 1000 are allowed. (Automatic Copy)
 this-field-contains-more-than-25-elements=This field contains more than 25 elements. (Automatic Copy)
 this-field-does-not-apply-if-the-show-all-options-toggle-is-active=This field does not apply if the show all options toggle is active. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
@@ -19150,6 +19150,7 @@ this-favicon-replaces-the-one-from-the-theme=Aquesta icona de web substitueix la
 this-feature-is-deprecated=Aquesta característica és obsoleta.
 this-feature-is-in-testing=Aquesta funció està en fase de prova. Utilitzeu-la amb cautela.
 this-feature-requires-internet-explorer-5.5-and-above=Aquesta característica requereix d'Internet Explorer 5.5 o superior.
+this-field-can-not-be-localized=This field can not be localized. (Automatic Copy)
 this-field-contains-an-invalid-number=Aquest camp conté un número no vàlid. Només es permeten números positius entre 1 i 1000.
 this-field-contains-more-than-25-elements=Aquest camp conté més de 25 elements.
 this-field-does-not-apply-if-the-show-all-options-toggle-is-active=Aquest camp no s'aplica si el commutador Mostra totes les opcions està activat.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
@@ -19148,6 +19148,7 @@ this-favicon-replaces-the-one-from-the-theme=This favicon replaces the one from 
 this-feature-is-deprecated=This feature is deprecated. (Automatic Copy)
 this-feature-is-in-testing=This feature is in testing. Please use it with caution. (Automatic Copy)
 this-feature-requires-internet-explorer-5.5-and-above=Tato funkcionalita potřebuje Internet Explorer 5.5 a vyšší.
+this-field-can-not-be-localized=This field can not be localized. (Automatic Copy)
 this-field-contains-an-invalid-number=This field contains an invalid number. Only positive numbers between 1 and 1000 are allowed. (Automatic Copy)
 this-field-contains-more-than-25-elements=This field contains more than 25 elements. (Automatic Copy)
 this-field-does-not-apply-if-the-show-all-options-toggle-is-active=This field does not apply if the show all options toggle is active. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
@@ -19148,6 +19148,7 @@ this-favicon-replaces-the-one-from-the-theme=This favicon replaces the one from 
 this-feature-is-deprecated=This feature is deprecated. (Automatic Copy)
 this-feature-is-in-testing=This feature is in testing. Please use it with caution. (Automatic Copy)
 this-feature-requires-internet-explorer-5.5-and-above=This feature requires Internet Explorer 5.5 and above. (Automatic Copy)
+this-field-can-not-be-localized=This field can not be localized. (Automatic Copy)
 this-field-contains-an-invalid-number=This field contains an invalid number. Only positive numbers between 1 and 1000 are allowed. (Automatic Copy)
 this-field-contains-more-than-25-elements=This field contains more than 25 elements. (Automatic Copy)
 this-field-does-not-apply-if-the-show-all-options-toggle-is-active=This field does not apply if the show all options toggle is active. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
@@ -19150,6 +19150,7 @@ this-favicon-replaces-the-one-from-the-theme=Dieses Favicon ersetzt dasjenige de
 this-feature-is-deprecated=Diese Funktion ist veraltet.
 this-feature-is-in-testing=Diese Funktion befindet sich in der Testphase. Bitte verwenden Sie sie mit Vorsicht.
 this-feature-requires-internet-explorer-5.5-and-above=Dieses Feature erfordert Internet Explorer 5.5 oder höher.
+this-field-can-not-be-localized=This field can not be localized. (Automatic Copy)
 this-field-contains-an-invalid-number=Dieses Feld enthält eine ungültige Zahl. Nur positive Zahlen zwischen 1 und 1.000 sind zulässig.
 this-field-contains-more-than-25-elements=Dieses Feld enthält mehr als 25 Elemente.
 this-field-does-not-apply-if-the-show-all-options-toggle-is-active=Dieses Feld wird nicht berücksichtigt, wenn die Option "Alle Optionen anzeigen" aktiviert ist.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
@@ -19148,6 +19148,7 @@ this-favicon-replaces-the-one-from-the-theme=This favicon replaces the one from 
 this-feature-is-deprecated=This feature is deprecated. (Automatic Copy)
 this-feature-is-in-testing=This feature is in testing. Please use it with caution. (Automatic Copy)
 this-feature-requires-internet-explorer-5.5-and-above=Αυτή η λειτουργία απαιτεί Internet Explorer 5.5 και ανώτερο.
+this-field-can-not-be-localized=This field can not be localized. (Automatic Copy)
 this-field-contains-an-invalid-number=This field contains an invalid number. Only positive numbers between 1 and 1000 are allowed. (Automatic Copy)
 this-field-contains-more-than-25-elements=This field contains more than 25 elements. (Automatic Copy)
 this-field-does-not-apply-if-the-show-all-options-toggle-is-active=This field does not apply if the show all options toggle is active. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
@@ -19154,6 +19154,7 @@ this-favicon-replaces-the-one-from-the-theme=This favicon replaces the one from 
 this-feature-is-deprecated=This feature is deprecated.
 this-feature-is-in-testing=This feature is in testing. Please use it with caution.
 this-feature-requires-internet-explorer-5.5-and-above=This feature requires Internet Explorer 5.5 and above.
+this-field-can-not-be-localized=This field can not be localized.
 this-field-contains-an-invalid-number=This field contains an invalid number. Only positive numbers between 1 and 1000 are allowed.
 this-field-contains-more-than-25-elements=This field contains more than 25 elements.
 this-field-does-not-apply-if-the-show-all-options-toggle-is-active=This field does not apply if the show all options toggle is active.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
@@ -19148,6 +19148,7 @@ this-favicon-replaces-the-one-from-the-theme=This favicon replaces the one from 
 this-feature-is-deprecated=This feature is deprecated. (Automatic Copy)
 this-feature-is-in-testing=This feature is in testing. Please use it with caution. (Automatic Copy)
 this-feature-requires-internet-explorer-5.5-and-above=This feature requires Internet Explorer 5.5 and above. (Automatic Copy)
+this-field-can-not-be-localized=This field can not be localized. (Automatic Copy)
 this-field-contains-an-invalid-number=This field contains an invalid number. Only positive numbers between 1 and 1000 are allowed. (Automatic Copy)
 this-field-contains-more-than-25-elements=This field contains more than 25 elements. (Automatic Copy)
 this-field-does-not-apply-if-the-show-all-options-toggle-is-active=This field does not apply if the show all options toggle is active. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_CA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_CA.properties
@@ -19148,6 +19148,7 @@ this-favicon-replaces-the-one-from-the-theme=This favicon replaces the one from 
 this-feature-is-deprecated=This feature is deprecated. (Automatic Copy)
 this-feature-is-in-testing=This feature is in testing. Please use it with caution. (Automatic Copy)
 this-feature-requires-internet-explorer-5.5-and-above=This feature requires Internet Explorer 5.5 and above. (Automatic Copy)
+this-field-can-not-be-localized=This field can not be localized. (Automatic Copy)
 this-field-contains-an-invalid-number=This field contains an invalid number. Only positive numbers between 1 and 1000 are allowed. (Automatic Copy)
 this-field-contains-more-than-25-elements=This field contains more than 25 elements. (Automatic Copy)
 this-field-does-not-apply-if-the-show-all-options-toggle-is-active=This field does not apply if the show all options toggle is active. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
@@ -19148,6 +19148,7 @@ this-favicon-replaces-the-one-from-the-theme=This favicon replaces the one from 
 this-feature-is-deprecated=This feature is deprecated. (Automatic Copy)
 this-feature-is-in-testing=This feature is in testing. Please use it with caution. (Automatic Copy)
 this-feature-requires-internet-explorer-5.5-and-above=This feature requires Internet Explorer 5.5 and above. (Automatic Copy)
+this-field-can-not-be-localized=This field can not be localized. (Automatic Copy)
 this-field-contains-an-invalid-number=This field contains an invalid number. Only positive numbers between 1 and 1000 are allowed. (Automatic Copy)
 this-field-contains-more-than-25-elements=This field contains more than 25 elements. (Automatic Copy)
 this-field-does-not-apply-if-the-show-all-options-toggle-is-active=This field does not apply if the show all options toggle is active. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
@@ -19150,6 +19150,7 @@ this-favicon-replaces-the-one-from-the-theme=Este icono de página reemplaza al 
 this-feature-is-deprecated=Esta característica está en desuso.
 this-feature-is-in-testing=Esta característica está en fase de pruebas. Utilícela con precaución.
 this-feature-requires-internet-explorer-5.5-and-above=Esta característica requiere tener instalado Internet Explorer 5,5 o superior.
+this-field-can-not-be-localized=This field can not be localized. (Automatic Copy)
 this-field-contains-an-invalid-number=Este campo contiene un número inválido. Solo son válidos los números positivos entre 1 y 1000.
 this-field-contains-more-than-25-elements=Este campo contiene más de 25 elementos.
 this-field-does-not-apply-if-the-show-all-options-toggle-is-active=Este campo no se aplica si el botón de alternancia de mostrar todas las opciones está activado.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_AR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_AR.properties
@@ -19150,6 +19150,7 @@ this-favicon-replaces-the-one-from-the-theme=This favicon replaces the one from 
 this-feature-is-deprecated=This feature is deprecated. (Automatic Copy)
 this-feature-is-in-testing=This feature is in testing. Please use it with caution. (Automatic Copy)
 this-feature-requires-internet-explorer-5.5-and-above=Esta característica requiere tener instalado Internet Explorer 5,5 o superior.
+this-field-can-not-be-localized=This field can not be localized. (Automatic Copy)
 this-field-contains-an-invalid-number=This field contains an invalid number. Only positive numbers between 1 and 1000 are allowed. (Automatic Copy)
 this-field-contains-more-than-25-elements=This field contains more than 25 elements. (Automatic Copy)
 this-field-does-not-apply-if-the-show-all-options-toggle-is-active=This field does not apply if the show all options toggle is active. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
@@ -19150,6 +19150,7 @@ this-favicon-replaces-the-one-from-the-theme=This favicon replaces the one from 
 this-feature-is-deprecated=This feature is deprecated. (Automatic Copy)
 this-feature-is-in-testing=This feature is in testing. Please use it with caution. (Automatic Copy)
 this-feature-requires-internet-explorer-5.5-and-above=Esta característica requiere tener instalado Internet Explorer 5,5 o superior.
+this-field-can-not-be-localized=This field can not be localized. (Automatic Copy)
 this-field-contains-an-invalid-number=This field contains an invalid number. Only positive numbers between 1 and 1000 are allowed. (Automatic Copy)
 this-field-contains-more-than-25-elements=This field contains more than 25 elements. (Automatic Copy)
 this-field-does-not-apply-if-the-show-all-options-toggle-is-active=This field does not apply if the show all options toggle is active. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_MX.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_MX.properties
@@ -19150,6 +19150,7 @@ this-favicon-replaces-the-one-from-the-theme=This favicon replaces the one from 
 this-feature-is-deprecated=This feature is deprecated. (Automatic Copy)
 this-feature-is-in-testing=This feature is in testing. Please use it with caution. (Automatic Copy)
 this-feature-requires-internet-explorer-5.5-and-above=Esta característica requiere tener instalado Internet Explorer 5,5 o superior.
+this-field-can-not-be-localized=This field can not be localized. (Automatic Copy)
 this-field-contains-an-invalid-number=This field contains an invalid number. Only positive numbers between 1 and 1000 are allowed. (Automatic Copy)
 this-field-contains-more-than-25-elements=This field contains more than 25 elements. (Automatic Copy)
 this-field-does-not-apply-if-the-show-all-options-toggle-is-active=This field does not apply if the show all options toggle is active. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
@@ -19148,6 +19148,7 @@ this-favicon-replaces-the-one-from-the-theme=This favicon replaces the one from 
 this-feature-is-deprecated=This feature is deprecated. (Automatic Copy)
 this-feature-is-in-testing=This feature is in testing. Please use it with caution. (Automatic Copy)
 this-feature-requires-internet-explorer-5.5-and-above=See funktsioon eeldab Internet Explorer 5.5 või uuemat versiooni.
+this-field-can-not-be-localized=This field can not be localized. (Automatic Copy)
 this-field-contains-an-invalid-number=This field contains an invalid number. Only positive numbers between 1 and 1000 are allowed. (Automatic Copy)
 this-field-contains-more-than-25-elements=This field contains more than 25 elements. (Automatic Copy)
 this-field-does-not-apply-if-the-show-all-options-toggle-is-active=This field does not apply if the show all options toggle is active. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
@@ -19148,6 +19148,7 @@ this-favicon-replaces-the-one-from-the-theme=This favicon replaces the one from 
 this-feature-is-deprecated=This feature is deprecated. (Automatic Copy)
 this-feature-is-in-testing=This feature is in testing. Please use it with caution. (Automatic Copy)
 this-feature-requires-internet-explorer-5.5-and-above=Ezaugarri honek Internet Explorer 5.5 edo berriagoa instalatuta edukitzeko eskatzen du.
+this-field-can-not-be-localized=This field can not be localized. (Automatic Copy)
 this-field-contains-an-invalid-number=Eremu honek balio ez duen zenbaki bat du. 1 eta 1000 arteko zenbaki positiboak bakarrik onartzen dira.
 this-field-contains-more-than-25-elements=This field contains more than 25 elements. (Automatic Copy)
 this-field-does-not-apply-if-the-show-all-options-toggle-is-active=This field does not apply if the show all options toggle is active. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
@@ -19148,6 +19148,7 @@ this-favicon-replaces-the-one-from-the-theme=This favicon replaces the one from 
 this-feature-is-deprecated=This feature is deprecated. (Automatic Copy)
 this-feature-is-in-testing=This feature is in testing. Please use it with caution. (Automatic Copy)
 this-feature-requires-internet-explorer-5.5-and-above=این ویژگی به مرورگر اینترنت IE نسخه 5.5 به بالا نیاز دارد
+this-field-can-not-be-localized=This field can not be localized. (Automatic Copy)
 this-field-contains-an-invalid-number=This field contains an invalid number. Only positive numbers between 1 and 1000 are allowed. (Automatic Copy)
 this-field-contains-more-than-25-elements=This field contains more than 25 elements. (Automatic Copy)
 this-field-does-not-apply-if-the-show-all-options-toggle-is-active=This field does not apply if the show all options toggle is active. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
@@ -19146,6 +19146,7 @@ this-favicon-replaces-the-one-from-the-theme=Tämä favicon korvaa pääteeman f
 this-feature-is-deprecated=Tämä ominaisuus on vanhentunut.
 this-feature-is-in-testing=Tämä ominaisuus on testattavana. Käytä sitä varoen.
 this-feature-requires-internet-explorer-5.5-and-above=Tämä toiminto vaatii Internet Explorer 5.5 tai tuoreemman selaimen.
+this-field-can-not-be-localized=This field can not be localized. (Automatic Copy)
 this-field-contains-an-invalid-number=Tämä kenttä sisältää virheellisen luvun. Vain positiiviset luvut välillä 1–1 000 sallitaan.
 this-field-contains-more-than-25-elements=Tämä kenttä sisältää yli 25 elementtiä.
 this-field-does-not-apply-if-the-show-all-options-toggle-is-active=Tätä kenttää ei käytetä, jos "näytä kaikki vaihtoehdot" -valitsin on aktiivinen.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
@@ -19150,6 +19150,7 @@ this-favicon-replaces-the-one-from-the-theme=Ce favicon remplace celui du thème
 this-feature-is-deprecated=Cette fonctionnalité est obsolète.
 this-feature-is-in-testing=Cette fonctionnalité est en cours de test. Veuillez l'utiliser avec prudence.
 this-feature-requires-internet-explorer-5.5-and-above=Ce dispositif exige Internet Explorer 5.5 ou plus.
+this-field-can-not-be-localized=This field can not be localized. (Automatic Copy)
 this-field-contains-an-invalid-number=Ce champ contient un numéro invalide. Seuls les nombres positifs entre 1 et 1000 sont autorisés.
 this-field-contains-more-than-25-elements=Ce champ contient plus de 25 éléments.
 this-field-does-not-apply-if-the-show-all-options-toggle-is-active=Ce champ ne s'applique pas si Afficher toutes les options est actif.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
@@ -19148,6 +19148,7 @@ this-favicon-replaces-the-one-from-the-theme=This favicon replaces the one from 
 this-feature-is-deprecated=This feature is deprecated. (Automatic Copy)
 this-feature-is-in-testing=This feature is in testing. Please use it with caution. (Automatic Copy)
 this-feature-requires-internet-explorer-5.5-and-above=Ce dispositif exige Internet Explorer 5.5 ou plus.
+this-field-can-not-be-localized=This field can not be localized. (Automatic Copy)
 this-field-contains-an-invalid-number=This field contains an invalid number. Only positive numbers between 1 and 1000 are allowed. (Automatic Copy)
 this-field-contains-more-than-25-elements=This field contains more than 25 elements. (Automatic Copy)
 this-field-does-not-apply-if-the-show-all-options-toggle-is-active=This field does not apply if the show all options toggle is active. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
@@ -19148,6 +19148,7 @@ this-favicon-replaces-the-one-from-the-theme=This favicon replaces the one from 
 this-feature-is-deprecated=This feature is deprecated. (Automatic Copy)
 this-feature-is-in-testing=This feature is in testing. Please use it with caution. (Automatic Copy)
 this-feature-requires-internet-explorer-5.5-and-above=Esta característica require ter instalado internet explorer 5.5 ou superior.
+this-field-can-not-be-localized=This field can not be localized. (Automatic Copy)
 this-field-contains-an-invalid-number=This field contains an invalid number. Only positive numbers between 1 and 1000 are allowed. (Automatic Copy)
 this-field-contains-more-than-25-elements=This field contains more than 25 elements. (Automatic Copy)
 this-field-does-not-apply-if-the-show-all-options-toggle-is-active=This field does not apply if the show all options toggle is active. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
@@ -19148,6 +19148,7 @@ this-favicon-replaces-the-one-from-the-theme=This favicon replaces the one from 
 this-feature-is-deprecated=This feature is deprecated. (Automatic Copy)
 this-feature-is-in-testing=This feature is in testing. Please use it with caution. (Automatic Copy)
 this-feature-requires-internet-explorer-5.5-and-above=इस feature को इंटरनेट एक्सप्लोरर 5.5 और इसके बाद के version की आवश्यकता है|
+this-field-can-not-be-localized=This field can not be localized. (Automatic Copy)
 this-field-contains-an-invalid-number=This field contains an invalid number. Only positive numbers between 1 and 1000 are allowed. (Automatic Copy)
 this-field-contains-more-than-25-elements=This field contains more than 25 elements. (Automatic Copy)
 this-field-does-not-apply-if-the-show-all-options-toggle-is-active=This field does not apply if the show all options toggle is active. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
@@ -19148,6 +19148,7 @@ this-favicon-replaces-the-one-from-the-theme=This favicon replaces the one from 
 this-feature-is-deprecated=This feature is deprecated. (Automatic Copy)
 this-feature-is-in-testing=This feature is in testing. Please use it with caution. (Automatic Copy)
 this-feature-requires-internet-explorer-5.5-and-above=Ovo svojstvo zahtjeva Internet Explorer 5.5 i iznad.
+this-field-can-not-be-localized=This field can not be localized. (Automatic Copy)
 this-field-contains-an-invalid-number=This field contains an invalid number. Only positive numbers between 1 and 1000 are allowed. (Automatic Copy)
 this-field-contains-more-than-25-elements=This field contains more than 25 elements. (Automatic Copy)
 this-field-does-not-apply-if-the-show-all-options-toggle-is-active=This field does not apply if the show all options toggle is active. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
@@ -19151,6 +19151,7 @@ this-favicon-replaces-the-one-from-the-theme=Ez a favicon lecseréli a témábó
 this-feature-is-deprecated=Ez a funkció elavult.
 this-feature-is-in-testing=Ez a funkció tesztelés alatt áll. Használja körültekintően.
 this-feature-requires-internet-explorer-5.5-and-above=Ehhez funkcióhoz Internet Explorer 5.5 vagy későbbi szükséges.
+this-field-can-not-be-localized=This field can not be localized. (Automatic Copy)
 this-field-contains-an-invalid-number=Ez a mező érvénytelen számot tartalmaz. Csak 1 és 1000 közötti pozitív számok engedélyezettek.
 this-field-contains-more-than-25-elements=Ez a mező több mint 25 elemet tartalmaz.
 this-field-does-not-apply-if-the-show-all-options-toggle-is-active=Ez a mező nem érvényes, ha az Összes lehetőség megjelenítése váltó aktív.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
@@ -19148,6 +19148,7 @@ this-favicon-replaces-the-one-from-the-theme=This favicon replaces the one from 
 this-feature-is-deprecated=This feature is deprecated. (Automatic Copy)
 this-feature-is-in-testing=This feature is in testing. Please use it with caution. (Automatic Copy)
 this-feature-requires-internet-explorer-5.5-and-above=Fitur ini membutuhkan Internet Explorer 5.5 dan di atasnya.
+this-field-can-not-be-localized=This field can not be localized. (Automatic Copy)
 this-field-contains-an-invalid-number=This field contains an invalid number. Only positive numbers between 1 and 1000 are allowed. (Automatic Copy)
 this-field-contains-more-than-25-elements=This field contains more than 25 elements. (Automatic Copy)
 this-field-does-not-apply-if-the-show-all-options-toggle-is-active=This field does not apply if the show all options toggle is active. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
@@ -19149,6 +19149,7 @@ this-favicon-replaces-the-one-from-the-theme=This favicon replaces the one from 
 this-feature-is-deprecated=This feature is deprecated. (Automatic Copy)
 this-feature-is-in-testing=This feature is in testing. Please use it with caution. (Automatic Copy)
 this-feature-requires-internet-explorer-5.5-and-above=Queste funzionalità richiedono una versione di Internet Explorer 5.5 o superiore.
+this-field-can-not-be-localized=This field can not be localized. (Automatic Copy)
 this-field-contains-an-invalid-number=This field contains an invalid number. Only positive numbers between 1 and 1000 are allowed. (Automatic Copy)
 this-field-contains-more-than-25-elements=This field contains more than 25 elements. (Automatic Copy)
 this-field-does-not-apply-if-the-show-all-options-toggle-is-active=This field does not apply if the show all options toggle is active. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
@@ -19148,6 +19148,7 @@ this-favicon-replaces-the-one-from-the-theme=This favicon replaces the one from 
 this-feature-is-deprecated=This feature is deprecated. (Automatic Copy)
 this-feature-is-in-testing=This feature is in testing. Please use it with caution. (Automatic Copy)
 this-feature-requires-internet-explorer-5.5-and-above=תכונה זו דורשת דפדפן Explorer 5.5 ומעלה
+this-field-can-not-be-localized=This field can not be localized. (Automatic Copy)
 this-field-contains-an-invalid-number=This field contains an invalid number. Only positive numbers between 1 and 1000 are allowed. (Automatic Copy)
 this-field-contains-more-than-25-elements=This field contains more than 25 elements. (Automatic Copy)
 this-field-does-not-apply-if-the-show-all-options-toggle-is-active=This field does not apply if the show all options toggle is active. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
@@ -19150,6 +19150,7 @@ this-favicon-replaces-the-one-from-the-theme=この favicon はテーマの favi
 this-feature-is-deprecated=この機能は廃止予定です。
 this-feature-is-in-testing=この機能はテスト中です。注意して使用してください。
 this-feature-requires-internet-explorer-5.5-and-above=この機能を利用するにはInternet Explorer 5.5以上が必要です。
+this-field-can-not-be-localized=This field can not be localized. (Automatic Copy)
 this-field-contains-an-invalid-number=このフィールドには無効な数値が含まれています。1 ～ 1000 の正の数値のみを使用できます。
 this-field-contains-more-than-25-elements=このフィールドには 25 を超える数の要素が含まれています。
 this-field-does-not-apply-if-the-show-all-options-toggle-is-active=このフィールドはすべてのオプションを表示するトグルが有効な場合は適用されません。

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
@@ -19148,6 +19148,7 @@ this-favicon-replaces-the-one-from-the-theme=This favicon replaces the one from 
 this-feature-is-deprecated=This feature is deprecated. (Automatic Copy)
 this-feature-is-in-testing=This feature is in testing. Please use it with caution. (Automatic Copy)
 this-feature-requires-internet-explorer-5.5-and-above=This feature requires Internet Explorer 5.5 and above. (Automatic Copy)
+this-field-can-not-be-localized=This field can not be localized. (Automatic Copy)
 this-field-contains-an-invalid-number=This field contains an invalid number. Only positive numbers between 1 and 1000 are allowed. (Automatic Copy)
 this-field-contains-more-than-25-elements=This field contains more than 25 elements. (Automatic Copy)
 this-field-does-not-apply-if-the-show-all-options-toggle-is-active=This field does not apply if the show all options toggle is active. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_km.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_km.properties
@@ -19154,6 +19154,7 @@ this-favicon-replaces-the-one-from-the-theme=This favicon replaces the one from 
 this-feature-is-deprecated=This feature is deprecated. (Automatic Copy)
 this-feature-is-in-testing=This feature is in testing. Please use it with caution. (Automatic Copy)
 this-feature-requires-internet-explorer-5.5-and-above=This feature requires Internet Explorer 5.5 and above.
+this-field-can-not-be-localized=This field can not be localized. (Automatic Copy)
 this-field-contains-an-invalid-number=This field contains an invalid number. Only positive numbers between 1 and 1000 are allowed. (Automatic Copy)
 this-field-contains-more-than-25-elements=This field contains more than 25 elements. (Automatic Copy)
 this-field-does-not-apply-if-the-show-all-options-toggle-is-active=This field does not apply if the show all options toggle is active.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
@@ -19147,6 +19147,7 @@ this-favicon-replaces-the-one-from-the-theme=This favicon replaces the one from 
 this-feature-is-deprecated=This feature is deprecated. (Automatic Copy)
 this-feature-is-in-testing=This feature is in testing. Please use it with caution. (Automatic Copy)
 this-feature-requires-internet-explorer-5.5-and-above=이 특징은 인터넷 탐색기 5.5을 의 위에 요구하고.
+this-field-can-not-be-localized=This field can not be localized. (Automatic Copy)
 this-field-contains-an-invalid-number=This field contains an invalid number. Only positive numbers between 1 and 1000 are allowed. (Automatic Copy)
 this-field-contains-more-than-25-elements=This field contains more than 25 elements. (Automatic Copy)
 this-field-does-not-apply-if-the-show-all-options-toggle-is-active=This field does not apply if the show all options toggle is active. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
@@ -19148,6 +19148,7 @@ this-favicon-replaces-the-one-from-the-theme=This favicon replaces the one from 
 this-feature-is-deprecated=This feature is deprecated. (Automatic Copy)
 this-feature-is-in-testing=This feature is in testing. Please use it with caution. (Automatic Copy)
 this-feature-requires-internet-explorer-5.5-and-above=ລັກສະນະຕ່າງໆນີ້ແມ່ນຕ້ອງການ Internet Explorer 5.5 ແລະສູງກວ່າ.
+this-field-can-not-be-localized=This field can not be localized. (Automatic Copy)
 this-field-contains-an-invalid-number=This field contains an invalid number. Only positive numbers between 1 and 1000 are allowed. (Automatic Copy)
 this-field-contains-more-than-25-elements=This field contains more than 25 elements. (Automatic Copy)
 this-field-does-not-apply-if-the-show-all-options-toggle-is-active=This field does not apply if the show all options toggle is active. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
@@ -19148,6 +19148,7 @@ this-favicon-replaces-the-one-from-the-theme=This favicon replaces the one from 
 this-feature-is-deprecated=This feature is deprecated. (Automatic Copy)
 this-feature-is-in-testing=This feature is in testing. Please use it with caution. (Automatic Copy)
 this-feature-requires-internet-explorer-5.5-and-above=Šiai funkcijai reikia "Internet Explorer 5.5" ir naujesnių versijos. (Automatic Translation)
+this-field-can-not-be-localized=This field can not be localized. (Automatic Copy)
 this-field-contains-an-invalid-number=This field contains an invalid number. Only positive numbers between 1 and 1000 are allowed. (Automatic Copy)
 this-field-contains-more-than-25-elements=This field contains more than 25 elements. (Automatic Copy)
 this-field-does-not-apply-if-the-show-all-options-toggle-is-active=This field does not apply if the show all options toggle is active. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
@@ -19148,6 +19148,7 @@ this-favicon-replaces-the-one-from-the-theme=This favicon replaces the one from 
 this-feature-is-deprecated=This feature is deprecated. (Automatic Copy)
 this-feature-is-in-testing=This feature is in testing. Please use it with caution. (Automatic Copy)
 this-feature-requires-internet-explorer-5.5-and-above=Ciri ini memerlukan Internet Explorer 5.5 dan ke atas. (Automatic Translation)
+this-field-can-not-be-localized=This field can not be localized. (Automatic Copy)
 this-field-contains-an-invalid-number=This field contains an invalid number. Only positive numbers between 1 and 1000 are allowed. (Automatic Copy)
 this-field-contains-more-than-25-elements=This field contains more than 25 elements. (Automatic Copy)
 this-field-does-not-apply-if-the-show-all-options-toggle-is-active=This field does not apply if the show all options toggle is active. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
@@ -19148,6 +19148,7 @@ this-favicon-replaces-the-one-from-the-theme=This favicon replaces the one from 
 this-feature-is-deprecated=This feature is deprecated. (Automatic Copy)
 this-feature-is-in-testing=This feature is in testing. Please use it with caution. (Automatic Copy)
 this-feature-requires-internet-explorer-5.5-and-above=Denne funksjonen krever Internet Explorer 5.5 eller nyere.
+this-field-can-not-be-localized=This field can not be localized. (Automatic Copy)
 this-field-contains-an-invalid-number=This field contains an invalid number. Only positive numbers between 1 and 1000 are allowed. (Automatic Copy)
 this-field-contains-more-than-25-elements=This field contains more than 25 elements. (Automatic Copy)
 this-field-does-not-apply-if-the-show-all-options-toggle-is-active=This field does not apply if the show all options toggle is active. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
@@ -19151,6 +19151,7 @@ this-favicon-replaces-the-one-from-the-theme=Dit favorietpictogram vervangt dat 
 this-feature-is-deprecated=Deze functie is afgeschaft.
 this-feature-is-in-testing=Deze functie wordt nog getest. Wees voorzichtig bij het gebruik ervan.
 this-feature-requires-internet-explorer-5.5-and-above=Deze functie vereist Internet Explorer 5.5 of hoger.
+this-field-can-not-be-localized=This field can not be localized. (Automatic Copy)
 this-field-contains-an-invalid-number=Dit veld bevat een ongeldig getal. Alleen positieve getallen tussen 1 en 1.000 zijn toegestaan.
 this-field-contains-more-than-25-elements=Dit veld bevat meer dan 25 elementen.
 this-field-does-not-apply-if-the-show-all-options-toggle-is-active=Dit veld is niet van toepassing als 'Alle opties tonen' is ingeschakeld.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
@@ -19151,6 +19151,7 @@ this-favicon-replaces-the-one-from-the-theme=This favicon replaces the one from 
 this-feature-is-deprecated=This feature is deprecated. (Automatic Copy)
 this-feature-is-in-testing=This feature is in testing. Please use it with caution. (Automatic Copy)
 this-feature-requires-internet-explorer-5.5-and-above=Deze functie vereist Internet Explorer 5.5 en hoger.
+this-field-can-not-be-localized=This field can not be localized. (Automatic Copy)
 this-field-contains-an-invalid-number=This field contains an invalid number. Only positive numbers between 1 and 1000 are allowed. (Automatic Copy)
 this-field-contains-more-than-25-elements=This field contains more than 25 elements. (Automatic Copy)
 this-field-does-not-apply-if-the-show-all-options-toggle-is-active=This field does not apply if the show all options toggle is active. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
@@ -19148,6 +19148,7 @@ this-favicon-replaces-the-one-from-the-theme=This favicon replaces the one from 
 this-feature-is-deprecated=This feature is deprecated. (Automatic Copy)
 this-feature-is-in-testing=This feature is in testing. Please use it with caution. (Automatic Copy)
 this-feature-requires-internet-explorer-5.5-and-above=Ta cecha wymaga Internet Explorer w wersji 5.5 i nowszych.
+this-field-can-not-be-localized=This field can not be localized. (Automatic Copy)
 this-field-contains-an-invalid-number=This field contains an invalid number. Only positive numbers between 1 and 1000 are allowed. (Automatic Copy)
 this-field-contains-more-than-25-elements=This field contains more than 25 elements. (Automatic Copy)
 this-field-does-not-apply-if-the-show-all-options-toggle-is-active=This field does not apply if the show all options toggle is active. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
@@ -19148,6 +19148,7 @@ this-favicon-replaces-the-one-from-the-theme=Este favicon substitui o do tema.
 this-feature-is-deprecated=Este recurso está descontinuado.
 this-feature-is-in-testing=Este recurso está sendo testado no momento. Use-o com cuidado.
 this-feature-requires-internet-explorer-5.5-and-above=Esta funcionalidade requer o Internet Explorer 5.5 ou mais recente.
+this-field-can-not-be-localized=This field can not be localized. (Automatic Copy)
 this-field-contains-an-invalid-number=Este campo contém um número inválido. Apenas números positivos entre 1 e 1000 são permitidos.
 this-field-contains-more-than-25-elements=Este campo contém mais de 25 elementos.
 this-field-does-not-apply-if-the-show-all-options-toggle-is-active=Este campo não se aplica se o seletor da opção exibir tudo estiver ativo.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
@@ -19150,6 +19150,7 @@ this-favicon-replaces-the-one-from-the-theme=This favicon replaces the one from 
 this-feature-is-deprecated=This feature is deprecated. (Automatic Copy)
 this-feature-is-in-testing=This feature is in testing. Please use it with caution. (Automatic Copy)
 this-feature-requires-internet-explorer-5.5-and-above=Esta funcionalidade requer o Internet Explorer 5.5 ou superior.
+this-field-can-not-be-localized=This field can not be localized. (Automatic Copy)
 this-field-contains-an-invalid-number=This field contains an invalid number. Only positive numbers between 1 and 1000 are allowed. (Automatic Copy)
 this-field-contains-more-than-25-elements=This field contains more than 25 elements. (Automatic Copy)
 this-field-does-not-apply-if-the-show-all-options-toggle-is-active=This field does not apply if the show all options toggle is active. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
@@ -19148,6 +19148,7 @@ this-favicon-replaces-the-one-from-the-theme=This favicon replaces the one from 
 this-feature-is-deprecated=This feature is deprecated. (Automatic Copy)
 this-feature-is-in-testing=This feature is in testing. Please use it with caution. (Automatic Copy)
 this-feature-requires-internet-explorer-5.5-and-above=Aceasta facilitate necesita Internet Explorer 5.5 sau orice versiune mai noua.
+this-field-can-not-be-localized=This field can not be localized. (Automatic Copy)
 this-field-contains-an-invalid-number=This field contains an invalid number. Only positive numbers between 1 and 1000 are allowed. (Automatic Copy)
 this-field-contains-more-than-25-elements=This field contains more than 25 elements. (Automatic Copy)
 this-field-does-not-apply-if-the-show-all-options-toggle-is-active=This field does not apply if the show all options toggle is active. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
@@ -19148,6 +19148,7 @@ this-favicon-replaces-the-one-from-the-theme=This favicon replaces the one from 
 this-feature-is-deprecated=This feature is deprecated. (Automatic Copy)
 this-feature-is-in-testing=This feature is in testing. Please use it with caution. (Automatic Copy)
 this-feature-requires-internet-explorer-5.5-and-above=Для использования этой возможности вам потребуется Internet Explorer 5.5 или более новый.
+this-field-can-not-be-localized=This field can not be localized. (Automatic Copy)
 this-field-contains-an-invalid-number=This field contains an invalid number. Only positive numbers between 1 and 1000 are allowed. (Automatic Copy)
 this-field-contains-more-than-25-elements=This field contains more than 25 elements. (Automatic Copy)
 this-field-does-not-apply-if-the-show-all-options-toggle-is-active=This field does not apply if the show all options toggle is active. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
@@ -19148,6 +19148,7 @@ this-favicon-replaces-the-one-from-the-theme=This favicon replaces the one from 
 this-feature-is-deprecated=This feature is deprecated. (Automatic Copy)
 this-feature-is-in-testing=This feature is in testing. Please use it with caution. (Automatic Copy)
 this-feature-requires-internet-explorer-5.5-and-above=Táto vlastnosť vyžaduje Internet Explorer verzie 5.5 alebo vyššej.
+this-field-can-not-be-localized=This field can not be localized. (Automatic Copy)
 this-field-contains-an-invalid-number=This field contains an invalid number. Only positive numbers between 1 and 1000 are allowed. (Automatic Copy)
 this-field-contains-more-than-25-elements=This field contains more than 25 elements. (Automatic Copy)
 this-field-does-not-apply-if-the-show-all-options-toggle-is-active=This field does not apply if the show all options toggle is active. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
@@ -19148,6 +19148,7 @@ this-favicon-replaces-the-one-from-the-theme=This favicon replaces the one from 
 this-feature-is-deprecated=This feature is deprecated. (Automatic Copy)
 this-feature-is-in-testing=This feature is in testing. Please use it with caution. (Automatic Copy)
 this-feature-requires-internet-explorer-5.5-and-above=Za to funkcionalnost morate imeti Internet Explorer 5.5 (ali novejšega).
+this-field-can-not-be-localized=This field can not be localized. (Automatic Copy)
 this-field-contains-an-invalid-number=This field contains an invalid number. Only positive numbers between 1 and 1000 are allowed. (Automatic Copy)
 this-field-contains-more-than-25-elements=This field contains more than 25 elements. (Automatic Copy)
 this-field-does-not-apply-if-the-show-all-options-toggle-is-active=This field does not apply if the show all options toggle is active. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
@@ -19148,6 +19148,7 @@ this-favicon-replaces-the-one-from-the-theme=This favicon replaces the one from 
 this-feature-is-deprecated=This feature is deprecated. (Automatic Copy)
 this-feature-is-in-testing=This feature is in testing. Please use it with caution. (Automatic Copy)
 this-feature-requires-internet-explorer-5.5-and-above=Ова функција захтева Интернет Explorer 5,5 и више.
+this-field-can-not-be-localized=This field can not be localized. (Automatic Copy)
 this-field-contains-an-invalid-number=This field contains an invalid number. Only positive numbers between 1 and 1000 are allowed. (Automatic Copy)
 this-field-contains-more-than-25-elements=This field contains more than 25 elements. (Automatic Copy)
 this-field-does-not-apply-if-the-show-all-options-toggle-is-active=This field does not apply if the show all options toggle is active. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
@@ -19148,6 +19148,7 @@ this-favicon-replaces-the-one-from-the-theme=This favicon replaces the one from 
 this-feature-is-deprecated=This feature is deprecated. (Automatic Copy)
 this-feature-is-in-testing=This feature is in testing. Please use it with caution. (Automatic Copy)
 this-feature-requires-internet-explorer-5.5-and-above=Ova funkcija zahteva Internet Explorer 5,5 i više.
+this-field-can-not-be-localized=This field can not be localized. (Automatic Copy)
 this-field-contains-an-invalid-number=This field contains an invalid number. Only positive numbers between 1 and 1000 are allowed. (Automatic Copy)
 this-field-contains-more-than-25-elements=This field contains more than 25 elements. (Automatic Copy)
 this-field-does-not-apply-if-the-show-all-options-toggle-is-active=This field does not apply if the show all options toggle is active. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
@@ -19148,6 +19148,7 @@ this-favicon-replaces-the-one-from-the-theme=Denna favicon ersätter den från t
 this-feature-is-deprecated=Den här funktionen är inaktuell.
 this-feature-is-in-testing=Den här funktionen testas. Använd den försiktigt.
 this-feature-requires-internet-explorer-5.5-and-above=Den här funktionen kräver Internet Explorer 5.5 eller senare.
+this-field-can-not-be-localized=This field can not be localized. (Automatic Copy)
 this-field-contains-an-invalid-number=Fältet innehåller en ogiltig siffra. Endast positiva tal mellan 1 och 1 000 tillåts.
 this-field-contains-more-than-25-elements=Fältet innehåller fler än 25 element.
 this-field-does-not-apply-if-the-show-all-options-toggle-is-active=Det här fältet gäller inte om växlingsknappen för Visa alla alternativ är aktiv.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
@@ -19148,6 +19148,7 @@ this-favicon-replaces-the-one-from-the-theme=This favicon replaces the one from 
 this-feature-is-deprecated=This feature is deprecated. (Automatic Copy)
 this-feature-is-in-testing=This feature is in testing. Please use it with caution. (Automatic Copy)
 this-feature-requires-internet-explorer-5.5-and-above=இந்த அம்சத்திற்கு Internet Explorer 5.5 மற்றும் அதற்கு மேல் தேவைப்படுகிறது.
+this-field-can-not-be-localized=This field can not be localized. (Automatic Copy)
 this-field-contains-an-invalid-number=This field contains an invalid number. Only positive numbers between 1 and 1000 are allowed. (Automatic Copy)
 this-field-contains-more-than-25-elements=This field contains more than 25 elements. (Automatic Copy)
 this-field-does-not-apply-if-the-show-all-options-toggle-is-active=This field does not apply if the show all options toggle is active. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
@@ -19148,6 +19148,7 @@ this-favicon-replaces-the-one-from-the-theme=This favicon replaces the one from 
 this-feature-is-deprecated=This feature is deprecated. (Automatic Copy)
 this-feature-is-in-testing=This feature is in testing. Please use it with caution. (Automatic Copy)
 this-feature-requires-internet-explorer-5.5-and-above=ฟีเจอร์นี้ต้องใช้ Internet Explorer 5.5 หรือสูงกว่านั้น
+this-field-can-not-be-localized=This field can not be localized. (Automatic Copy)
 this-field-contains-an-invalid-number=This field contains an invalid number. Only positive numbers between 1 and 1000 are allowed. (Automatic Copy)
 this-field-contains-more-than-25-elements=This field contains more than 25 elements. (Automatic Copy)
 this-field-does-not-apply-if-the-show-all-options-toggle-is-active=This field does not apply if the show all options toggle is active. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
@@ -19148,6 +19148,7 @@ this-favicon-replaces-the-one-from-the-theme=This favicon replaces the one from 
 this-feature-is-deprecated=This feature is deprecated. (Automatic Copy)
 this-feature-is-in-testing=This feature is in testing. Please use it with caution. (Automatic Copy)
 this-feature-requires-internet-explorer-5.5-and-above=Bu özellik için Internet Explorer 5.5 ve üstü gerekmektedir.
+this-field-can-not-be-localized=This field can not be localized. (Automatic Copy)
 this-field-contains-an-invalid-number=This field contains an invalid number. Only positive numbers between 1 and 1000 are allowed. (Automatic Copy)
 this-field-contains-more-than-25-elements=This field contains more than 25 elements. (Automatic Copy)
 this-field-does-not-apply-if-the-show-all-options-toggle-is-active=This field does not apply if the show all options toggle is active. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
@@ -19148,6 +19148,7 @@ this-favicon-replaces-the-one-from-the-theme=This favicon replaces the one from 
 this-feature-is-deprecated=This feature is deprecated. (Automatic Copy)
 this-feature-is-in-testing=This feature is in testing. Please use it with caution. (Automatic Copy)
 this-feature-requires-internet-explorer-5.5-and-above=Для використання цієї можливості вам знадобиться Internet Explorer 5.5 або більш новий.
+this-field-can-not-be-localized=This field can not be localized. (Automatic Copy)
 this-field-contains-an-invalid-number=This field contains an invalid number. Only positive numbers between 1 and 1000 are allowed. (Automatic Copy)
 this-field-contains-more-than-25-elements=This field contains more than 25 elements. (Automatic Copy)
 this-field-does-not-apply-if-the-show-all-options-toggle-is-active=This field does not apply if the show all options toggle is active. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
@@ -19148,6 +19148,7 @@ this-favicon-replaces-the-one-from-the-theme=This favicon replaces the one from 
 this-feature-is-deprecated=This feature is deprecated. (Automatic Copy)
 this-feature-is-in-testing=This feature is in testing. Please use it with caution. (Automatic Copy)
 this-feature-requires-internet-explorer-5.5-and-above=Tính năng này yêu cầu IE 5.5 hoặc hơn.
+this-field-can-not-be-localized=This field can not be localized. (Automatic Copy)
 this-field-contains-an-invalid-number=This field contains an invalid number. Only positive numbers between 1 and 1000 are allowed. (Automatic Copy)
 this-field-contains-more-than-25-elements=This field contains more than 25 elements. (Automatic Copy)
 this-field-does-not-apply-if-the-show-all-options-toggle-is-active=This field does not apply if the show all options toggle is active. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
@@ -19150,6 +19150,7 @@ this-favicon-replaces-the-one-from-the-theme=此网站图标会替换主题中�
 this-feature-is-deprecated=此功能已弃用。
 this-feature-is-in-testing=此功能正在测试中。请谨慎使用。
 this-feature-requires-internet-explorer-5.5-and-above=此特性需要使用Internet Explorer 5.5或以上版本。
+this-field-can-not-be-localized=This field can not be localized. (Automatic Copy)
 this-field-contains-an-invalid-number=此字段包含无效数字。只允许输入 1 到 1000 之间的正数。
 this-field-contains-more-than-25-elements=此字段包含超过 25 个元素。
 this-field-does-not-apply-if-the-show-all-options-toggle-is-active=如果"显示所有选项"开关处于打开状态，则此字段不适用。

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
@@ -19149,6 +19149,7 @@ this-favicon-replaces-the-one-from-the-theme=This favicon replaces the one from 
 this-feature-is-deprecated=This feature is deprecated. (Automatic Copy)
 this-feature-is-in-testing=This feature is in testing. Please use it with caution. (Automatic Copy)
 this-feature-requires-internet-explorer-5.5-and-above=這個特點要求Internet Explorer 5.5 或以上版本。
+this-field-can-not-be-localized=This field can not be localized. (Automatic Copy)
 this-field-contains-an-invalid-number=This field contains an invalid number. Only positive numbers between 1 and 1000 are allowed. (Automatic Copy)
 this-field-contains-more-than-25-elements=This field contains more than 25 elements. (Automatic Copy)
 this-field-does-not-apply-if-the-show-all-options-toggle-is-active=This field does not apply if the show all options toggle is active. (Automatic Copy)

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/dynamicdatamapping/DDMEditStructure.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/dynamicdatamapping/DDMEditStructure.path
@@ -187,12 +187,12 @@
 </tr>
 <tr>
 	<td>FORM_FIELD_CONTAINER</td>
-	<td>//label[normalize-space(text())='${key_fieldFieldLabel}']/parent::div[contains(@class,'form-group')] | //legend[normalize-space(text())='${key_fieldFieldLabel}']/parent::fieldset/parent::div[contains(@class,'form-group')]</td>
+	<td>//label[normalize-space(text())='${key_fieldFieldLabel}']/parent::div[contains(@class,'form-group')] | //label[normalize-space(text())='${key_fieldFieldLabel}']/parent::div/parent::div[contains(@class,'form-group')]</td>
 	<td></td>
 </tr>
 <tr>
 	<td>FORM_FIELD_CONTAINER_TARGET</td>
-	<td>//label[normalize-space(text())='${key_targetFieldLabel}']/parent::div[contains(@class,'form-group')] | //legend[normalize-space(text())='${key_targetFieldLabel}']/parent::fieldset/parent::div[contains(@class,'form-group')]</td>
+	<td>//label[normalize-space(text())='${key_targetFieldLabel}']/parent::div[contains(@class,'form-group')] | //label[normalize-space(text())='${key_targetFieldLabel}']/parent::div/parent::div[contains(@class,'form-group')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/dynamicdatamapping/DDMEditStructure.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/dynamicdatamapping/DDMEditStructure.path
@@ -129,12 +129,12 @@
 </tr>
 <tr>
 	<td>SETTINGS_TEXT</td>
-	<td>//label[normalize-space(text())='${key_fieldFieldLabel}']//following-sibling::div[contains(@class,'form-feedback-group')] | //legend[normalize-space(text())='${key_fieldFieldLabel}']/..//following-sibling::div[contains(@class,'form-feedback-group')]</td>
+	<td>//label[normalize-space(text())='${key_fieldFieldLabel}']//following-sibling::div[contains(@class,'form-feedback-group')] | //label[normalize-space(text())='${key_fieldFieldLabel}']/..//following-sibling::div[contains(@class,'form-feedback-group')]</td>
 	<td></td>
 </tr>
 <tr>
 	<td>SETTINGS_TEXT_ANY</td>
-	<td>xpath=(//label[normalize-space(text())='${key_fieldFieldLabel}']//following-sibling::div[contains(@class,'form-feedback-group')] | //legend[normalize-space(text())='${key_fieldFieldLabel}']//following-sibling::div[contains(@class,'form-feedback-group')])[${key_index}]</td>
+	<td>xpath=(//label[normalize-space(text())='${key_fieldFieldLabel}']//following-sibling::div[contains(@class,'form-feedback-group')] | //label[normalize-space(text())='${key_fieldFieldLabel}']//following-sibling::div[contains(@class,'form-feedback-group')])[${key_index}]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/forms/Form.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/forms/Form.path
@@ -448,7 +448,7 @@
 </tr>
 <tr>
 	<td>FIELD_LABEL</td>
-	<td>//div[@data-field-name='${key_fieldName}' and contains(@class,'ddm-field')]//label[contains(@class,'ddm-label')] | //div[contains(@class,'ddm-field-container')]//label[text()='${key_fieldName}'] | //div[@data-field-name='${key_fieldName}' and contains(@class,'ddm-field')]//legend[contains(@class,'lfr-ddm-legend')] | //div[contains(@class,'ddm-field-container')]//legend[text()='${key_fieldName}'] | //div[@class='ddm-field']//label[text()='${key_fieldName}']</td>
+	<td>//div[@data-field-name='${key_fieldName}' and contains(@class,'ddm-field')]//label[contains(@class,'ddm-label')] | //div[contains(@class,'ddm-field-container')]//label[text()='${key_fieldName}'] | //div[@data-field-name='${key_fieldName}' and contains(@class,'ddm-field')]//label[contains(@class,'lfr-ddm-legend')] | //div[contains(@class,'ddm-field-container')]//legend[text()='${key_fieldName}'] | //div[@class='ddm-field']//label[text()='${key_fieldName}']</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/forms/FormFields.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/forms/FormFields.path
@@ -72,7 +72,7 @@
 </tr>
 <tr>
 	<td>FIELD_LABEL_BY_INDEX</td>
-	<td>//div[@data-ddm-page='${key_formPageNumber}']/div[${key_index}]//label[contains(text(),'${key_fieldLabel}')] | //div[@data-ddm-page='${key_formPageNumber}']/div[${key_index}]//legend[contains(text(),'${key_fieldLabel}')]</td>
+	<td>//div[@data-ddm-page='${key_formPageNumber}']/div[${key_index}]//label[contains(text(),'${key_fieldLabel}')] | //div[@data-ddm-page='${key_formPageNumber}']/div[${key_index}]//label[contains(text(),'${key_fieldLabel}')]</td>
 	<td></td>
 </tr>
 <tr>
@@ -182,7 +182,7 @@
 </tr>
 <tr>
 	<td>LABEL</td>
-	<td>//p[contains(text(),'${key_fieldLabel}')] | //label[contains(text(),'${key_fieldLabel}')] | //legend[contains(text(),'${key_fieldLabel}')]</td>
+	<td>//p[contains(text(),'${key_fieldLabel}')] | //label[contains(text(),'${key_fieldLabel}')] | //label[contains(text(),'${key_fieldLabel}')]</td>
 	<td></td>
 </tr>
 <tr>
@@ -207,7 +207,7 @@
 </tr>
 <tr>
 	<td>FIELD_TARGET_LABEL_AND_BODY_TEXT</td>
-	<td>//div[contains(@class,'ddm-drag')]//div[contains(*,'${key_fieldName}')]/*/*[contains(text(),'${key_bodyText}')] | //fieldset//legend[text()='${key_fieldName}']/..//p[text()='${key_bodyText}']</td>
+	<td>//div[contains(@class,'ddm-drag')]//div[contains(*,'${key_fieldName}')]/*/*[contains(text(),'${key_bodyText}')] | //div//label[text()='${key_fieldName}']/..//p[text()='${key_bodyText}']</td>
 	<td></td>
 </tr>
 <tr>
@@ -258,7 +258,7 @@
 </tr>
 <tr>
 	<td>CHECKBOX_LABEL</td>
-	<td>//div[contains(@data-field-name,'${key_fieldName}')]//label | //div[contains(@data-field-name,'${key_fieldName}')]//legend | //div[contains(@class,'custom-control-input')]//div[contains(@data-field-name,'${key_fieldName}')]//label |//label[.//input[@type='checkbox' and contains(@id,'${key_fieldName}') or contains(@name,'${key_fieldName}')]] | //input[contains(@type,'checkbox')]//following-sibling::span[contains(.,'${key_fieldName}')]</td>
+	<td>//div[contains(@data-field-name,'${key_fieldName}')]//label | //div[contains(@data-field-name,'${key_fieldName}')]//label | //div[contains(@class,'custom-control-input')]//div[contains(@data-field-name,'${key_fieldName}')]//label |//label[.//input[@type='checkbox' and contains(@id,'${key_fieldName}') or contains(@name,'${key_fieldName}')]] | //input[contains(@type,'checkbox')]//following-sibling::span[contains(.,'${key_fieldName}')]</td>
 	<td></td>
 </tr>
 <tr>
@@ -273,7 +273,7 @@
 </tr>
 <tr>
 	<td>CHECKBOX_OPTION_LABEL</td>
-	<td>//div[contains(@data-field-name,'${key_fieldName}')]//label[contains(.,'${key_checkboxOption}')]/input[@type='checkbox' and contains(@name,'${key_fieldName}')]/../span | //fieldset//legend[text()='${key_fieldName}']/..//label[contains(.,'${key_checkboxOption}')]/input[@type='checkbox']/../span</td>
+	<td>//div[contains(@data-field-name,'${key_fieldName}')]//label[contains(.,'${key_checkboxOption}')]/input[@type='checkbox' and contains(@name,'${key_fieldName}')]/../span | //div//label[text()='${key_fieldName}']/..//label[contains(.,'${key_checkboxOption}')]/input[@type='checkbox']/../span</td>
 	<td></td>
 </tr>
 <tr>
@@ -489,7 +489,7 @@
 </tr>
 <tr>
 	<td>GRID_OPTIONS_OPTION_CHECKED</td>
-	<td>//div[contains(@data-field-name,'Grid')]//input[contains(@aria-label,'Row: ${key_rowValue}, Column: ${key_columnValue}') and @checked] | //fieldset//legend[text()='Grid']/..//input[contains(@aria-label,'Row: Option 1, Column: Option 1') and @checked]</td>
+	<td>//div[contains(@data-field-name,'Grid')]//input[contains(@aria-label,'Row: ${key_rowValue}, Column: ${key_columnValue}') and @checked] | //div//label[text()='Grid']/..//input[contains(@aria-label,'Row: Option 1, Column: Option 1') and @checked]</td>
 	<td></td>
 </tr>
 <tr>
@@ -504,7 +504,7 @@
 </tr>
 <tr>
 	<td>GRID_RADIO_OPTIONS</td>
-	<td>//div[contains(@data-field-name,'${key_fieldName}')]//input[contains(@aria-label, '${key_optionNumber}')] | //fieldset//legend[text()='${key_fieldName}']/..//input[contains(@aria-label, '${key_optionNumber}')]</td>
+	<td>//div[contains(@data-field-name,'${key_fieldName}')]//input[contains(@aria-label, '${key_optionNumber}')] | //div//label[text()='${key_fieldName}']/..//input[contains(@aria-label, '${key_optionNumber}')]</td>
 	<td></td>
 </tr>
 <tr>
@@ -519,12 +519,12 @@
 </tr>
 <tr>
 	<td>GRID_OPTIONS_OPTION_ROW_NAME</td>
-	<td>//legend[text()='${key_fieldName}']/following-sibling::div[1]//..//tr[${key_rowNumber}]/td[contains(.,'${key_optionName}')]</td>
+	<td>//label[text()='${key_fieldName}']/following-sibling::div[1]//..//tr[${key_rowNumber}]/td[contains(.,'${key_optionName}')]</td>
 	<td></td>
 </tr>
 <tr>
 	<td>GRID_OPTIONS_OPTION_COL_NAME</td>
-	<td>//legend[text()='${key_fieldName}']/following-sibling::div[1]//..//tr[${key_rowNumber}]/th[contains(.,'${key_optionName}')]</td>
+	<td>//label[text()='${key_fieldName}']/following-sibling::div[1]//..//tr[${key_rowNumber}]/th[contains(.,'${key_optionName}')]</td>
 	<td></td>
 </tr>
 <tr>
@@ -542,7 +542,7 @@
 </tr>
 <tr>
 	<td>RADIO_OPTION_CHECKED</td>
-	<td>//label[contains(@*,'${key_radioOption}') or contains(.,'${key_radioOption}')]/input[@type='radio' and @checked="checked" and contains(@name,'${key_fieldName}')] | //label[contains(@*,'${key_radioOption}') or contains(.,'${key_radioOption}')]/input[@type='radio' and @checked="" and contains(@name,'${key_fieldName}')] | //fieldset//legend[text()='${key_fieldName}']/..//span[text()='${key_radioOption}'] | //div[@*='${key_fieldName}']//div[contains(@*,'ddm__radio')]//div[@data-checked='true']//descendant::span[text()='${key_radioOption}']</td>
+	<td>//label[contains(@*,'${key_radioOption}') or contains(.,'${key_radioOption}')]/input[@type='radio' and @checked="checked" and contains(@name,'${key_fieldName}')] | //label[contains(@*,'${key_radioOption}') or contains(.,'${key_radioOption}')]/input[@type='radio' and @checked="" and contains(@name,'${key_fieldName}')] | //div//label[text()='${key_fieldName}']/..//span[text()='${key_radioOption}'] | //div[@*='${key_fieldName}']//div[contains(@*,'ddm__radio')]//div[@data-checked='true']//descendant::span[text()='${key_radioOption}']</td>
 	<td></td>
 </tr>
 <tr>
@@ -740,7 +740,7 @@
 </tr>
 <tr>
 	<td>PARAGRAPH_BODY_TEXT_CONTENT</td>
-	<td>//div[(@class='form-group') and contains(@data-field-name,'${key_fieldName}')]//div</td>
+	<td>//div[(@class='form-group liferay-ddm-form-field-paragraph') and contains(@data-field-name,'${key_fieldName}')]//div</td>
 	<td></td>
 </tr>
 <tr>
@@ -765,12 +765,12 @@
 </tr>
 <tr>
 	<td>PARAGRAPH_CONTENT_UNORDERED_LIST</td>
-	<td>//legend[contains(text(),'${key_labelName}')]//..//ul//li[contains(.,'${key_itemName}')]</td>
+	<td>//label[contains(text(),'${key_labelName}')]//..//ul//li[contains(.,'${key_itemName}')]</td>
 	<td></td>
 </tr>
 <tr>
 	<td>PARAGRAPH_CONTENT_ORDERED_LIST</td>
-	<td>//legend[contains(text(),'${key_labelName}')]//..//ol//li[contains(.,'${key_itemName}')]</td>
+	<td>//label[contains(text(),'${key_labelName}')]//..//ol//li[contains(.,'${key_itemName}')]</td>
 	<td></td>
 </tr>
 <tr>
@@ -800,7 +800,7 @@
 </tr>
 <tr>
 	<td>PARAGRAPH_TITLE</td>
-	<td>//div[(@class='form-group') and contains(@data-field-name,'${key_fieldName}')]//legend</td>
+	<td>//div[(@class='form-group') and contains(@data-field-name,'${key_fieldName}')]//label</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/webcontent/WCEditWebContent.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/webcontent/WCEditWebContent.path
@@ -57,7 +57,7 @@
 </tr>
 <tr>
 	<td>GRID_OPTION</td>
-	<td>//legend[normalize-space(text())='${key_fieldFieldLabel}']//following-sibling::div//tbody/tr[${key_row}]/td[${key_column}]//input</td>
+	<td>//label[normalize-space(text())='${key_fieldFieldLabel}']//following-sibling::div//tbody/tr[${key_row}]/td[${key_column}]//input</td>
 	<td></td>
 </tr>
 <tr>
@@ -140,7 +140,7 @@
 </tr>
 <tr>
 	<td>SELECTION_OPTION</td>
-	<td>//legend[normalize-space(text())='${key_fieldFieldLabel}']//following-sibling::div//input//following-sibling::span[normalize-space()='${key_optionValue}']//preceding-sibling::input</td>
+	<td>//label[normalize-space(text())='${key_fieldFieldLabel}']//following-sibling::div//input//following-sibling::span[normalize-space()='${key_optionValue}']//preceding-sibling::input</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
Hi guys, 

In Echo team we are working on a new functionality in editing Web Contents to identify non-localizable fields more easily (https://liferay.atlassian.net/browse/LPD-6819). Therefore, for each non-localizable field, when the language changes, an info icon has been added next to the label with a tooltip, indicating that the field is not localizable, and also the color of the label changes.


https://github.com/liferay-forms/liferay-portal/assets/9701095/7c98738a-7c33-45bd-8626-cd251dc67b49



Improvements have also been made regarding accessibility:
- A tooltip should be opened with a click or keydown events and for this reason the element that launches the tooltip has been changed to a button (https://github.com/liferay-forms/liferay-portal/commit/ad252bcbe8a9d9244e5848749dc5f4c66e732c1f).
- Change a `fieldset` to a `<div role="group" aria-labelledby={labelId}>` and `legend` to `label`. In terms of semantics it is the same and this technique provides additional styling possibilities (https://github.com/liferay-forms/liferay-portal/commit/638f650dd97c239cb03d8b1e1faef67060b84821).


The Feature Flag to test it is `feature.flag.LPS-114700=true`


Thanks in advance! :smile: 
