### PR TITLE
LPD-26654 Cannot duplicate repeatable field group

### DIFF
--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/reducers/fieldReducer.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/reducers/fieldReducer.es.js
@@ -36,7 +36,7 @@ export function createRepeatedField(
 		localizedValueEdited,
 		name: generateName(name, {instanceId, repeatedIndex}),
 		nestedFields: nestedFields?.map((nestedField) =>
-			createRepeatedField(nestedField)
+			createRepeatedField(defaultLanguageId, nestedField)
 		),
 		valid: true,
 		value: predefinedValue,


### PR DESCRIPTION
Hello,

The issue was caused by [this commit](https://github.com/liferay/liferay-portal/commit/7bbf00f4b071d6e0aae7c37a9494e623970fff92), I had to pass the defaultLocale to the repeated calls for the nested fields as well. The motivation behind this change is to not inherit localization when we repeat a field. Without this change, a repeated field was already considered translated. With this change we only update the default Locale's translation with predefined values if there is any.

Please review my change.

Thanks,