### PR TITLE
LPD-36089 Fix broken aria reference

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/util/DDMFormDisplayContextUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/util/DDMFormDisplayContextUtil.java
@@ -13,7 +13,9 @@ import com.liferay.dynamic.data.mapping.model.DDMFormLayout;
 import com.liferay.dynamic.data.mapping.model.DDMFormLayoutColumn;
 import com.liferay.dynamic.data.mapping.model.DDMFormLayoutPage;
 import com.liferay.dynamic.data.mapping.model.DDMFormLayoutRow;
+import com.liferay.dynamic.data.mapping.model.LocalizedValue;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -39,6 +41,14 @@ public class DDMFormDisplayContextUtil {
 			_DDM_FORM_FIELD_NAME_CAPTCHA, DDMFormFieldTypeConstants.CAPTCHA);
 
 		captchaDDMFormField.setDataType("string");
+		captchaDDMFormField.setLabel(
+			new LocalizedValue() {
+				{
+					addString(
+						LocaleUtil.getDefault(),
+						DDMFormFieldTypeConstants.CAPTCHA);
+				}
+			});
 
 		ThemeDisplay themeDisplay = (ThemeDisplay)renderRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
@@ -54,6 +64,7 @@ public class DDMFormDisplayContextUtil {
 		}
 
 		captchaDDMFormField.setProperty("url", captchaResourceURL);
+		captchaDDMFormField.setShowLabel(false);
 
 		ddmForm.addDDMFormField(captchaDDMFormField);
 	}

