### PR TITLE
LPD-20194 Allow User to Drop a Fieldset Into a Single Field

### DIFF
--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/hooks/useDrop.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/hooks/useDrop.es.js
@@ -19,10 +19,69 @@ export const DND_ORIGIN_TYPE = {
 
 const DRAG_ELEMENT_SET_ADD = 'elementSet:add';
 
-const isSameIndexes = (target, source) =>
-	target.pageIndex === source.pageIndex &&
-	target.rowIndex === source.rowIndex &&
-	target.columnIndex === source.columnIndex;
+/**
+ * Determines whether are moving the source Field into inside the Field
+ * in the same FieldGroup to create another FieldGroup but with only
+ * two fields.
+ */
+const isDroppingFieldIntoFieldAndSameGroup = (
+	origin,
+	sourceParentField,
+	targetParentField
+) =>
+	origin === DND_ORIGIN_TYPE.FIELD &&
+	sourceParentField?.type === 'fieldset' &&
+	sourceParentField?.fieldName === targetParentField?.fieldName &&
+	targetParentField.nestedFields.length === 2;
+
+const isDroppingFieldIntoFieldset = (sourceField, targetField) =>
+	sourceField.fieldName !== targetField?.fieldName &&
+	targetField?.type === 'fieldset' &&
+	!!targetField?.ddmStructureId;
+
+/**
+ * Determines whether the source Field is being moved into inside a Field
+ * where its parent is a FieldGroup with just that element.
+ */
+const isDroppingFieldIntoSingleField = (origin, targetParentField) =>
+	origin === DND_ORIGIN_TYPE.FIELD &&
+	targetParentField?.type === 'fieldset' &&
+	targetParentField.nestedFields.length === 1;
+
+const isDroppingFieldsetIntoNestedField = ({sourceField, targetField}) =>
+	sourceField?.type === 'fieldset' &&
+	targetField &&
+	'nestedFieldIndex' in targetField;
+
+const isElementsSetOverTarget = (target, source) => {
+	if (target) {
+		return (
+			!!Object.keys(target).length &&
+			source?.dragType === 'elementSet:add'
+		);
+	}
+
+	return false;
+};
+
+/**
+ * Just check if the Field is a FieldGroup before checking if it is moving into
+ * itself. The index of the source and target are added to the loc, at the
+ * level where `useDrop` is used it is not visible the loc of the Field being
+ * rendered.
+ */
+const isFieldGroupMovingIntoItself = ({
+	sourceIndexes,
+	sourceParentField,
+	targetIndexes,
+	targetParentField,
+	type,
+}) =>
+	type === 'fieldset' &&
+	isMovingIntoItself(
+		[targetIndexes, ...(targetParentField?.loc ?? [])],
+		[sourceIndexes, ...(sourceParentField?.loc ?? [])]
+	);
 
 /**
  * Checks whether Field is moving into itself. In conventional mode, we would be
@@ -60,72 +119,13 @@ const isMovingIntoItself = (targetParentLoc, sourceParentLoc) => {
 	);
 };
 
-/**
- * Just check if the Field is a FieldGroup before checking if it is moving into
- * itself. The index of the source and target are added to the loc, at the
- * level where `useDrop` is used it is not visible the loc of the Field being
- * rendered.
- */
-const isFieldGroupMovingIntoItself = ({
-	sourceIndexes,
-	sourceParentField,
-	targetIndexes,
-	targetParentField,
-	type,
-}) =>
-	type === 'fieldset' &&
-	isMovingIntoItself(
-		[targetIndexes, ...(targetParentField?.loc ?? [])],
-		[sourceIndexes, ...(sourceParentField?.loc ?? [])]
-	);
-
-/**
- * Determines whether the source Field is being moved into inside a Field
- * where its parent is a FieldGroup with just that element.
- */
-const isDroppingFieldIntoSingleField = (origin, targetParentField) =>
-	origin === DND_ORIGIN_TYPE.FIELD &&
-	targetParentField?.type === 'fieldset' &&
-	targetParentField.nestedFields.length === 1;
-
-/**
- * Determines whether are moving the source Field into inside the Field
- * in the same FieldGroup to create another FieldGroup but with only
- * two fields.
- */
-const isDroppingFieldIntoFieldAndSameGroup = (
-	origin,
-	sourceParentField,
-	targetParentField
-) =>
-	origin === DND_ORIGIN_TYPE.FIELD &&
-	sourceParentField?.type === 'fieldset' &&
-	sourceParentField?.fieldName === targetParentField?.fieldName &&
-	targetParentField.nestedFields.length === 2;
-
-const isDroppingFieldIntoFieldset = (sourceField, targetField) =>
-	sourceField.fieldName !== targetField?.fieldName &&
-	targetField?.type === 'fieldset' &&
-	!!targetField?.ddmStructureId;
-
-const isDroppingFieldsetIntoNestedField = ({sourceField, targetField}) =>
-	sourceField?.type === 'fieldset' &&
-	targetField &&
-	'nestedFieldIndex' in targetField;
-
 const isSameField = (targetField, sourceField) =>
 	targetField && targetField.fieldName === sourceField.fieldName;
 
-const isElementsSetOverTarget = (target, source) => {
-	if (target) {
-		return (
-			!!Object.keys(target).length &&
-			source?.dragType === 'elementSet:add'
-		);
-	}
-
-	return false;
-};
+const isSameIndexes = (target, source) =>
+	target.pageIndex === source.pageIndex &&
+	target.rowIndex === source.rowIndex &&
+	target.columnIndex === source.columnIndex;
 
 export function useDrop({
 	columnIndex,
@@ -151,14 +151,13 @@ export function useDrop({
 	const [{canDrop, overTarget}, drop] = useDndDrop({
 		accept: [...Object.values(DRAG_TYPES), DRAG_ELEMENT_SET_ADD],
 		canDrop: (item) =>
-			!isElementsSetOverTarget(field, item.data) &&
-			!isElementsSetOverTarget(parentField, item.data) &&
-			!isSameField(field, item.data) &&
+			!isDroppingFieldIntoFieldset(item.data, field) &&
 			!isDroppingFieldsetIntoNestedField({
 				sourceField: item.data,
 				targetField: field,
 			}) &&
-			!isDroppingFieldIntoFieldset(item.data, field) &&
+			!isElementsSetOverTarget(field, item.data) &&
+			!isElementsSetOverTarget(parentField, item.data) &&
 			!isFieldGroupMovingIntoItself({
 				sourceIndexes: item.sourceIndexes,
 				sourceParentField: item.sourceParentField,
@@ -169,7 +168,8 @@ export function useDrop({
 				},
 				targetParentField: parentField,
 				type: item.data.type,
-			}),
+			}) &&
+			!isSameField(field, item.data),
 		collect: (monitor) => ({
 			canDrop: monitor.canDrop(),
 			overTarget: monitor.isOver({shallow: true}),

--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/hooks/useDrop.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/hooks/useDrop.es.js
@@ -79,9 +79,6 @@ const isFieldGroupMovingIntoItself = ({
 		[sourceIndexes, ...(sourceParentField?.loc ?? [])]
 	);
 
-const isDroppingFieldGroupIntoField = (targetField, sourceField) =>
-	sourceField?.type === 'fieldset' && targetField !== undefined;
-
 /**
  * Determines whether the source Field is being moved into inside a Field
  * where its parent is a FieldGroup with just that element.
@@ -110,6 +107,11 @@ const isDroppingFieldIntoFieldset = (sourceField, targetField) =>
 	sourceField.fieldName !== targetField?.fieldName &&
 	targetField?.type === 'fieldset' &&
 	!!targetField?.ddmStructureId;
+
+const isDroppingFieldsetIntoNestedField = ({sourceField, targetField}) =>
+	sourceField?.type === 'fieldset' &&
+	targetField &&
+	'nestedFieldIndex' in targetField;
 
 const isSameField = (targetField, sourceField) =>
 	targetField && targetField.fieldName === sourceField.fieldName;
@@ -152,7 +154,10 @@ export function useDrop({
 			!isElementsSetOverTarget(field, item.data) &&
 			!isElementsSetOverTarget(parentField, item.data) &&
 			!isSameField(field, item.data) &&
-			!isDroppingFieldGroupIntoField(field, item.data) &&
+			!isDroppingFieldsetIntoNestedField({
+				sourceField: item.data,
+				targetField: field,
+			}) &&
 			!isDroppingFieldIntoFieldset(item.data, field) &&
 			!isFieldGroupMovingIntoItself({
 				sourceIndexes: item.sourceIndexes,


### PR DESCRIPTION
Related [Ticket](https://liferay.atlassian.net/browse/LPD-20194)

This pull request enhances field group organization by enabling drag-and-drop functionality. Users can now drag a group of fields within a single field, essentially creating a new field group. To achieve this, the `isDroppingFieldGroupIntoField` function, which previously restricted this behavior, has been removed. However, a new function called `isDroppingFieldsetIntoNestedField` has been implemented to prevent users from dropping groups into nested fields, thereby avoiding potential bugs.

https://github.com/liferay-forms/liferay-portal/assets/61854510/bf927f4c-f162-48b6-a5fb-473e47edf7bb
