### PR TITLE
LPD-34375 WIP

### DIFF
--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/components/PageRenderer/Layout.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/components/PageRenderer/Layout.es.js
@@ -3,10 +3,9 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import React, {useContext, useEffect} from 'react';
+import React, {useContext} from 'react';
 
 import {getFormId, getFormNode} from '../../../utils/formId.es';
-import {EVENT_TYPES} from '../../actions/eventTypes.es';
 import {useConfig} from '../../hooks/useConfig.es';
 import {useEvaluate} from '../../hooks/useEvaluate.es';
 import {useForm, useFormState} from '../../hooks/useForm.es';
@@ -30,41 +29,6 @@ export function Layout({components, editable, itemPath, rows, viewMode}) {
 	const variants = useContext(VariantsContext);
 
 	const Components = components ?? mergeVariants(editable, variants);
-
-	useEffect(() => {
-		dispatch({type: EVENT_TYPES.HISTORY.RESET});
-	}, [defaultLanguageId, dispatch]);
-
-	useEffect(() => {
-		const goToHandler = ({step}) => {
-			dispatch({step, type: EVENT_TYPES.HISTORY.GOTO});
-		};
-		const handleStoreState = () => {
-			dispatch({type: EVENT_TYPES.HISTORY.ADD});
-		};
-		const undoHandler = () => {
-			dispatch({type: EVENT_TYPES.HISTORY.PREV});
-		};
-		const redoHandler = () => {
-			dispatch({type: EVENT_TYPES.HISTORY.NEXT});
-		};
-
-		Liferay.on('journal:goto', goToHandler);
-		Liferay.on('journal:undo', undoHandler);
-		Liferay.on('journal:redo', redoHandler);
-		Liferay.on('journal:storeState', handleStoreState);
-
-		return () => {
-			Liferay.detach('journal:goto', goToHandler);
-			Liferay.detach('journal:undo', undoHandler);
-			Liferay.detach('journal:redo', redoHandler);
-			Liferay.detach('journal:storeState', handleStoreState);
-		};
-	}, [dispatch]);
-
-	useEffect(() => {
-		dispatch({type: EVENT_TYPES.HISTORY.RESET});
-	}, [dispatch]);
 
 	return (
 		<Components.Rows

--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/components/PageRenderer/WebContentVariant.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/components/PageRenderer/WebContentVariant.es.js
@@ -203,6 +203,8 @@ function Placeholder({field, index, nestedFieldIndex}) {
 				type: EVENT_TYPES.FORM_VIEW.REPEATABLE_FIELD.CHANGE_ORDER,
 			});
 
+			Liferay.fire('journal:storeState', {fieldName: 'Repeatable Moved'});
+
 			item.index = targetIndex;
 		},
 	});

--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/components/PageRenderer/WebContentVariant.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/components/PageRenderer/WebContentVariant.es.js
@@ -5,7 +5,7 @@
 
 import ClayLayout from '@clayui/layout';
 import classnames from 'classnames';
-import React, {forwardRef, useRef} from 'react';
+import React, {forwardRef, useEffect, useRef} from 'react';
 import {useDrop} from 'react-dnd';
 
 import {EVENT_TYPES} from '../../../custom/form/eventTypes';
