### PR TITLE
LPD-15620

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-impl/build.gradle
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-impl/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
 	compileInclude group: "com.jayway.jsonpath", name: "json-path", version: "2.2.0"
 	compileInclude group: "com.netflix.archaius", name: "archaius-core", version: "0.4.1"
-	compileInclude group: "com.netflix.hystrix", name: "hystrix-core", version: "1.5.11"
+	compileInclude group: "com.netflix.hystrix", name: "hystrix-core", version: "1.5.18"
 	compileInclude group: "commons-configuration", name: "commons-configuration", version: "1.8"
 	compileInclude group: "commons-io", name: "commons-io", version: "2.11.0"
 	compileInclude group: "io.reactivex", name: "rxjava", version: "1.2.0"

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-impl/src/main/java/com/liferay/dynamic/data/mapping/data/provider/internal/DDMDataProviderInvokeCommand.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-impl/src/main/java/com/liferay/dynamic/data/mapping/data/provider/internal/DDMDataProviderInvokeCommand.java
@@ -17,6 +17,7 @@ import com.netflix.hystrix.HystrixCommand;
 import com.netflix.hystrix.HystrixCommandGroupKey;
 import com.netflix.hystrix.HystrixCommandKey;
 import com.netflix.hystrix.HystrixCommandProperties;
+import com.netflix.hystrix.HystrixThreadPoolProperties;
 import com.netflix.hystrix.strategy.HystrixPlugins;
 import com.netflix.hystrix.strategy.properties.HystrixPropertiesStrategy;
 
@@ -40,9 +41,17 @@ public class DDMDataProviderInvokeCommand
 				HystrixCommandKey.Factory.asKey(
 					"DDMDataProviderInvokeCommand#" + nameCurrentValue)
 			).andCommandPropertiesDefaults(
-				HystrixCommandProperties.Setter().
-					withExecutionTimeoutInMilliseconds(
+				HystrixCommandProperties.Setter()
+					.withExecutionIsolationStrategy(
+						HystrixCommandProperties.ExecutionIsolationStrategy.THREAD)
+					.withExecutionTimeoutInMilliseconds(
 						_getTimeout(ddmRESTDataProviderSettings))
+					.withFallbackEnabled(false)
+			).andThreadPoolPropertiesDefaults(
+				HystrixThreadPoolProperties.Setter()
+					.withAllowMaximumSizeToDivergeFromCoreSize(true)
+					.withCoreSize(5)
+					.withMetricsRollingStatisticalWindowInMilliseconds(1000)
 			));
 
 		_ddmDataProvider = ddmDataProvider;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-impl/src/main/java/com/liferay/dynamic/data/mapping/data/provider/internal/DDMDataProviderInvokerImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-impl/src/main/java/com/liferay/dynamic/data/mapping/data/provider/internal/DDMDataProviderInvokerImpl.java
@@ -151,7 +151,24 @@ public class DDMDataProviderInvokerImpl implements DDMDataProviderInvoker {
 					ddmDataProviderInstance,
 					DDMRESTDataProviderSettings.class));
 
-		return ddmDataProviderInvokeCommand.execute();
+		DDMDataProviderResponse ddmDataProviderResponse =
+			ddmDataProviderInvokeCommand.execute();
+
+		try {
+			deactivate();
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+			else if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Unable to disable the Data Provider threads from running",
+					exception);
+			}
+		}
+
+		return ddmDataProviderResponse;
 	}
 
 	protected DDMDataProviderInstance fetchDDMDataProviderInstance(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-15620

Upgrading version = This version is from 2018. Since then, Hystrix was descontinued by the Netflix team and the latest fixes related to maintenance are added on this version.

Thread Properties = Avoiding execution being stuck if some external, unpredicted action affects and block the process. According to the documentation "The general principle is keep the pool as small as possible", so I'm changing to a lower base value (default:10). The Maximum value still 10, so, if necessary, will reach all of them. In addition, we're not analyzing metrics, consequently, we don't need this information as much on the thread pool. that's the reason to change from 10000 to 1000.

Command Properties = We are also not treating the fallback cases on our current code. User must retry by themselves. Threads are better then Semaphore in our case to the isolation strategy, also it was noticed a good response through time compared to increasing the max concurrent size of multiple access.

InvokerImpl = Reducing consume that OSGI Classloader took over time after requesting some information to a Data Provider by cleaning the stored value and removing it from the running threads.

It’s safe to say, after a median of the tests, the value from the beginning was reduced at a rate of almost 30% after the changes. That means, the object from the Data Provider itself is not consuming as much during its allocation on the memory usage **during the execution**.  The tests on the *Test class were executed and the usage was tried on different network connections.

Best result on test: Almost 43% - from 325,028,952 (34.60%) to  196,072,392 (20.16%)
![image](https://github.com/liferay-forms/liferay-portal/assets/41641596/ff743f7a-382a-4a7d-ba8f-c41b54a3e7fb) 

All the results can be found here https://docs.google.com/spreadsheets/d/1xra2COzVTr1Ecvdmgyk7LCo_XCqOsk6lTMLO7SR88hA/edit#gid=0

No change of threshhold or change of timeout is indicated, since the field defining the value of this parameter is mandatory for each entry made on Liferay Data Provider, being treated by the class code if it is not in the range. Indication: A rule could be inserted in the numeric field and rendering the notification in the UI, removing validation in the backend. Tell me if it's necessary. Manipulating this attribute is NOT recommended as it may result in failure to load due to factors such as oscillation, speed and high demand.

After all the tests, there is no evident object pointing to the DDM module so far. 

Cheers,
Richard.

