### PR TITLE
LPD-18623 LocalFile.FormsTranslations#CanBeCreatedInMultipleLanguages

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/FormsTranslations.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/FormsTranslations.testcase
@@ -117,7 +117,7 @@ definition {
 
 		FormViewBuilder.changeAppLanguageTo(changeAppLanguageTo = "ja-JP");
 
-		FormViewBuilder.changeAppLanguageTo(changeAppLanguageTo = "العربية-السعودية");
+		FormViewBuilder.changeAppLanguageTo(changeAppLanguageTo = "السعودية");
 
 		FormViewBuilder.validateFieldLabel(fieldLabel = "عربى");
 	}


### PR DESCRIPTION
Hi Team,

This is for [LPD-18623](https://liferay.atlassian.net/browse/LPD-18623)
Our current java locale provider is JRE (jdk8 default)
In preparation to make the change to jdk21, we noticed that jdk21 default is CLDR. This made many functional tests fail because display name for timezone, country, format are slightly different.

This works both with JRE and CLDR

Testing here:
[CLDR](https://github.com/p-albuquerque/liferay-portal/pull/121)
[JRE](https://github.com/p-albuquerque/liferay-portal/pull/122)