@@ -34,7 +34,7 @@ export const Column = forwardRef(
 		},
 		ref
 	) => {
-		const {portletId} = useFormState();
+		const {defaultLanguageId, portletId} = useFormState();
 
 		const addr = {
 			'data-ddm-field-column': index,
@@ -45,6 +45,43 @@ export const Column = forwardRef(
 		const firstField = column.fields[0];
 		const isFieldSetOrGroup = firstField?.type === 'fieldset';
 		const isFieldSet = firstField?.ddmStructureId && isFieldSetOrGroup;
+
+		const defaultLanguageIdRef = useRef(defaultLanguageId);
+		const dispatch = useForm();
+
+		useEffect(() => {
+			if (defaultLanguageIdRef.current !== defaultLanguageId) {
+				defaultLanguageIdRef.current = defaultLanguageId;
+				dispatch({type: EVENT_TYPES.HISTORY.RESET});
+			}
+		}, [defaultLanguageId, dispatch]);
+
+		useEffect(() => {
+			const goToHandler = ({step}) => {
+				dispatch({step, type: EVENT_TYPES.HISTORY.GOTO});
+			};
+			const handleStoreState = () => {
+				dispatch({type: EVENT_TYPES.HISTORY.ADD});
+			};
+			const undoHandler = () => {
+				dispatch({type: EVENT_TYPES.HISTORY.PREV});
+			};
+			const redoHandler = () => {
+				dispatch({type: EVENT_TYPES.HISTORY.NEXT});
+			};
+
+			Liferay.on('journal:goto', goToHandler);
+			Liferay.on('journal:undo', undoHandler);
+			Liferay.on('journal:redo', redoHandler);
+			Liferay.on('journal:storeState', handleStoreState);
+
+			return () => {
+				Liferay.detach('journal:goto', goToHandler);
+				Liferay.detach('journal:undo', undoHandler);
+				Liferay.detach('journal:redo', redoHandler);
+				Liferay.detach('journal:storeState', handleStoreState);
+			};
+		}, [dispatch]);
 
 		return (
 			<ClayLayout.Col

--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/thunks/fieldChange.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/thunks/fieldChange.es.js
@@ -94,7 +94,8 @@ export default function fieldChange({
 			if (
 				fieldInstance.type === 'numeric' ||
 				fieldInstance.type === 'text' ||
-				fieldInstance.type === 'rich_text'
+				fieldInstance.type === 'rich_text' ||
+				fieldInstance.type === 'image'
 			) {
 				dispatch({type: EVENT_TYPES.HISTORY.EDITED});
 			}
@@ -184,7 +185,8 @@ export default function fieldChange({
 			if (
 				fieldInstance.type !== 'numeric' &&
 				fieldInstance.type !== 'text' &&
-				fieldInstance.type !== 'rich_text'
+				fieldInstance.type !== 'rich_text' &&
+				fieldInstance.type !== 'image'
 			) {
 				setTimeout(
 					() =>

--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/custom/form/eventTypes.ts
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/custom/form/eventTypes.ts
@@ -18,6 +18,15 @@ const FORM_VIEW = {
 	},
 };
 
+const HISTORY = {
+	ADD: 'add_step',
+	BLUR: 'handle_blur',
+	EDITED: 'mark_edited',
+	NEXT: 'next_step',
+	PREV: 'prev_step',
+	RESET: 'reset_history',
+};
+
 const OBJECT = {
 	FIELDS_CHANGE: 'object_fields_change',
 	RELATIONSHIPS_CHANGE: 'object_relationships_change',
@@ -45,6 +54,7 @@ const RULES = {
 export const EVENT_TYPES = {
 	FORM_BUILDER,
 	FORM_VIEW,
+	HISTORY,
 	OBJECT,
 	PAGE,
 	PAGINATION,

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
@@ -613,12 +613,16 @@ export default function FieldBase({
 								}
 							)}
 							disabled={readOnly || disabledRepeatableButton}
-							onClick={() =>
+							onClick={() => {
 								dispatch({
 									payload: name,
 									type: CORE_EVENT_TYPES.FIELD.REMOVED,
-								})
-							}
+								});
+
+								Liferay.fire('journal:storeState', {
+									fieldName: 'Repeatable Removed',
+								});
+							}}
 							small
 							title={Liferay.Language.get('remove')}
 							type="button"
@@ -641,12 +645,16 @@ export default function FieldBase({
 							}
 						)}
 						disabled={readOnly || disabledRepeatableButton}
-						onClick={() =>
+						onClick={() => {
 							dispatch({
 								payload: name,
 								type: CORE_EVENT_TYPES.FIELD.REPEATED,
-							})
-						}
+							});
+
+							Liferay.fire('journal:storeState', {
+								fieldName: 'Repeatable Added',
+							});
+						}}
 						small
 						title={Liferay.Language.get('duplicate')}
 						type="button"

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/ImagePicker/ImagePicker.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/ImagePicker/ImagePicker.es.js
@@ -119,7 +119,9 @@ const ImagePicker = ({
 		}
 
 		openSelectionModal({
-			onClose: () => onBlur(event),
+			onClose: () => {
+				setTimeout(() => onBlur(event), 100);
+			},
 			onSelect: handleFieldChanged,
 			selectEventName: `${portletNamespace}selectDocumentLibrary`,
 			title: sub(
@@ -256,6 +258,7 @@ const ImagePicker = ({
 								disabled={readOnly}
 								lang={editingLanguageId}
 								name={`${name}-description`}
+								onBlur={onBlur}
 								onChange={({event, target: {value}}) =>
 									dispatchValue(
 										{value: {description: value, event}},


### PR DESCRIPTION
Hey Team,

I implemented the missing functionality of `Undo/Redo `for the `repeatable fields` the same way you described it in the [Spike](https://liferay.atlassian.net/browse/LPD-34562), but in the end I discovered 2 major issues that blocks the whole story.

1. The `HistoryReducer` is called twice when receiving the `journal:storeState` event from `input_localized.js` For example when we edit the title. The event is fired once from `input_localized.js`, it received once in `Layout.es.js`  and it is dispatched one time from there. Still the Action is received two times in the `HistoryReducer` creating a duplicate step.

2. The second issue is with the repeatable fields. Once a field is repeated, The `Layout` is rerendered as many times as many fields we have in the `Layout`. This in return creates multiple `Layout`s what creates multiple event handlers that ends up creating multiple steps in the `HistoryReducer`. Essentially creating so many steps that the functionality seems to not work at all with the repeatable fields. But in reality it works, just we have too many steps in the state to make it work.

I created this PR with the tmp commit so we can start collaborating on these issues more easily. It implements the step creating for repeating, removing and moving a repeatable field. It changes how we reset the History so it does not cause issues when the Layout is rerenderd. It also provides console.log statements to every relevant part of the codeBase where the code of Undo/Redo story runs, so we can all see what is happening in what order and the two issues described above is easier to see.

Reproduction steps to follow:

1. Go to Web content => structures => Create a structure with a repeatable text field and a non repeatable text field
2. Create a web content from this structure
3. Add a title
(Notice the first issue, HistoryReducer's `ADD` action runs twice)
5. Add text for the repeated field
6. Add text for the non repeated field
7. Click the history button and select 'Undo-all'
(Notice that the fields are reseted correctly as stepping back to the first History step works well in every case. Restoring the state works for repeatable fields as well)
8. Repeat the repeated field
(Notice the `'Layout is rendered and events are registered'` console log appears 3 times)
9. Add a text to the newly repeated field and click outside of it

Expected: `dispatching storeState from layout` appears one time in the console and we dispatch the storeState event one time
Actual: It appears multiple times and the Action is dispatched multiple times

After a field is repeated all the fields produce the same behaviour, meaning we don't have to edit one of the repeated fields to have multiple Action dispatched from the Layout

These issues are blockers for our story and we would appreciate the help as this seem to be a bug in data-engine.

Thank you in advance!