### PR TITLE
LPD-23506 Keeping characters in Forms success page message

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormDisplayContext.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormDisplayContext.java
@@ -548,10 +548,8 @@ public class DDMFormDisplayContext {
 
 		LocalizedValue body = ddmFormSuccessPageSettings.getBody();
 
-		return HtmlUtil.escape(
-			GetterUtil.getString(
-				body.getString(locale),
-				body.getString(body.getDefaultLocale())));
+		return GetterUtil.getString(
+			body.getString(locale), body.getString(body.getDefaultLocale()));
 	}
 
 	public String getSuccessPageTitle(Locale locale) throws PortalException {


### PR DESCRIPTION
Hi team. 

The customer is facing some difficulties regarding the message description on Forms success page. 
My change is to remove the escape method when rendering the content. 


- The value was already treated before being saved in the database 
- The content is created by a person with permissions, not a random person that would be necessary to pay attention in every action as escaping the value defined by allowed users.
- Script tags and other actions are not being executed when rendering the page with the PR change.