### PR TITLE
LPD-15620

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-impl/build.gradle
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-impl/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
 	compileInclude group: "com.jayway.jsonpath", name: "json-path", version: "2.2.0"
 	compileInclude group: "com.netflix.archaius", name: "archaius-core", version: "0.4.1"
-	compileInclude group: "com.netflix.hystrix", name: "hystrix-core", version: "1.5.11"
+	compileInclude group: "com.netflix.hystrix", name: "hystrix-core", version: "1.5.18"
 	compileInclude group: "commons-configuration", name: "commons-configuration", version: "1.8"
 	compileInclude group: "commons-io", name: "commons-io", version: "2.11.0"
 	compileInclude group: "io.reactivex", name: "rxjava", version: "1.2.0"

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-impl/src/main/java/com/liferay/dynamic/data/mapping/data/provider/internal/DDMDataProviderInvokeCommand.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-impl/src/main/java/com/liferay/dynamic/data/mapping/data/provider/internal/DDMDataProviderInvokeCommand.java
@@ -43,6 +43,9 @@ public class DDMDataProviderInvokeCommand
 				HystrixCommandProperties.Setter().
 					withExecutionTimeoutInMilliseconds(
 						_getTimeout(ddmRESTDataProviderSettings))
+			).andCommandPropertiesDefaults(
+			   HystrixCommandProperties.Setter()
+					.withExecutionIsolationSemaphoreMaxConcurrentRequests(20)
 			));
 
 		_ddmDataProvider = ddmDataProvider;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-15620

The customer is informing that a data provider object is retaining a huge value on their memory. The intention is to execute the data process faster  (defining a limit to its memory) and treat (on a system configuration level) the GC properties to deal better with old objects. I had good results by changing the setent.sh file on the web server folder and starting the portal with this configuration:

`CATALINA_OPTS="$CATALINA_OPTS -Dfile.encoding=UTF-8 -Djava.locale.providers=JRE,COMPAT,CLDR -Djava.net.preferIPv4Stack=true -Duser.timezone=GMT -XX:NewSize=700m -XX:MaxNewSize=700m -Xms2048m -Xmx2048m -XX:MaxPermSize=128m -XX:+UseParNewGC -XX:+UseConcMarkSweepGC -XX:+CMSParallelRemarkEnabled -XX:SurvivorRatio=20 -XX:ParallelGCThreads=8"`


Analysis: https://github.com/Netflix/Hystrix/wiki/Configuration 

Let me know the necessary changes. If passed review, please let me know which test to implement on this case. 

Thanks =)