### PR TITLE
LPD-17380 Use the editing language to get the success message according to the set language

### DIFF
--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/custom/form/renderer/SuccessVariant.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/custom/form/renderer/SuccessVariant.es.js
@@ -78,17 +78,17 @@ export function Page({page: {successPageSettings}}) {
 	const {initialBody, initialTitle} = {
 		initialBody:
 			(successPageSettings.body &&
-				(successPageSettings.body[
-					Liferay.ThemeDisplay.getLanguageId()
-				] ||
+				(successPageSettings.body[editingLanguageId] ||
 					successPageSettings.body[defaultLanguageId])) ||
+			Liferay.Language.get(
+				'your-information-was-successfully-received-thank-you-for-filling-out-the-form'
+			) ||
 			'',
 		initialTitle:
 			(successPageSettings.title &&
-				(successPageSettings.title[
-					Liferay.ThemeDisplay.getLanguageId()
-				] ||
+				(successPageSettings.title[editingLanguageId] ||
 					successPageSettings.title[defaultLanguageId])) ||
+			Liferay.Language.get('thank-you') ||
 			'',
 	};
 


### PR DESCRIPTION
[LPP-52619](https://liferay.atlassian.net/browse/LPP-52619)
[LPD-17380](https://liferay.atlassian.net/browse/LPD-17380)
Hi team!
When you create a form, add it to a new language, put a success message different for each language, and save or publish, the message for the other language is lost, so the default message (in English) is rendering.
I am using the editing language instead of the `Liferay.ThemeDisplay.getLanguageId()` to solve this issue.
Thank you for your attention and review. :blush: