### PR TITLE
LPD-34654 Empty option restores in Select from List when using undo/redo

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Select/Select.tsx
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Select/Select.tsx
@@ -153,9 +153,7 @@ function Select({
 						}
 					}}
 					placeholder={placeholder}
-					selectedKey={
-						selectedItem === null ? 'chooseAnOption' : selectedItem
-					}
+					selectedKey={selectedItem ?? 'chooseAnOption'}
 				>
 					{(group) => (
 						<DropDown.Group

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Select/Select.tsx
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Select/Select.tsx
@@ -103,7 +103,7 @@ function Select({
 
 	useEffect(() => {
 		const selectedOption = options.find(
-			(option) => option.value === selectedItem?.[0]
+			(option) => option.value === selectedItem
 		);
 
 		if (selectedOption) {


### PR DESCRIPTION
LPD-34654 Handle undo/redo in Select From List field

# What is this trying to solve?

When using undo/redo, we cannot go back to the "Choose an option" option, we should be able to restore this option when undoing the selection

[Link to ticket Select From List Field](https://liferay.atlassian.net/browse/LPD-34654)

# How am I fixing it?

1. [LPD-34654 This is not an array](https://github.com/liferay-forms/liferay-portal/pull/2614/commits/99669f6c2a7d140cfc7f9399e0988aa55c99defd): This is just a fix, selectedItem is always a string as [defined here](https://github.com/liferay-forms/liferay-portal/blob/84711dbea2ac4c1c9565eef780604aed268a0ba7/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Select/Select.tsx#L73), this fixes an accessibility issue adding the title to the option

2. [LPD-34654 Set chooseAnOption if selectedItem doesn't exist](https://github.com/liferay-forms/liferay-portal/pull/2614/commits/747a9b5cd1faacb74598ce3cdae9c5cd2acd35e6): set `chooseAnOption` if `selectedItem` doesn't exist

# How can I test it?

The steps are in the ticket description

Enable FFs LPD-11228 and LPD-15596  
Go to Content & Data > Structures  
Add a Selec From List field > Add some options  
Go to Content & Data > Web Content  
Fill the title  
Choose an option from the select from list  
Undo the action  
See that the undo restores restore the “Choose an option“ option

**Notes**

The tests will be send in ahoter task as it's part of Web Content.

Thanks!