### PR TITLE
LPD-23020 - Screen is Not Properly Read in Required Field Error Messages with JAWS Screen Reader 

### DIFF
--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/components/FieldFeedback.tsx
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/components/FieldFeedback.tsx
@@ -15,30 +15,25 @@ export function FieldFeedback({
 	warningMessage,
 	...otherProps
 }: IProps) {
-	if (!errorMessage && !helpMessage && !warningMessage) {
-		return null;
-	}
+	const message =
+		warningMessage && !errorMessage ? warningMessage : errorMessage;
+
+	const symbol =
+		warningMessage && !errorMessage ? 'warning-full' : 'exclamation-full';
 
 	return (
 		<ClayForm.FeedbackGroup
 			className="lfr-de__field-feedback"
 			{...otherProps}
 		>
-			{errorMessage && (
-				<ClayForm.FeedbackItem id={`${name}_fieldError`} role="alert">
-					<ClayForm.FeedbackIndicator symbol="exclamation-full" />
+			<ClayForm.FeedbackItem
+				aria-live="assertive"
+				id={`${name}_fieldError`}
+			>
+				{message && <ClayForm.FeedbackIndicator symbol={symbol} />}
 
-					{errorMessage}
-				</ClayForm.FeedbackItem>
-			)}
-
-			{warningMessage && !errorMessage && (
-				<ClayForm.FeedbackItem id={`${name}_fieldError`} role="alert">
-					<ClayForm.FeedbackIndicator symbol="warning-full" />
-
-					{warningMessage}
-				</ClayForm.FeedbackItem>
-			)}
+				{message}
+			</ClayForm.FeedbackItem>
 
 			{helpMessage && <div id={`${name}_fieldHelp`}>{helpMessage}</div>}
 		</ClayForm.FeedbackGroup>

--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/components/FieldFeedback.tsx
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/components/FieldFeedback.tsx
@@ -15,11 +15,10 @@ export function FieldFeedback({
 	warningMessage,
 	...otherProps
 }: IProps) {
-	const message =
-		warningMessage && !errorMessage ? warningMessage : errorMessage;
+	const showWarning = warningMessage && !errorMessage;
 
-	const symbol =
-		warningMessage && !errorMessage ? 'warning-full' : 'exclamation-full';
+	const message = showWarning ? warningMessage : errorMessage;
+	const symbol = showWarning ? 'warning-full' : 'exclamation-full';
 
 	return (
 		<ClayForm.FeedbackGroup

--- a/modules/apps/data-engine/data-engine-js-components-web/types/src/main/resources/META-INF/resources/js/core/components/FieldFeedback.d.ts
+++ b/modules/apps/data-engine/data-engine-js-components-web/types/src/main/resources/META-INF/resources/js/core/components/FieldFeedback.d.ts
@@ -11,7 +11,7 @@ export declare function FieldFeedback({
 	name,
 	warningMessage,
 	...otherProps
-}: IProps): JSX.Element | null;
+}: IProps): JSX.Element;
 interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	errorMessage?: string;
 	helpMessage?: string;

--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/paths/DataEngineBuilder.path
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/paths/DataEngineBuilder.path
@@ -87,7 +87,7 @@
 </tr>
 <tr>
 	<td>OPTION_REFERENCE_ERROR</td>
-	<td>xpath=(//div[contains(@class,'ddm-option-entry')])[${index}]//div[contains(@class,'form-feedback-item')]</td>
+	<td>xpath=(//div[contains(@class,'ddm-option-entry')])[${index}]//div[contains(@class,'form-feedback-item') and text()='${assertErrorMessage}']</td>
 	<td></td>
 </tr>
 <tr>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Text/Text.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Text/Text.es.js
@@ -168,6 +168,7 @@ const Text = ({
 						{...(htmlAutocompleteAttribute && {
 							autoComplete: htmlAutocompleteAttribute,
 						})}
+						aria-describedby={`${name}_fieldError`}
 						className="ddm-field-text"
 						dir={Liferay.Language.direction[editingLanguageId]}
 						disabled={disabled}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Checkbox/__snapshots__/Checkbox.es.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Checkbox/__snapshots__/Checkbox.es.js.snap
@@ -47,6 +47,11 @@ exports[`Field Checkbox has a helptext 1`] = `
       class="form-feedback-group lfr-de__field-feedback"
     >
       <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="undefined_fieldError"
+      />
+      <div
         id="undefined_fieldHelp"
       >
         Type something
@@ -105,6 +110,16 @@ exports[`Field Checkbox has a key 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="undefined_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -152,6 +167,16 @@ exports[`Field Checkbox has a label 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="undefined_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -198,6 +223,16 @@ exports[`Field Checkbox has a predefined Value 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="undefined_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -245,6 +280,16 @@ exports[`Field Checkbox has a value 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="undefined_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -291,6 +336,16 @@ exports[`Field Checkbox has an id 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="ID_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -338,6 +393,16 @@ exports[`Field Checkbox is not editable 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="undefined_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -385,6 +450,16 @@ exports[`Field Checkbox is not required 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="undefined_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -431,6 +506,16 @@ exports[`Field Checkbox is shown as a switcher 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="undefined_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -464,6 +549,16 @@ exports[`Field Checkbox is shown as checkbox 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="undefined_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -510,6 +605,16 @@ exports[`Field Checkbox renders Label if showLabel is true 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="undefined_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/CheckboxMultiple/__snapshots__/CheckboxMultiple.es.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/CheckboxMultiple/__snapshots__/CheckboxMultiple.es.js.snap
@@ -78,6 +78,11 @@ exports[`Field Checkbox Multiple has a helptext 1`] = `
       class="form-feedback-group lfr-de__field-feedback"
     >
       <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="undefined_fieldError"
+      />
+      <div
         id="undefined_fieldHelp"
       >
         Type something
@@ -166,6 +171,16 @@ exports[`Field Checkbox Multiple has a key 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="undefined_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -248,6 +263,16 @@ exports[`Field Checkbox Multiple has a label 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="undefined_fieldError"
+      />
+    </div>
     <span
       class="sr-only"
       id="undefined_fieldDetails"
@@ -331,6 +356,16 @@ exports[`Field Checkbox Multiple has a predefined Value 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="undefined_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -408,6 +443,16 @@ exports[`Field Checkbox Multiple has a spritemap 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="undefined_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -485,6 +530,16 @@ exports[`Field Checkbox Multiple has a value 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="undefined_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -562,6 +617,16 @@ exports[`Field Checkbox Multiple has an id 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="ID_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -641,6 +706,16 @@ exports[`Field Checkbox Multiple is not editable 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="undefined_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -718,6 +793,16 @@ exports[`Field Checkbox Multiple is not required 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="undefined_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -795,6 +880,16 @@ exports[`Field Checkbox Multiple is shown as a switcher 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="undefined_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -860,6 +955,16 @@ exports[`Field Checkbox Multiple is shown as checkbox 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="undefined_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -942,6 +1047,16 @@ exports[`Field Checkbox Multiple renders Label if showLabel is true 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="undefined_fieldError"
+      />
+    </div>
     <span
       class="sr-only"
       id="undefined_fieldDetails"

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/ColorPicker/__snapshots__/ColorPicker.es.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/ColorPicker/__snapshots__/ColorPicker.es.js.snap
@@ -57,6 +57,16 @@ exports[`Field Color Picker renders field disabled 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="colorPicker_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -120,6 +130,11 @@ exports[`Field Color Picker renders field with helptext 1`] = `
       aria-hidden="true"
       class="form-feedback-group lfr-de__field-feedback"
     >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="colorPicker_fieldError"
+      />
       <div
         id="colorPicker_fieldHelp"
       >
@@ -200,6 +215,11 @@ exports[`Field Color Picker renders field with label 1`] = `
       aria-hidden="true"
       class="form-feedback-group lfr-de__field-feedback"
     >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="colorPicker_fieldError"
+      />
       <div
         id="colorPicker_fieldHelp"
       >

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/DocumentLibrary/__snapshots__/DocumentLibrary.es.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/DocumentLibrary/__snapshots__/DocumentLibrary.es.js.snap
@@ -60,9 +60,9 @@ exports[`Field DocumentLibrary has a helptext 1`] = `
       class="form-feedback-group lfr-de__field-feedback"
     >
       <div
+        aria-live="assertive"
         class="form-feedback-item"
         id="uploadField_fieldError"
-        role="alert"
       >
         <span
           class="form-feedback-indicator inline-item-before"
@@ -161,9 +161,9 @@ exports[`Field DocumentLibrary has a label 1`] = `
       class="form-feedback-group lfr-de__field-feedback"
     >
       <div
+        aria-live="assertive"
         class="form-feedback-item"
         id="uploadField_fieldError"
-        role="alert"
       >
         <span
           class="form-feedback-indicator inline-item-before"
@@ -253,9 +253,9 @@ exports[`Field DocumentLibrary has a placeholder 1`] = `
       class="form-feedback-group lfr-de__field-feedback"
     >
       <div
+        aria-live="assertive"
         class="form-feedback-item"
         id="uploadField_fieldError"
-        role="alert"
       >
         <span
           class="form-feedback-indicator inline-item-before"
@@ -342,9 +342,9 @@ exports[`Field DocumentLibrary has a spritemap 1`] = `
       class="form-feedback-group lfr-de__field-feedback"
     >
       <div
+        aria-live="assertive"
         class="form-feedback-item"
         id="uploadField_fieldError"
-        role="alert"
       >
         <span
           class="form-feedback-indicator inline-item-before"
@@ -431,9 +431,9 @@ exports[`Field DocumentLibrary has a value 1`] = `
       class="form-feedback-group lfr-de__field-feedback"
     >
       <div
+        aria-live="assertive"
         class="form-feedback-item"
         id="uploadField_fieldError"
-        role="alert"
       >
         <span
           class="form-feedback-indicator inline-item-before"
@@ -521,9 +521,9 @@ exports[`Field DocumentLibrary has an id 1`] = `
       class="form-feedback-group lfr-de__field-feedback"
     >
       <div
+        aria-live="assertive"
         class="form-feedback-item"
         id="ID_fieldError"
-        role="alert"
       >
         <span
           class="form-feedback-indicator inline-item-before"
@@ -603,6 +603,16 @@ exports[`Field DocumentLibrary is not readOnly 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="uploadField_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -668,9 +678,9 @@ exports[`Field DocumentLibrary is not required 1`] = `
       class="form-feedback-group lfr-de__field-feedback"
     >
       <div
+        aria-live="assertive"
         class="form-feedback-item"
         id="uploadField_fieldError"
-        role="alert"
       >
         <span
           class="form-feedback-indicator inline-item-before"
@@ -762,9 +772,9 @@ exports[`Field DocumentLibrary renders Label if showLabel is true 1`] = `
       class="form-feedback-group lfr-de__field-feedback"
     >
       <div
+        aria-live="assertive"
         class="form-feedback-item"
         id="uploadField_fieldError"
-        role="alert"
       >
         <span
           class="form-feedback-indicator inline-item-before"

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/FieldBase/__snapshots__/ReactFieldBase.es.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/FieldBase/__snapshots__/ReactFieldBase.es.js.snap
@@ -33,6 +33,16 @@ exports[`ReactFieldBase does not render the add button when repeatable is true a
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="undefined_fieldError"
+      />
+    </div>
     <span
       class="sr-only"
       id="undefined_fieldDetails"
@@ -54,6 +64,16 @@ exports[`ReactFieldBase does not render the label if showLabel is false 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="undefined_fieldError"
+      />
+    </div>
     <span
       class="sr-only"
       id="undefined_fieldDetails"
@@ -80,6 +100,16 @@ exports[`ReactFieldBase renders the FieldBase with contentRenderer 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="undefined_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -99,6 +129,11 @@ exports[`ReactFieldBase renders the FieldBase with help text 1`] = `
       aria-hidden="true"
       class="form-feedback-group lfr-de__field-feedback"
     >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="undefined_fieldError"
+      />
       <div
         id="undefined_fieldHelp"
       >
@@ -126,6 +161,16 @@ exports[`ReactFieldBase renders the FieldBase with id 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="Id_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -146,6 +191,16 @@ exports[`ReactFieldBase renders the FieldBase with label 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="undefined_fieldError"
+      />
+    </div>
     <span
       class="sr-only"
       id="undefined_fieldDetails"
@@ -183,6 +238,16 @@ exports[`ReactFieldBase renders the FieldBase with required 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="undefined_fieldError"
+      />
+    </div>
     <span
       class="sr-only"
       id="undefined_fieldDetails"
@@ -226,6 +291,16 @@ exports[`ReactFieldBase renders the add button when repeatable is true 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="undefined_fieldError"
+      />
+    </div>
     <span
       class="sr-only"
       id="undefined_fieldDetails"
@@ -247,6 +322,16 @@ exports[`ReactFieldBase renders the default markup 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="undefined_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Grid/__snapshots__/Grid.es.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Grid/__snapshots__/Grid.es.js.snap
@@ -80,6 +80,16 @@ exports[`Grid has a label 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="undefined_fieldError"
+      />
+    </div>
     <span
       class="sr-only"
       id="undefined_fieldDetails"
@@ -169,6 +179,11 @@ exports[`Grid has a tip 1`] = `
       aria-hidden="true"
       class="form-feedback-group lfr-de__field-feedback"
     >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="undefined_fieldError"
+      />
       <div
         id="undefined_fieldHelp"
       >
@@ -260,6 +275,16 @@ exports[`Grid has an id 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="Id_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -336,6 +361,16 @@ exports[`Grid is not editable 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="undefined_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -416,6 +451,16 @@ exports[`Grid is not required 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="undefined_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -500,6 +545,16 @@ exports[`Grid renders Label if showLabel is true 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="undefined_fieldError"
+      />
+    </div>
     <span
       class="sr-only"
       id="undefined_fieldDetails"
@@ -612,6 +667,16 @@ exports[`Grid renders columns 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="undefined_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -664,6 +729,16 @@ exports[`Grid renders no columns when columns comes empty 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="undefined_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -706,6 +781,16 @@ exports[`Grid renders no rows when row comes empty 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="undefined_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -821,6 +906,16 @@ exports[`Grid renders rows 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="undefined_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/KeyValue/OptionFieldKeyValue.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/KeyValue/OptionFieldKeyValue.js
@@ -223,7 +223,7 @@ describe('OptionFieldKeyValue', () => {
 		);
 
 		const OptionFieldKeyValueInput = container.querySelectorAll(
-			'[id*="keyValueName"]'
+			'[id*="keyValueName"]:not([id*="_fieldError"])'
 		);
 
 		expect(OptionFieldKeyValueInput.length).toBe(1);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/KeyValue/__snapshots__/OptionFieldKeyValue.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/KeyValue/__snapshots__/OptionFieldKeyValue.js.snap
@@ -69,6 +69,7 @@ exports[`OptionFieldKeyValue has a helptext 1`] = `
               data-tooltip-align="top"
             >
               <input
+                aria-describedby="keyValueDisplayNameOptionFieldKeyValue_fieldError"
                 aria-invalid="true"
                 class="form-control ddm-field-text"
                 id="keyValueDisplayNameOptionFieldKeyValue"
@@ -82,6 +83,16 @@ exports[`OptionFieldKeyValue has a helptext 1`] = `
               type="hidden"
               value="false"
             />
+            <div
+              aria-hidden="true"
+              class="form-feedback-group lfr-de__field-feedback"
+            >
+              <div
+                aria-live="assertive"
+                class="form-feedback-item"
+                id="keyValueDisplayNameOptionFieldKeyValue_fieldError"
+              />
+            </div>
           </div>
           <input
             name="OptionFieldKeyValue_edited"
@@ -92,6 +103,11 @@ exports[`OptionFieldKeyValue has a helptext 1`] = `
             aria-hidden="true"
             class="form-feedback-group lfr-de__field-feedback"
           >
+            <div
+              aria-live="assertive"
+              class="form-feedback-item"
+              id="OptionFieldKeyValue_fieldError"
+            />
             <div
               id="OptionFieldKeyValue_fieldHelp"
             >
@@ -124,6 +140,7 @@ exports[`OptionFieldKeyValue has a helptext 1`] = `
               data-tooltip-align="top"
             >
               <input
+                aria-describedby="keyValueReferenceundefined_fieldError"
                 aria-invalid="true"
                 class="form-control ddm-field-text"
                 id="keyValueReferenceundefined"
@@ -137,6 +154,16 @@ exports[`OptionFieldKeyValue has a helptext 1`] = `
               type="hidden"
               value="false"
             />
+            <div
+              aria-hidden="true"
+              class="form-feedback-group lfr-de__field-feedback"
+            >
+              <div
+                aria-live="assertive"
+                class="form-feedback-item"
+                id="keyValueReferenceundefined_fieldError"
+              />
+            </div>
           </div>
           <input
             name="undefined_edited"
@@ -147,6 +174,11 @@ exports[`OptionFieldKeyValue has a helptext 1`] = `
             aria-hidden="true"
             class="form-feedback-group lfr-de__field-feedback"
           >
+            <div
+              aria-live="assertive"
+              class="form-feedback-item"
+              id="undefined_fieldError"
+            />
             <div
               id="undefined_fieldHelp"
             >
@@ -240,6 +272,7 @@ exports[`OptionFieldKeyValue has a label 1`] = `
               data-tooltip-align="top"
             >
               <input
+                aria-describedby="keyValueDisplayNameOptionFieldKeyValue_fieldError"
                 aria-invalid="true"
                 class="form-control ddm-field-text"
                 id="keyValueDisplayNameOptionFieldKeyValue"
@@ -253,12 +286,32 @@ exports[`OptionFieldKeyValue has a label 1`] = `
               type="hidden"
               value="false"
             />
+            <div
+              aria-hidden="true"
+              class="form-feedback-group lfr-de__field-feedback"
+            >
+              <div
+                aria-live="assertive"
+                class="form-feedback-item"
+                id="keyValueDisplayNameOptionFieldKeyValue_fieldError"
+              />
+            </div>
           </div>
           <input
             name="OptionFieldKeyValue_edited"
             type="hidden"
             value="false"
           />
+          <div
+            aria-hidden="true"
+            class="form-feedback-group lfr-de__field-feedback"
+          >
+            <div
+              aria-live="assertive"
+              class="form-feedback-item"
+              id="OptionFieldKeyValue_fieldError"
+            />
+          </div>
           <span
             class="sr-only"
             id="OptionFieldKeyValue_fieldDetails"
@@ -290,6 +343,7 @@ exports[`OptionFieldKeyValue has a label 1`] = `
               data-tooltip-align="top"
             >
               <input
+                aria-describedby="keyValueReferenceundefined_fieldError"
                 aria-invalid="true"
                 class="form-control ddm-field-text"
                 id="keyValueReferenceundefined"
@@ -303,12 +357,32 @@ exports[`OptionFieldKeyValue has a label 1`] = `
               type="hidden"
               value="false"
             />
+            <div
+              aria-hidden="true"
+              class="form-feedback-group lfr-de__field-feedback"
+            >
+              <div
+                aria-live="assertive"
+                class="form-feedback-item"
+                id="keyValueReferenceundefined_fieldError"
+              />
+            </div>
           </div>
           <input
             name="undefined_edited"
             type="hidden"
             value="false"
           />
+          <div
+            aria-hidden="true"
+            class="form-feedback-group lfr-de__field-feedback"
+          >
+            <div
+              aria-live="assertive"
+              class="form-feedback-item"
+              id="undefined_fieldError"
+            />
+          </div>
           <span
             class="sr-only"
             id="undefined_fieldDetails"
@@ -392,6 +466,7 @@ exports[`OptionFieldKeyValue has a predefined Value 1`] = `
               title="Option 1"
             >
               <input
+                aria-describedby="keyValueDisplayNameOptionFieldKeyValue_fieldError"
                 aria-invalid="true"
                 class="form-control ddm-field-text"
                 id="keyValueDisplayNameOptionFieldKeyValue"
@@ -406,12 +481,32 @@ exports[`OptionFieldKeyValue has a predefined Value 1`] = `
               type="hidden"
               value="false"
             />
+            <div
+              aria-hidden="true"
+              class="form-feedback-group lfr-de__field-feedback"
+            >
+              <div
+                aria-live="assertive"
+                class="form-feedback-item"
+                id="keyValueDisplayNameOptionFieldKeyValue_fieldError"
+              />
+            </div>
           </div>
           <input
             name="OptionFieldKeyValue_edited"
             type="hidden"
             value="false"
           />
+          <div
+            aria-hidden="true"
+            class="form-feedback-group lfr-de__field-feedback"
+          >
+            <div
+              aria-live="assertive"
+              class="form-feedback-item"
+              id="OptionFieldKeyValue_fieldError"
+            />
+          </div>
         </div>
         <label
           class="mt-3"
@@ -432,6 +527,7 @@ exports[`OptionFieldKeyValue has a predefined Value 1`] = `
               data-tooltip-align="top"
             >
               <input
+                aria-describedby="keyValueReferenceundefined_fieldError"
                 aria-invalid="true"
                 class="form-control ddm-field-text"
                 id="keyValueReferenceundefined"
@@ -445,12 +541,32 @@ exports[`OptionFieldKeyValue has a predefined Value 1`] = `
               type="hidden"
               value="false"
             />
+            <div
+              aria-hidden="true"
+              class="form-feedback-group lfr-de__field-feedback"
+            >
+              <div
+                aria-live="assertive"
+                class="form-feedback-item"
+                id="keyValueReferenceundefined_fieldError"
+              />
+            </div>
           </div>
           <input
             name="undefined_edited"
             type="hidden"
             value="false"
           />
+          <div
+            aria-hidden="true"
+            class="form-feedback-group lfr-de__field-feedback"
+          >
+            <div
+              aria-live="assertive"
+              class="form-feedback-item"
+              id="undefined_fieldError"
+            />
+          </div>
         </div>
       </div>
     </div>
@@ -528,6 +644,7 @@ exports[`OptionFieldKeyValue has a value 1`] = `
               title="value"
             >
               <input
+                aria-describedby="keyValueDisplayNameOptionFieldKeyValue_fieldError"
                 aria-invalid="true"
                 class="form-control ddm-field-text"
                 id="keyValueDisplayNameOptionFieldKeyValue"
@@ -541,12 +658,32 @@ exports[`OptionFieldKeyValue has a value 1`] = `
               type="hidden"
               value="false"
             />
+            <div
+              aria-hidden="true"
+              class="form-feedback-group lfr-de__field-feedback"
+            >
+              <div
+                aria-live="assertive"
+                class="form-feedback-item"
+                id="keyValueDisplayNameOptionFieldKeyValue_fieldError"
+              />
+            </div>
           </div>
           <input
             name="OptionFieldKeyValue_edited"
             type="hidden"
             value="false"
           />
+          <div
+            aria-hidden="true"
+            class="form-feedback-group lfr-de__field-feedback"
+          >
+            <div
+              aria-live="assertive"
+              class="form-feedback-item"
+              id="OptionFieldKeyValue_fieldError"
+            />
+          </div>
         </div>
         <label
           class="mt-3"
@@ -567,6 +704,7 @@ exports[`OptionFieldKeyValue has a value 1`] = `
               data-tooltip-align="top"
             >
               <input
+                aria-describedby="keyValueReferenceundefined_fieldError"
                 aria-invalid="true"
                 class="form-control ddm-field-text"
                 id="keyValueReferenceundefined"
@@ -580,12 +718,32 @@ exports[`OptionFieldKeyValue has a value 1`] = `
               type="hidden"
               value="false"
             />
+            <div
+              aria-hidden="true"
+              class="form-feedback-group lfr-de__field-feedback"
+            >
+              <div
+                aria-live="assertive"
+                class="form-feedback-item"
+                id="keyValueReferenceundefined_fieldError"
+              />
+            </div>
           </div>
           <input
             name="undefined_edited"
             type="hidden"
             value="false"
           />
+          <div
+            aria-hidden="true"
+            class="form-feedback-group lfr-de__field-feedback"
+          >
+            <div
+              aria-live="assertive"
+              class="form-feedback-item"
+              id="undefined_fieldError"
+            />
+          </div>
         </div>
       </div>
     </div>
@@ -662,6 +820,7 @@ exports[`OptionFieldKeyValue has an id 1`] = `
               data-tooltip-align="top"
             >
               <input
+                aria-describedby="keyValueDisplayNameOptionFieldKeyValue_fieldError"
                 aria-invalid="true"
                 class="form-control ddm-field-text"
                 id="keyValueDisplayNameOptionFieldKeyValue"
@@ -675,12 +834,32 @@ exports[`OptionFieldKeyValue has an id 1`] = `
               type="hidden"
               value="false"
             />
+            <div
+              aria-hidden="true"
+              class="form-feedback-group lfr-de__field-feedback"
+            >
+              <div
+                aria-live="assertive"
+                class="form-feedback-item"
+                id="keyValueDisplayNameOptionFieldKeyValue_fieldError"
+              />
+            </div>
           </div>
           <input
             name="OptionFieldKeyValue_edited"
             type="hidden"
             value="false"
           />
+          <div
+            aria-hidden="true"
+            class="form-feedback-group lfr-de__field-feedback"
+          >
+            <div
+              aria-live="assertive"
+              class="form-feedback-item"
+              id="Id_fieldError"
+            />
+          </div>
         </div>
         <label
           class="mt-3"
@@ -701,6 +880,7 @@ exports[`OptionFieldKeyValue has an id 1`] = `
               data-tooltip-align="top"
             >
               <input
+                aria-describedby="keyValueReferenceundefined_fieldError"
                 aria-invalid="true"
                 class="form-control ddm-field-text"
                 id="keyValueReferenceundefined"
@@ -714,12 +894,32 @@ exports[`OptionFieldKeyValue has an id 1`] = `
               type="hidden"
               value="false"
             />
+            <div
+              aria-hidden="true"
+              class="form-feedback-group lfr-de__field-feedback"
+            >
+              <div
+                aria-live="assertive"
+                class="form-feedback-item"
+                id="keyValueReferenceundefined_fieldError"
+              />
+            </div>
           </div>
           <input
             name="undefined_edited"
             type="hidden"
             value="false"
           />
+          <div
+            aria-hidden="true"
+            class="form-feedback-group lfr-de__field-feedback"
+          >
+            <div
+              aria-live="assertive"
+              class="form-feedback-item"
+              id="Id_fieldError"
+            />
+          </div>
         </div>
       </div>
     </div>
@@ -796,6 +996,7 @@ exports[`OptionFieldKeyValue is not editable 1`] = `
               data-tooltip-align="top"
             >
               <input
+                aria-describedby="keyValueDisplayNameOptionFieldKeyValue_fieldError"
                 aria-invalid="true"
                 class="form-control ddm-field-text"
                 disabled=""
@@ -810,12 +1011,32 @@ exports[`OptionFieldKeyValue is not editable 1`] = `
               type="hidden"
               value="false"
             />
+            <div
+              aria-hidden="true"
+              class="form-feedback-group lfr-de__field-feedback"
+            >
+              <div
+                aria-live="assertive"
+                class="form-feedback-item"
+                id="keyValueDisplayNameOptionFieldKeyValue_fieldError"
+              />
+            </div>
           </div>
           <input
             name="OptionFieldKeyValue_edited"
             type="hidden"
             value="false"
           />
+          <div
+            aria-hidden="true"
+            class="form-feedback-group lfr-de__field-feedback"
+          >
+            <div
+              aria-live="assertive"
+              class="form-feedback-item"
+              id="OptionFieldKeyValue_fieldError"
+            />
+          </div>
         </div>
         <label
           class="mt-3"
@@ -836,6 +1057,7 @@ exports[`OptionFieldKeyValue is not editable 1`] = `
               data-tooltip-align="top"
             >
               <input
+                aria-describedby="keyValueReferenceundefined_fieldError"
                 aria-invalid="true"
                 class="form-control ddm-field-text"
                 id="keyValueReferenceundefined"
@@ -849,12 +1071,32 @@ exports[`OptionFieldKeyValue is not editable 1`] = `
               type="hidden"
               value="false"
             />
+            <div
+              aria-hidden="true"
+              class="form-feedback-group lfr-de__field-feedback"
+            >
+              <div
+                aria-live="assertive"
+                class="form-feedback-item"
+                id="keyValueReferenceundefined_fieldError"
+              />
+            </div>
           </div>
           <input
             name="undefined_edited"
             type="hidden"
             value="false"
           />
+          <div
+            aria-hidden="true"
+            class="form-feedback-group lfr-de__field-feedback"
+          >
+            <div
+              aria-live="assertive"
+              class="form-feedback-item"
+              id="undefined_fieldError"
+            />
+          </div>
         </div>
       </div>
     </div>
@@ -931,6 +1173,7 @@ exports[`OptionFieldKeyValue is not required 1`] = `
               data-tooltip-align="top"
             >
               <input
+                aria-describedby="keyValueDisplayNameOptionFieldKeyValue_fieldError"
                 aria-invalid="true"
                 aria-required="false"
                 class="form-control ddm-field-text"
@@ -945,12 +1188,32 @@ exports[`OptionFieldKeyValue is not required 1`] = `
               type="hidden"
               value="false"
             />
+            <div
+              aria-hidden="true"
+              class="form-feedback-group lfr-de__field-feedback"
+            >
+              <div
+                aria-live="assertive"
+                class="form-feedback-item"
+                id="keyValueDisplayNameOptionFieldKeyValue_fieldError"
+              />
+            </div>
           </div>
           <input
             name="OptionFieldKeyValue_edited"
             type="hidden"
             value="false"
           />
+          <div
+            aria-hidden="true"
+            class="form-feedback-group lfr-de__field-feedback"
+          >
+            <div
+              aria-live="assertive"
+              class="form-feedback-item"
+              id="OptionFieldKeyValue_fieldError"
+            />
+          </div>
         </div>
         <label
           class="mt-3"
@@ -971,6 +1234,7 @@ exports[`OptionFieldKeyValue is not required 1`] = `
               data-tooltip-align="top"
             >
               <input
+                aria-describedby="keyValueReferenceundefined_fieldError"
                 aria-invalid="true"
                 class="form-control ddm-field-text"
                 id="keyValueReferenceundefined"
@@ -984,12 +1248,32 @@ exports[`OptionFieldKeyValue is not required 1`] = `
               type="hidden"
               value="false"
             />
+            <div
+              aria-hidden="true"
+              class="form-feedback-group lfr-de__field-feedback"
+            >
+              <div
+                aria-live="assertive"
+                class="form-feedback-item"
+                id="keyValueReferenceundefined_fieldError"
+              />
+            </div>
           </div>
           <input
             name="undefined_edited"
             type="hidden"
             value="false"
           />
+          <div
+            aria-hidden="true"
+            class="form-feedback-group lfr-de__field-feedback"
+          >
+            <div
+              aria-live="assertive"
+              class="form-feedback-item"
+              id="undefined_fieldError"
+            />
+          </div>
         </div>
       </div>
     </div>
@@ -1071,6 +1355,7 @@ exports[`OptionFieldKeyValue renders Label if showLabel is true 1`] = `
               data-tooltip-align="top"
             >
               <input
+                aria-describedby="keyValueDisplayNameOptionFieldKeyValue_fieldError"
                 aria-invalid="true"
                 class="form-control ddm-field-text"
                 id="keyValueDisplayNameOptionFieldKeyValue"
@@ -1084,12 +1369,32 @@ exports[`OptionFieldKeyValue renders Label if showLabel is true 1`] = `
               type="hidden"
               value="false"
             />
+            <div
+              aria-hidden="true"
+              class="form-feedback-group lfr-de__field-feedback"
+            >
+              <div
+                aria-live="assertive"
+                class="form-feedback-item"
+                id="keyValueDisplayNameOptionFieldKeyValue_fieldError"
+              />
+            </div>
           </div>
           <input
             name="OptionFieldKeyValue_edited"
             type="hidden"
             value="false"
           />
+          <div
+            aria-hidden="true"
+            class="form-feedback-group lfr-de__field-feedback"
+          >
+            <div
+              aria-live="assertive"
+              class="form-feedback-item"
+              id="OptionFieldKeyValue_fieldError"
+            />
+          </div>
           <span
             class="sr-only"
             id="OptionFieldKeyValue_fieldDetails"
@@ -1121,6 +1426,7 @@ exports[`OptionFieldKeyValue renders Label if showLabel is true 1`] = `
               data-tooltip-align="top"
             >
               <input
+                aria-describedby="keyValueReferenceundefined_fieldError"
                 aria-invalid="true"
                 class="form-control ddm-field-text"
                 id="keyValueReferenceundefined"
@@ -1134,12 +1440,32 @@ exports[`OptionFieldKeyValue renders Label if showLabel is true 1`] = `
               type="hidden"
               value="false"
             />
+            <div
+              aria-hidden="true"
+              class="form-feedback-group lfr-de__field-feedback"
+            >
+              <div
+                aria-live="assertive"
+                class="form-feedback-item"
+                id="keyValueReferenceundefined_fieldError"
+              />
+            </div>
           </div>
           <input
             name="undefined_edited"
             type="hidden"
             value="false"
           />
+          <div
+            aria-hidden="true"
+            class="form-feedback-group lfr-de__field-feedback"
+          >
+            <div
+              aria-live="assertive"
+              class="form-feedback-item"
+              id="undefined_fieldError"
+            />
+          </div>
           <span
             class="sr-only"
             id="undefined_fieldDetails"
@@ -1222,6 +1548,7 @@ exports[`OptionFieldKeyValue renders component with a key 1`] = `
               data-tooltip-align="top"
             >
               <input
+                aria-describedby="keyValueDisplayNameOptionFieldKeyValue_fieldError"
                 aria-invalid="true"
                 class="form-control ddm-field-text"
                 id="keyValueDisplayNameOptionFieldKeyValue"
@@ -1235,12 +1562,32 @@ exports[`OptionFieldKeyValue renders component with a key 1`] = `
               type="hidden"
               value="false"
             />
+            <div
+              aria-hidden="true"
+              class="form-feedback-group lfr-de__field-feedback"
+            >
+              <div
+                aria-live="assertive"
+                class="form-feedback-item"
+                id="keyValueDisplayNameOptionFieldKeyValue_fieldError"
+              />
+            </div>
           </div>
           <input
             name="OptionFieldKeyValue_edited"
             type="hidden"
             value="false"
           />
+          <div
+            aria-hidden="true"
+            class="form-feedback-group lfr-de__field-feedback"
+          >
+            <div
+              aria-live="assertive"
+              class="form-feedback-item"
+              id="OptionFieldKeyValue_fieldError"
+            />
+          </div>
         </div>
         <label
           class="mt-3"
@@ -1261,6 +1608,7 @@ exports[`OptionFieldKeyValue renders component with a key 1`] = `
               data-tooltip-align="top"
             >
               <input
+                aria-describedby="keyValueReferenceundefined_fieldError"
                 aria-invalid="true"
                 class="form-control ddm-field-text"
                 id="keyValueReferenceundefined"
@@ -1274,12 +1622,32 @@ exports[`OptionFieldKeyValue renders component with a key 1`] = `
               type="hidden"
               value="false"
             />
+            <div
+              aria-hidden="true"
+              class="form-feedback-group lfr-de__field-feedback"
+            >
+              <div
+                aria-live="assertive"
+                class="form-feedback-item"
+                id="keyValueReferenceundefined_fieldError"
+              />
+            </div>
           </div>
           <input
             name="undefined_edited"
             type="hidden"
             value="false"
           />
+          <div
+            aria-hidden="true"
+            class="form-feedback-group lfr-de__field-feedback"
+          >
+            <div
+              aria-live="assertive"
+              class="form-feedback-item"
+              id="undefined_fieldError"
+            />
+          </div>
         </div>
       </div>
     </div>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/LocalizableText/__snapshots__/LocalizableText.es.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/LocalizableText/__snapshots__/LocalizableText.es.js.snap
@@ -717,6 +717,16 @@ exports[`Field LocalizableText adds a new translation for an untranslated item 1
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -1436,6 +1446,16 @@ exports[`Field LocalizableText emits field edit event on field change 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -2157,6 +2177,16 @@ exports[`Field LocalizableText fills with the default language value when the se
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -2878,6 +2908,16 @@ exports[`Field LocalizableText fills with the selected language value when the s
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -3602,6 +3642,16 @@ exports[`Field LocalizableText has a label 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US_fieldError"
+      />
+    </div>
     <span
       class="sr-only"
       id="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US_fieldDetails"
@@ -4327,6 +4377,16 @@ exports[`Field LocalizableText has a placeholder 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -5046,6 +5106,16 @@ exports[`Field LocalizableText is not readOnly 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -5765,6 +5835,16 @@ exports[`Field LocalizableText is not required 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -6486,6 +6566,16 @@ exports[`Field LocalizableText removes the translation of an item already transl
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -7205,6 +7295,16 @@ exports[`Field LocalizableText renders no values when values come empty 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -7924,6 +8024,16 @@ exports[`Field LocalizableText renders values 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -8643,6 +8753,16 @@ exports[`Field LocalizableText shows default language value when no other langua
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_ddm$$emailArticleAddedSubject$uoeJR4Me$0$$en_US_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Numeric/__snapshots__/Numeric.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Numeric/__snapshots__/Numeric.js.snap
@@ -31,6 +31,16 @@ exports[`Field Numeric Integer Input Mask toggle has an inputMaskFormat 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="numericField_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -57,6 +67,16 @@ exports[`Field Numeric renders the default markup 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="undefined_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Options/__snapshots__/Options.es.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Options/__snapshots__/Options.es.js.snap
@@ -100,6 +100,7 @@ exports[`Options shows the options 1`] = `
                       title="Option 1"
                     >
                       <input
+                        aria-describedby="keyValueDisplayNameoption0_fieldError"
                         aria-invalid="true"
                         class="form-control ddm-field-text"
                         id="keyValueDisplayNameoption0"
@@ -114,6 +115,16 @@ exports[`Options shows the options 1`] = `
                       type="hidden"
                       value="false"
                     />
+                    <div
+                      aria-hidden="true"
+                      class="form-feedback-group lfr-de__field-feedback"
+                    >
+                      <div
+                        aria-live="assertive"
+                        class="form-feedback-item"
+                        id="keyValueDisplayNameoption0_fieldError"
+                      />
+                    </div>
                   </div>
                   <button
                     aria-label="remove-x-option"
@@ -134,6 +145,16 @@ exports[`Options shows the options 1`] = `
                     type="hidden"
                     value="false"
                   />
+                  <div
+                    aria-hidden="true"
+                    class="form-feedback-group lfr-de__field-feedback"
+                  >
+                    <div
+                      aria-live="assertive"
+                      class="form-feedback-item"
+                      id="option0_fieldError"
+                    />
+                  </div>
                 </div>
                 <label
                   class="mt-3"
@@ -156,6 +177,7 @@ exports[`Options shows the options 1`] = `
                       title="Option1"
                     >
                       <input
+                        aria-describedby="keyValueReferenceOption1_fieldError"
                         aria-invalid="true"
                         class="form-control ddm-field-text"
                         id="keyValueReferenceOption1"
@@ -169,12 +191,32 @@ exports[`Options shows the options 1`] = `
                       type="hidden"
                       value="false"
                     />
+                    <div
+                      aria-hidden="true"
+                      class="form-feedback-group lfr-de__field-feedback"
+                    >
+                      <div
+                        aria-live="assertive"
+                        class="form-feedback-item"
+                        id="keyValueReferenceOption1_fieldError"
+                      />
+                    </div>
                   </div>
                   <input
                     name="Option1_edited"
                     type="hidden"
                     value="false"
                   />
+                  <div
+                    aria-hidden="true"
+                    class="form-feedback-group lfr-de__field-feedback"
+                  >
+                    <div
+                      aria-live="assertive"
+                      class="form-feedback-item"
+                      id="Option1_fieldError"
+                    />
+                  </div>
                 </div>
                 <label
                   class="mt-3"
@@ -211,6 +253,7 @@ exports[`Options shows the options 1`] = `
                       title="Option1"
                     >
                       <input
+                        aria-describedby="keyValueNameOption1_fieldError"
                         aria-invalid="true"
                         class="form-control ddm-field-text"
                         id="keyValueNameOption1"
@@ -224,12 +267,32 @@ exports[`Options shows the options 1`] = `
                       type="hidden"
                       value="false"
                     />
+                    <div
+                      aria-hidden="true"
+                      class="form-feedback-group lfr-de__field-feedback"
+                    >
+                      <div
+                        aria-live="assertive"
+                        class="form-feedback-item"
+                        id="keyValueNameOption1_fieldError"
+                      />
+                    </div>
                   </div>
                   <input
                     name="Option1_edited"
                     type="hidden"
                     value="false"
                   />
+                  <div
+                    aria-hidden="true"
+                    class="form-feedback-group lfr-de__field-feedback"
+                  >
+                    <div
+                      aria-live="assertive"
+                      class="form-feedback-item"
+                      id="Option1_fieldError"
+                    />
+                  </div>
                 </div>
               </div>
             </div>
@@ -326,6 +389,7 @@ exports[`Options shows the options 1`] = `
                       title="Option 2"
                     >
                       <input
+                        aria-describedby="keyValueDisplayNameoption1_fieldError"
                         aria-invalid="true"
                         class="form-control ddm-field-text"
                         id="keyValueDisplayNameoption1"
@@ -340,6 +404,16 @@ exports[`Options shows the options 1`] = `
                       type="hidden"
                       value="false"
                     />
+                    <div
+                      aria-hidden="true"
+                      class="form-feedback-group lfr-de__field-feedback"
+                    >
+                      <div
+                        aria-live="assertive"
+                        class="form-feedback-item"
+                        id="keyValueDisplayNameoption1_fieldError"
+                      />
+                    </div>
                   </div>
                   <button
                     aria-label="remove-x-option"
@@ -360,6 +434,16 @@ exports[`Options shows the options 1`] = `
                     type="hidden"
                     value="false"
                   />
+                  <div
+                    aria-hidden="true"
+                    class="form-feedback-group lfr-de__field-feedback"
+                  >
+                    <div
+                      aria-live="assertive"
+                      class="form-feedback-item"
+                      id="option1_fieldError"
+                    />
+                  </div>
                 </div>
                 <label
                   class="mt-3"
@@ -382,6 +466,7 @@ exports[`Options shows the options 1`] = `
                       title="Option2"
                     >
                       <input
+                        aria-describedby="keyValueReferenceOption2_fieldError"
                         aria-invalid="true"
                         class="form-control ddm-field-text"
                         id="keyValueReferenceOption2"
@@ -395,12 +480,32 @@ exports[`Options shows the options 1`] = `
                       type="hidden"
                       value="false"
                     />
+                    <div
+                      aria-hidden="true"
+                      class="form-feedback-group lfr-de__field-feedback"
+                    >
+                      <div
+                        aria-live="assertive"
+                        class="form-feedback-item"
+                        id="keyValueReferenceOption2_fieldError"
+                      />
+                    </div>
                   </div>
                   <input
                     name="Option2_edited"
                     type="hidden"
                     value="false"
                   />
+                  <div
+                    aria-hidden="true"
+                    class="form-feedback-group lfr-de__field-feedback"
+                  >
+                    <div
+                      aria-live="assertive"
+                      class="form-feedback-item"
+                      id="Option2_fieldError"
+                    />
+                  </div>
                 </div>
                 <label
                   class="mt-3"
@@ -437,6 +542,7 @@ exports[`Options shows the options 1`] = `
                       title="Option2"
                     >
                       <input
+                        aria-describedby="keyValueNameOption2_fieldError"
                         aria-invalid="true"
                         class="form-control ddm-field-text"
                         id="keyValueNameOption2"
@@ -450,12 +556,32 @@ exports[`Options shows the options 1`] = `
                       type="hidden"
                       value="false"
                     />
+                    <div
+                      aria-hidden="true"
+                      class="form-feedback-group lfr-de__field-feedback"
+                    >
+                      <div
+                        aria-live="assertive"
+                        class="form-feedback-item"
+                        id="keyValueNameOption2_fieldError"
+                      />
+                    </div>
                   </div>
                   <input
                     name="Option2_edited"
                     type="hidden"
                     value="false"
                   />
+                  <div
+                    aria-hidden="true"
+                    class="form-feedback-group lfr-de__field-feedback"
+                  >
+                    <div
+                      aria-live="assertive"
+                      class="form-feedback-item"
+                      id="Option2_fieldError"
+                    />
+                  </div>
                 </div>
               </div>
             </div>
@@ -476,6 +602,16 @@ exports[`Options shows the options 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="options_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Paragraph/__snapshots__/Paragraph.es.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Paragraph/__snapshots__/Paragraph.es.js.snap
@@ -20,6 +20,16 @@ exports[`Field Paragraph has a key 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="textField_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -49,6 +59,16 @@ exports[`Field Paragraph has a label 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="textField_fieldError"
+      />
+    </div>
     <span
       class="sr-only"
       id="textField_fieldDetails"
@@ -79,6 +99,16 @@ exports[`Field Paragraph has a placeholder 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="textField_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -103,6 +133,16 @@ exports[`Field Paragraph has a value 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="textField_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -127,6 +167,16 @@ exports[`Field Paragraph has an id 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="Id_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -151,6 +201,16 @@ exports[`Field Paragraph is not required 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="textField_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -175,6 +235,16 @@ exports[`Field Paragraph is readOnly 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="textField_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -204,6 +274,16 @@ exports[`Field Paragraph renders Label if showLabel is true 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="textField_fieldError"
+      />
+    </div>
     <span
       class="sr-only"
       id="textField_fieldDetails"

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Radio/__snapshots__/Radio.es.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Radio/__snapshots__/Radio.es.js.snap
@@ -74,6 +74,11 @@ exports[`Field Radio has a helptext 1`] = `
       class="form-feedback-group lfr-de__field-feedback"
     >
       <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="radioField_fieldError"
+      />
+      <div
         id="radioField_fieldHelp"
       >
         Type something
@@ -163,6 +168,16 @@ exports[`Field Radio has a label 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="radioField_fieldError"
+      />
+    </div>
     <span
       class="sr-only"
       id="radioField_fieldDetails"
@@ -242,6 +257,16 @@ exports[`Field Radio has a placeholder 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="radioField_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -315,6 +340,16 @@ exports[`Field Radio has a value 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="radioField_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -388,6 +423,16 @@ exports[`Field Radio has an id 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="Id_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -463,6 +508,16 @@ exports[`Field Radio is not editable 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="radioField_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -538,6 +593,16 @@ exports[`Field Radio is not required 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="radioField_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -616,6 +681,16 @@ exports[`Field Radio renders Label if showLabel is true 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="radioField_fieldError"
+      />
+    </div>
     <span
       class="sr-only"
       id="radioField_fieldDetails"
@@ -650,6 +725,16 @@ exports[`Field Radio renders no options when options is empty 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="radioField_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -723,6 +808,16 @@ exports[`Field Radio renders options 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="radioField_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/SearchLocation/SearchLocation.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/SearchLocation/SearchLocation.es.js
@@ -343,7 +343,7 @@ describe('Field Search Location', () => {
 		fireEvent.blur(country);
 
 		expect(
-			container.getElementsByClassName('form-feedback-group').length
+			container.getElementsByClassName('form-feedback-indicator').length
 		).toBe(2);
 	});
 
@@ -360,7 +360,7 @@ describe('Field Search Location', () => {
 		);
 
 		expect(
-			container.getElementsByClassName('form-feedback-group').length
+			container.getElementsByClassName('form-feedback-indicator').length
 		).toBe(5);
 	});
 });

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Text/__snapshots__/Text.es.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Text/__snapshots__/Text.es.js.snap
@@ -11,7 +11,7 @@ exports[`Field Text has a helptext 1`] = `
       data-tooltip-align="top"
     >
       <input
-        aria-describedby="textField_fieldHelp"
+        aria-describedby="textField_fieldError"
         aria-invalid="true"
         class="form-control ddm-field-text"
         id="textField"
@@ -29,6 +29,11 @@ exports[`Field Text has a helptext 1`] = `
       aria-hidden="true"
       class="form-feedback-group lfr-de__field-feedback"
     >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="textField_fieldError"
+      />
       <div
         id="textField_fieldHelp"
       >
@@ -61,6 +66,7 @@ exports[`Field Text has a label 1`] = `
       data-tooltip-align="top"
     >
       <input
+        aria-describedby="textField_fieldError"
         aria-invalid="true"
         class="form-control ddm-field-text"
         id="textField"
@@ -74,6 +80,16 @@ exports[`Field Text has a label 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="textField_fieldError"
+      />
+    </div>
     <span
       class="sr-only"
       id="textField_fieldDetails"
@@ -96,6 +112,7 @@ exports[`Field Text has a placeholder 1`] = `
       title="Placeholder"
     >
       <input
+        aria-describedby="textField_fieldError"
         aria-invalid="true"
         class="form-control ddm-field-text"
         id="textField"
@@ -110,6 +127,16 @@ exports[`Field Text has a placeholder 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="textField_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -126,6 +153,7 @@ exports[`Field Text has a value 1`] = `
       title="value"
     >
       <input
+        aria-describedby="textField_fieldError"
         aria-invalid="true"
         class="form-control ddm-field-text"
         id="textField"
@@ -139,6 +167,16 @@ exports[`Field Text has a value 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="textField_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -154,6 +192,7 @@ exports[`Field Text has an id 1`] = `
       data-tooltip-align="top"
     >
       <input
+        aria-describedby="textField_fieldError"
         aria-invalid="true"
         class="form-control ddm-field-text"
         id="Id"
@@ -167,6 +206,16 @@ exports[`Field Text has an id 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="Id_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -182,6 +231,7 @@ exports[`Field Text is not readOnly 1`] = `
       data-tooltip-align="top"
     >
       <input
+        aria-describedby="textField_fieldError"
         aria-invalid="true"
         class="form-control ddm-field-text"
         id="textField"
@@ -195,6 +245,16 @@ exports[`Field Text is not readOnly 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="textField_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -210,6 +270,7 @@ exports[`Field Text is not required 1`] = `
       data-tooltip-align="top"
     >
       <input
+        aria-describedby="textField_fieldError"
         aria-invalid="true"
         aria-required="false"
         class="form-control ddm-field-text"
@@ -224,6 +285,16 @@ exports[`Field Text is not required 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="textField_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -239,6 +310,7 @@ exports[`Field Text is readOnly 1`] = `
       data-tooltip-align="top"
     >
       <input
+        aria-describedby="textField_fieldError"
         aria-invalid="true"
         class="form-control ddm-field-text"
         disabled=""
@@ -253,6 +325,16 @@ exports[`Field Text is readOnly 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="textField_fieldError"
+      />
+    </div>
   </div>
 </div>
 `;
@@ -273,6 +355,7 @@ exports[`Field Text renders Label if showLabel is true 1`] = `
       data-tooltip-align="top"
     >
       <input
+        aria-describedby="textField_fieldError"
         aria-invalid="true"
         class="form-control ddm-field-text"
         id="textField"
@@ -286,6 +369,16 @@ exports[`Field Text renders Label if showLabel is true 1`] = `
       type="hidden"
       value="false"
     />
+    <div
+      aria-hidden="true"
+      class="form-feedback-group lfr-de__field-feedback"
+    >
+      <div
+        aria-live="assertive"
+        class="form-feedback-item"
+        id="textField_fieldError"
+      />
+    </div>
     <span
       class="sr-only"
       id="textField_fieldDetails"

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Validation/__snapshots__/Validation.js.snap
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/Validation/__snapshots__/Validation.js.snap
@@ -49,6 +49,16 @@ exports[`Validation renders checkbox to enable Validation 1`] = `
         type="hidden"
         value="false"
       />
+      <div
+        aria-hidden="true"
+        class="form-feedback-group lfr-de__field-feedback"
+      >
+        <div
+          aria-live="assertive"
+          class="form-feedback-item"
+          id="enableValidation_fieldError"
+        />
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Jira issue: https://liferay.atlassian.net/browse/LPD-23020

**Error**: After pressing `tabKey`, the name of the field you land on is ignored and we can only hear the error message.

**Expected Result**: After pressing `tabKey`, the name of the field you land on and the error message should be read out if the previous field wasn't filled.

Evidence:


https://github.com/liferay-forms/liferay-portal/assets/47724428/c56bfb9d-4a7c-4429-a51f-ca7b5393f329