--- a/modules/test/playwright/pages/dynamic-data-mapping-form-web/FormBuilderPage.ts
+++ b/modules/test/playwright/pages/dynamic-data-mapping-form-web/FormBuilderPage.ts
@@ -8,7 +8,7 @@ import {Locator, Page, expect} from '@playwright/test';
 import {FormsPage} from './FormsPage';
 
 export class FormBuilderPage {
-	readonly formPage: FormsPage;
+	readonly formsPage: FormsPage;
 	readonly formSettingsButton: Locator;
 	readonly formTitle: Locator;
 	readonly page: Page;
@@ -18,7 +18,7 @@ export class FormBuilderPage {
 	readonly newPageButton: Locator;
 
 	constructor(page: Page) {
-		this.formPage = new FormsPage(page);
+		this.formsPage = new FormsPage(page);
 		this.formSettingsButton = page.getByRole('button', {name: 'Settings'});
 		this.formTitle = page.getByPlaceholder('Untitled Form');
 		this.page = page;
@@ -37,10 +37,10 @@ export class FormBuilderPage {
 	}
 
 	async goToNew() {
-		await this.formPage.goTo();
+		await this.formsPage.goTo();
 
-		await expect(this.formPage.formsHeader).toBeVisible();
+		await expect(this.formsPage.formsHeader).toBeVisible();
 
-		await this.formPage.clickManagementToolbarNewButton();
+		await this.formsPage.clickManagementToolbarNewButton();
 	}
 }

--- a/modules/test/playwright/pages/dynamic-data-mapping-form-web/FormBuilderPage.ts
+++ b/modules/test/playwright/pages/dynamic-data-mapping-form-web/FormBuilderPage.ts
@@ -10,22 +10,26 @@ import {FormsPage} from './FormsPage';
 export class FormBuilderPage {
 	readonly formsPage: FormsPage;
 	readonly formSettingsButton: Locator;
+	readonly formSettingsDoneButton: Locator;
 	readonly formTitle: Locator;
 	readonly page: Page;
 	readonly previewButton: Locator;
 	readonly publishButton: Locator;
 	readonly newFormHeading: Locator;
 	readonly newPageButton: Locator;
+	readonly requireCaptchaToggle: Locator;
 
 	constructor(page: Page) {
 		this.formsPage = new FormsPage(page);
 		this.formSettingsButton = page.getByRole('button', {name: 'Settings'});
+		this.formSettingsDoneButton = page.getByRole('button', {name: 'Done'});
 		this.formTitle = page.getByPlaceholder('Untitled Form');
 		this.page = page;
 		this.previewButton = page.getByRole('button', {name: 'Preview'});
 		this.publishButton = page.getByRole('button', {name: 'Publish'});
 		this.newFormHeading = page.getByRole('heading', {name: 'New Form'});
 		this.newPageButton = page.getByRole('button', {name: 'New Page'});
+		this.requireCaptchaToggle = page.getByLabel('Require CAPTCHA');
 	}
 
 	async clickPreviewButton() {

--- a/modules/test/playwright/pages/dynamic-data-mapping-form-web/FormsPage.ts
+++ b/modules/test/playwright/pages/dynamic-data-mapping-form-web/FormsPage.ts
@@ -10,8 +10,10 @@ import {ProductMenuPage} from '../../pages/product-navigation-control-menu-web/P
 export class FormsPage {
 	readonly emptyResultNewFormButton: Locator;
 	readonly formsHeader: Locator;
+	readonly managementToolbarDeleteButton: Locator;
 	readonly managementToolbarNewButton: Locator;
 	readonly managementToolbarSearchForButton: Locator;
+	readonly managementToolbarSelectAllItems: Locator;
 	readonly page: Page;
 	readonly productMenuPage: ProductMenuPage;
 
@@ -23,10 +25,16 @@ export class FormsPage {
 			exact: true,
 			name: 'Forms',
 		});
+		this.managementToolbarDeleteButton = page.getByRole('button', {
+			name: 'Delete',
+		});
 		this.managementToolbarNewButton = page.getByText('New', {exact: true});
 		this.managementToolbarSearchForButton = page.getByRole('button', {
 			name: 'Search for',
 		});
+		this.managementToolbarSelectAllItems = page.getByLabel(
+			'Select All Items on the Page'
+		);
 		this.page = page;
 
 		this.productMenuPage = new ProductMenuPage(page);

--- a/modules/test/playwright/tests/dynamic-data-mapping-form-web/formFields.spec.ts
+++ b/modules/test/playwright/tests/dynamic-data-mapping-form-web/formFields.spec.ts
@@ -105,3 +105,49 @@ test.describe('Can configure a HTML autocomplete attribute in Date, Numeric and 
 		await newTabPage.close();
 	});
 });
+
+test('make sure the aria-labelledby reference is present in the captcha form view', async ({
+	formBuilderPage,
+	formBuilderSidePanelPage,
+}) => {
+	await formBuilderPage.goToNew();
+
+	await formBuilderPage.fillFormTitle('Form' + getRandomInt());
+
+	await formBuilderSidePanelPage.addFieldByDoubleClick('Text');
+
+	await formBuilderPage.formSettingsButton.click();
+
+	await formBuilderPage.requireCaptchaToggle.click();
+
+	await formBuilderPage.formSettingsDoneButton.click();
+
+	const newTabPagePromise = new Promise<Page>((resolve) =>
+		formBuilderPage.page.once('popup', resolve)
+	);
+
+	await formBuilderPage.previewButton.click();
+
+	const newTabPage = await newTabPagePromise;
+
+	await newTabPage.waitForLoadState('domcontentloaded');
+
+	const captchaContainer = newTabPage.locator(
+		"[data-field-reference='_CAPTCHA_']"
+	);
+
+	await expect(captchaContainer).toBeVisible();
+
+	const captchaContainerAriaLabelledby =
+		await captchaContainer.getAttribute('aria-labelledby');
+
+	const screenReaderOnlyCaptchaSpan = newTabPage.locator(
+		`span[id='${captchaContainerAriaLabelledby}']`
+	);
+
+	await expect(screenReaderOnlyCaptchaSpan).toHaveClass('sr-only');
+
+	await expect(screenReaderOnlyCaptchaSpan).toContainText('captcha');
+
+	await newTabPage.close();
+});

--- a/modules/test/playwright/tests/dynamic-data-mapping-form-web/formFields.spec.ts
+++ b/modules/test/playwright/tests/dynamic-data-mapping-form-web/formFields.spec.ts
@@ -11,6 +11,22 @@ import {getRandomInt} from '../../utils/getRandomInt';
 
 export const test = mergeTests(loginTest(), formsPagesTest);
 
+test.afterEach(async ({formsPage, page}) => {
+	await formsPage.goTo();
+
+	await page.waitForTimeout(1000);
+
+	if (await formsPage.managementToolbarSelectAllItems.isEnabled()) {
+		await formsPage.managementToolbarSelectAllItems.click();
+
+		page.once('dialog', (dialog) => {
+			dialog.accept();
+		});
+
+		await formsPage.managementToolbarDeleteButton.click();
+	}
+});
+
 test.describe('Can configure a HTML autocomplete attribute in Date, Numeric and Text field types', () => {
 	test('LPD-12824 HTML autocomplete attribute is rendered and has the configured value limited to 20 non-special characters', async ({
 		formBuilderPage,
@@ -85,5 +101,7 @@ test.describe('Can configure a HTML autocomplete attribute in Date, Numeric and 
 				newTabPage.getByLabel(data.fieldTitle)
 			).toHaveAttribute('autocomplete', data.expectedValue);
 		}
+
+		await newTabPage.close();
 	});
 });


### PR DESCRIPTION
Related [Ticket](https://liferay.atlassian.net/browse/LPD-36089)

If the captcha has a label, we will have a return other than false from the [getFieldDetails](https://github.com/liferay/liferay-portal/blob/e08d8ed42c872b7e16adc38ce1ff7ccbccce9662/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js#L59) function.

Which will trigger further actions that will ultimately make the validation of `hasFieldDetails` true [here](https://github.com/liferay/liferay-portal/blob/e08d8ed42c872b7e16adc38ce1ff7ccbccce9662/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js#L764-L772), thus constructing the span screen reader only element with the required reference containing the label.