### PR TITLE
LPD-18515 Follow the WCAG pattern for contrast in the form email notification template

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/META-INF/resources/notification/form_entry_add_body.ftl
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/META-INF/resources/notification/form_entry_add_body.ftl
@@ -19,7 +19,7 @@
 		}
 
 		.field-label {
-			color: #9aa2a6;
+			color: #535a5e;
 			font-size: 18px;
 			margin: 32px 0 16px;
 		}
@@ -36,7 +36,7 @@
 		}
 
 		h3 {
-			color: #9aa2a6;
+			color: #474d51;
 			font-weight: 300;
 			margin: 8px 0;
 			text-align: center;
@@ -62,12 +62,12 @@
 		}
 
 		.view-form-entries-url {
-			color: #7bc4f4;
+			color: #0c5d92;
 			text-decoration: none;
 		}
 
 		.view-form-url {
-			background: #65b4f1;
+			background: #0d5b97;
 			border-radius: 4px;
 			color: #fff;
 			display: block;


### PR DESCRIPTION
[LPD-18515](https://liferay.atlassian.net/browse/LPD-18515)
[LPP-52832](https://liferay.atlassian.net/browse/LPP-52832)

Hi team!
A customer reported an issue with accessibility.
The customer indicates the colors used in emails received by form entries don't keep to accessibility rules about minimum contrast (considering default template email).

I used an extension (Color Contrast Checker) to recommend colors that meet the accessibility pattern.