### PR TITLE
LPD-31144 Save and restore state in rich text

### DIFF
--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/components/PageRenderer/Layout.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/components/PageRenderer/Layout.es.js
@@ -56,6 +56,10 @@ export function Layout({components, editable, itemPath, rows, viewMode}) {
 		};
 	}, [dispatch]);
 
+	useEffect(() => {
+		dispatch({type: EVENT_TYPES.HISTORY.RESET});
+	}, [dispatch]);
+
 	return (
 		<Components.Rows
 			activePage={activePage}

--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/reducers/historyReducer.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/reducers/historyReducer.es.js
@@ -40,6 +40,8 @@ export default function historyReducer(state, action) {
 				},
 			};
 		case EVENT_TYPES.HISTORY.NEXT:
+			setTimeout(() => Liferay.fire('ddm:restoreState'), 100);
+
 			return {
 				...state.history.steps[state.history.currentStep + 1],
 				history: {
@@ -48,6 +50,8 @@ export default function historyReducer(state, action) {
 				},
 			};
 		case EVENT_TYPES.HISTORY.PREV:
+			setTimeout(() => Liferay.fire('ddm:restoreState'), 100);
+
 			return {
 				...state.history.steps[state.history.currentStep - 1],
 				history: {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/RichText/RichText.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/RichText/RichText.es.js
@@ -202,6 +202,18 @@ const RichText = ({
 	}, [editorRef, currentValue, defaultLocale]);
 
 	useEffect(() => {
+		const handleRestoreState = () => {
+			editorRef.current.editor.setData(value);
+		};
+
+		Liferay.after('ddm:restoreState', handleRestoreState);
+
+		return () => {
+			Liferay.detach('ddm:restoreState', handleRestoreState);
+		};
+	}, [value, currentValue]);
+
+	useEffect(() => {
 		Liferay.after('inputLocalized:resetTranslations', resetTranslation);
 
 		return () => {


### PR DESCRIPTION
LPD-31144 Save and restore state in rich text

# What is this trying to solve?

In Content Management team we are implementing undo/redo component for Web Content (https://liferay.atlassian.net/browse/LPD-22301), in this PR we are sending the part that handles the rich text editor.

[Link to ticket](https://liferay.atlassian.net/browse/LPD-31144)

# How am I fixing it?

Now we have a historyReducer component that handles the changes that we make in the undo/redo for data engine components. We have added an event that fires the event when clicking on undo/redo buttons and change the value of the rich text editor.

Only these two commits needs to be reviewed, the other ones are already in [Brian's repo pending for submit](https://github.com/brianchandotcom/liferay-portal/pull/152716):
- [LPD-31144 Handle undo/redo events for rich text](https://github.com/liferay-forms/liferay-portal/pull/2576/commits/e7f52ed33aeaed1cfd029dfae07a1b9c8567e29f)
- [LPD-31144 Save initial state for ddm fields](https://github.com/liferay-forms/liferay-portal/pull/2576/commits/9b62554db4a5db2d414f1cba502eba1039f118ee)

# How can I test it?

**Steps of the test:**

- Enable FF 'LPD-11228': true
- Enable FF 'LPD-15596': true 
- Create a WC
- Fill the title 
- Fill the content field
- Click on undo button
- See content field gets empty
- Click on redo button
- See the content if filled

# Tests are not needed

We don't need tests for every data engine component, we already have this test that checks undo/redo buttons work for data engine components. **journalArticle.spec.ts > 'LPD-26863: Undo/Redo buttons work with content field'** (https://github.com/liferay/liferay-portal/blob/ab1686f25a5a3b47aaca2b02287fe377ef470e6c/modules/test/playwright/tests/journal-web/journalArticle.spec.ts#L219)

CC: @ambrinchaudhary